### PR TITLE
UPDATE ::: Add conditional creation for pgvector database tables

### DIFF
--- a/src/prerna/util/sql/PGVectorQueryUtil.java
+++ b/src/prerna/util/sql/PGVectorQueryUtil.java
@@ -24,30 +24,54 @@ public class PGVectorQueryUtil extends PostgresQueryUtil {
 	}
 
 	public String createEmbeddingsTable(String table) {
-		return "CREATE TABLE IF NOT EXISTS "+table+"("
-				+ "ID INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY, "
-				+ "EMBEDDING VECTOR, "
-				+ "SOURCE TEXT, "
-				+ "MODALITY TEXT, "
-				+ "DIVIDER TEXT, "
-				+ "PART TEXT, "
-				+ "TOKENS INTEGER, "
-				+ "CONTENT TEXT "
-				+ ");";
+		return "DO $$\n" +
+	                "DECLARE\n" +
+	                "    tbl_name text := '" + table + "';\n" +
+	                "BEGIN\n" +
+	                "    IF NOT EXISTS (\n" +
+	                "        SELECT 1\n" +
+	                "        FROM information_schema.tables \n" +
+	                "        WHERE table_schema = current_schema() \n" +
+	                "          AND table_name = tbl_name\n" +
+	                "    ) THEN\n" +
+	                "        EXECUTE format('CREATE TABLE %I (\n" +
+	                "            ID SERIAL PRIMARY KEY,\n" +
+	                "            EMBEDDING vector,\n" +
+	                "            SOURCE text,\n" +
+	                "            MODALITY text,\n" +
+	                "            DIVIDER text,\n" +
+	                "            PART text,\n" +
+	                "            TOKENS text,\n" +
+	                "            CONTENT text\n" +
+	                "        )', tbl_name);\n" +
+	                "    END IF;\n" +
+	                "END $$;";
 	}
 	
 	public String createEmbeddingsMetadataTable(String table) {
-		return "CREATE TABLE IF NOT EXISTS "+table+"("
-				+ "ID INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY, "
-				+ "SOURCE TEXT, "
-				+ "ATTRIBUTE TEXT, "
-				+ "STR_VALUE TEXT, "
-				+ "INT_VALUE INTEGER, "
-				+ "NUM_VALUE NUMERIC(18,4), "
-				+ "BOOL_VALUE BOOLEAN, "
-				+ "DATE_VAL DATE, "
-				+ "TIMESTAMP_VAL TIMESTAMP "
-				+ ");";
+		return "DO $$\n" +
+	                "DECLARE\n" +
+	                "    tbl_name text := '" + table + "';\n" +
+	                "BEGIN\n" +
+	                "    IF NOT EXISTS (\n" +
+	                "        SELECT 1\n" +
+	                "        FROM information_schema.tables \n" +
+	                "        WHERE table_schema = current_schema() \n" +
+	                "          AND table_name = tbl_name\n" +
+	                "    ) THEN\n" +
+	                "        EXECUTE format('CREATE TABLE %I (\n" +
+	                "            ID INTEGER PRIMARY KEY GENERATED ALWAYS AS IDENTITY,\n" +
+	                "            SOURCE TEXT,\n" +
+	                "            ATTRIBUTE TEXT,\n" +
+	                "            STR_VALUE TEXT,\n" +
+	                "            INT_VALUE INTEGER,\n" +
+	                "            NUM_VALUE NUMERIC(18,4),\n" +
+	                "            BOOL_VALUE BOOLEAN,\n" +
+	                "            DATE_VAL DATE,\n" +
+	                "            TIMESTAMP_VAL TIMESTAMP\n" +
+	                "        )', tbl_name);\n" +
+	                "    END IF;\n" +
+	                "END $$;";
 	}
 
 	public String addVectorExtension() {


### PR DESCRIPTION
- Implemented logic to create pgvector db tables only if they do not already exist.
- The SQL scripts use a PL/pgSQL block to check for the existence of the tables before attempting to create them. This approach leverages the information_schema.tables view to determine if the tables are already present in the current schema.