### PR TITLE
Reducing Python Log Sizes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ storage/**
 vector/**
 *.mv.db
 InsightCache/
+
+# Python local log file
+py/log.txt

--- a/RDF_Map.prop
+++ b/RDF_Map.prop
@@ -4,6 +4,12 @@ ENGINE_WATCHER	SMSSWatcher
 ENGINE_WEB_WATCHER	SMSSWebWatcher;SMSSStorageWatcher;SMSSModelWatcher;SMSSVectorWatcher;SMSSFunctionWatcher;SMSSVenvWatcher
 PROJECT_WATCHER	ProjectWatcher
 
+PYTHONHOME C:\\Users\\rweiler\\AppData\\Local\\anaconda3\\envs\\semoss-pytorch
+
+TCP_WORKER prerna.tcp.SocketServer
+TCP_CLIENT prerna.tcp.client.NativePySocketClient
+NATIVE_PY_SERVER true
+
 INSIGHT_CACHE_DIR C:\\workspace\\Semoss\\InsightCache
 CSV_INSIGHT_CACHE_FOLDER CSV_Insights
 
@@ -63,9 +69,9 @@ ENCRYPT_SMSS false
 
 #USE SOCKET FOR RUNNING R/PYTHON IN SEPARATE PROCESS
 NETTY_R false
-NETTY_PYTHON false
+NETTY_PYTHON true
 
-USE_PYTHON false
+USE_PYTHON true
 PY_WORKER prerna.pyserve.FileBasedPyWorker
 LD_LIBRARY_PATH	{{INPUT_YOUR_PYTHON_HOME}}\\Lib\\site-packages\\jep
 USE_PY_FILE	TRUE 

--- a/RDF_Map.prop
+++ b/RDF_Map.prop
@@ -4,12 +4,6 @@ ENGINE_WATCHER	SMSSWatcher
 ENGINE_WEB_WATCHER	SMSSWebWatcher;SMSSStorageWatcher;SMSSModelWatcher;SMSSVectorWatcher;SMSSFunctionWatcher;SMSSVenvWatcher
 PROJECT_WATCHER	ProjectWatcher
 
-PYTHONHOME C:\\Users\\rweiler\\AppData\\Local\\anaconda3\\envs\\semoss-pytorch
-
-TCP_WORKER prerna.tcp.SocketServer
-TCP_CLIENT prerna.tcp.client.NativePySocketClient
-NATIVE_PY_SERVER true
-
 INSIGHT_CACHE_DIR C:\\workspace\\Semoss\\InsightCache
 CSV_INSIGHT_CACHE_FOLDER CSV_Insights
 
@@ -69,9 +63,9 @@ ENCRYPT_SMSS false
 
 #USE SOCKET FOR RUNNING R/PYTHON IN SEPARATE PROCESS
 NETTY_R false
-NETTY_PYTHON true
+NETTY_PYTHON false
 
-USE_PYTHON true
+USE_PYTHON false
 PY_WORKER prerna.pyserve.FileBasedPyWorker
 LD_LIBRARY_PATH	{{INPUT_YOUR_PYTHON_HOME}}\\Lib\\site-packages\\jep
 USE_PY_FILE	TRUE 

--- a/py/gaas_tcp_server_handler.py
+++ b/py/gaas_tcp_server_handler.py
@@ -184,7 +184,8 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
                 # Receive the first 4 bytes to get the size
                 data = self.request.recv(4)
                 if not data:
-                    raise RuntimeError("No data received or connection closed.")
+                    raise RuntimeError(
+                        "No data received or connection closed.")
 
                 size = int.from_bytes(data, "big")
 
@@ -195,7 +196,8 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
                 while len(epoc) < epoc_size:
                     chunk = self.request.recv(epoc_size - len(epoc))
                     if not chunk:
-                        raise RuntimeError("No data received or connection closed.")
+                        raise RuntimeError(
+                            "No data received or connection closed.")
                     epoc += chunk
 
                 # Decode the epoc data as UTF-8
@@ -207,13 +209,15 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
                 while len(data) < size:
                     chunk = self.request.recv(size - len(data))
                     if not chunk:
-                        raise RuntimeError("No data received or connection closed.")
+                        raise RuntimeError(
+                            "No data received or connection closed.")
                     data += chunk
 
                 # print(f"process the data ---- {data.decode('utf-8')}")
                 # payload = data.decode('utf-8')
                 if self.server.blocking:
-                    self.custom_dev_logger("Server is BLOCKING: Getting final output.")
+                    self.custom_dev_logger(
+                        "Server is BLOCKING: Getting final output.")
                     self.get_final_output(data, epoc)
                 else:
                     self.custom_dev_logger(
@@ -236,8 +240,29 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
             # print("all processing has finished !!")
         # self.get_final_output(data)
 
+    def log_data(self, data):
+        """
+        Log the data to the log file. This is useful for debugging purposes.
+        Trimming the payload to 50 characters to avoid log file bloat.
+        """
+        try:
+            if isinstance(data, bytes):
+                data = json.loads(data.decode('utf-8'))
+            elif data is None:
+                data = {}
+
+            payload = data.get('payload', [])
+            trimmed_payload = payload[0][:50] if isinstance(
+                payload, list) and payload else "N/A"
+
+            log_message = f"Final Output: epoc={data.get('epoc', 'N/A')}, payload={trimmed_payload}, operation={data.get('operation', 'N/A')}"
+
+            self.prod_logger(log_message)
+        except Exception as e:
+            self.prod_logger(f"Error in get_final_output: {str(e)}")
+
     def get_final_output(self, data=None, epoc=None):
-        self.prod_logger(f"Getting Final Output for Data === {data}")
+        self.log_data(data)
 
         payload = ""
         # payload = data
@@ -288,7 +313,8 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
                     print("The prefix is None")
                 else:
                     print("The prefix is set to value = " + self.prefix)
-                self.send_output("prefix set", operation="PYTHON", response=True)
+                self.send_output(
+                    "prefix set", operation="PYTHON", response=True)
 
             # handle log out
             elif command == "CLOSE_ALL_LOGOUT<o>" and payload["operation"] == "CMD":
@@ -391,7 +417,8 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
         }
 
         if "insightId" in self.thread_local.payload:
-            payload.update({"insightId": self.thread_local.payload["insightId"]})
+            payload.update(
+                {"insightId": self.thread_local.payload["insightId"]})
 
         if exception:
             payload.update(
@@ -464,7 +491,8 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
                 self.log_file.write("\n")
                 self.log_file.write(f"New Payload: {new_payload}")
                 self.log_file.write("\n")
-                self.log_file.write(f"New Payload Insight ID: {new_payload_insight_id}")
+                self.log_file.write(
+                    f"New Payload Insight ID: {new_payload_insight_id}")
                 self.log_file.write("\n")
                 self.log_file.write("\n")
                 self.log_file.write(
@@ -541,7 +569,7 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
 
     def handle_python(self, command):
         is_exception = False
-        print(f"Executing command {command.encode('utf-8')}")
+        # print(f"Executing command {command.encode('utf-8')}")
 
         payload = self.thread_local.payload
         # set the payload coming in
@@ -639,7 +667,8 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
             f"handle_response() -- Handling response which is going to check the monitors for epoc {payload.get('epoc', 'EPOC NOT FOUND')}. Here are the monitors: {self.monitors}"
         )
         if payload["epoc"] in self.monitors:
-            self.prod_logger(f"handle_response() -- Payload Response: {payload}")
+            self.prod_logger(
+                f"handle_response() -- Payload Response: {payload}")
 
             condition = self.monitors[payload["epoc"]]
             self.monitors.update({payload["epoc"]: payload})
@@ -654,7 +683,6 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
             # we can look at changing it to a lower point
             self.cmd_monitor.acquire()
             method_name = payload["methodName"]
-            print(f"insight id is {payload['insightId']}")
             mount_name, mount_dir = payload["insightId"].split("__", 1)
             if method_name == "constructor":
                 # set the mount point
@@ -690,22 +718,29 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
                 # need to see the process of cd etc.
                 cur_dir = self.get_cd(mount_name)
                 commands = payload["payload"][0].split(" ")
-                commands = [command for command in commands if len(command) > 0]
+                commands = [
+                    command for command in commands if len(command) > 0]
                 command = commands[0]
                 output = "Command not allowed"
                 # mounts =
                 if command == "cd" or command.startswith("cd"):
-                    output = self.exec_cd(mount_name=mount_name, payload=commands)
+                    output = self.exec_cd(
+                        mount_name=mount_name, payload=commands)
                 elif command == "dir" or command == "ls":
-                    output = self.exec_dir(mount_name=mount_name, payload=commands)
+                    output = self.exec_dir(
+                        mount_name=mount_name, payload=commands)
                 elif command == "cp" or command == "copy":
-                    output = self.exec_cp(mount_name=mount_name, payload=commands)
+                    output = self.exec_cp(
+                        mount_name=mount_name, payload=commands)
                 elif command == "mv" or command == "move":
-                    output = self.exec_cp(mount_name=mount_name, payload=commands)
+                    output = self.exec_cp(
+                        mount_name=mount_name, payload=commands)
                 elif command == "git":
-                    output = self.exec_generic(mount_name=mount_name, payload=commands)
+                    output = self.exec_generic(
+                        mount_name=mount_name, payload=commands)
                 elif command == "mvn":
-                    output = self.exec_generic(mount_name=mount_name, payload=commands)
+                    output = self.exec_generic(
+                        mount_name=mount_name, payload=commands)
                 elif command == "rm" or command == "del":
                     # if commands has -r
                     # get the third argument and try to see it can resolve to a directory
@@ -713,13 +748,16 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
                     dir_name = commands[1]
                     # dir_name = self.exec_cd(mount_name = mount_name, payload=["cd", dir_name])
                     # if not dir_name.startswith("Sorry"):
-                    output = self.exec_generic(mount_name=mount_name, payload=commands)
+                    output = self.exec_generic(
+                        mount_name=mount_name, payload=commands)
                     # else:
                     #  output = dir_name
                 elif command == "pwd":
-                    output = self.exec_generic(mount_name=mount_name, payload=commands)
+                    output = self.exec_generic(
+                        mount_name=mount_name, payload=commands)
                 elif command == "deltree":
-                    output = self.exec_generic(mount_name=mount_name, payload=commands)
+                    output = self.exec_generic(
+                        mount_name=mount_name, payload=commands)
                 elif command == "mkdir":
                     dir_name = commands[1]
                     dir_name = self.exec_cd(
@@ -732,7 +770,8 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
                     else:
                         output = dir_name
                 elif command == "pnpm":
-                    output = self.exec_generic(mount_name=mount_name, payload=commands)
+                    output = self.exec_generic(
+                        mount_name=mount_name, payload=commands)
                 else:
                     output = "Commands allowed cd, dir, ls, copy, cp, mv, move, del <specific file>, rm <specific file>, deltree, pwd, git, mvn (Experimental), mkdir, pnpm(Experimental)"
 
@@ -740,7 +779,8 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
                 output = output.replace("\\", "/")
                 orig_dir = self.orig_mount_points[mount_name]
                 orig_dir_opt1 = orig_dir.replace("\\", "/")
-                insensitive_orig_dir = re.compile(re.escape(orig_dir), re.IGNORECASE)
+                insensitive_orig_dir = re.compile(
+                    re.escape(orig_dir), re.IGNORECASE)
                 output = insensitive_orig_dir.sub("_", output)
                 insensitive_orig_dir = re.compile(
                     re.escape(orig_dir_opt1), re.IGNORECASE
@@ -748,7 +788,8 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
                 output = insensitive_orig_dir.sub("_", output)
 
                 # send the output
-                self.send_output(output, operation=payload["operation"], response=True)
+                self.send_output(
+                    output, operation=payload["operation"], response=True)
                 # if command == 'ls' or command == 'dir':
                 #  exec_cd(mount_name=mount_name, payload=payload['payload'])
             self.cmd_monitor.release()


### PR DESCRIPTION
Reducing the log sizes generated in console.txt and log.txt in the InsightCache directory. Removing payload print statements to console.txt and trimming payload log statements for log.txt. 

To test:
1. Run a Q&A through a vector model
2. Open the console.txt and log.txt in the InsightCache dir (ex: `C:\workspace\Semoss\InsightCache\MODEL_4acbe913-df40-4ac0-b28a-daa5ad91b172_aoVo2cZ`)
3. Verify that they don't contain huge payload strings. 

(It looks like I changed a lot more in server-handler because of the formatting. Going to fix this in a future PR.)