### PR TITLE
Add Support for Dynamic Safety Settings for Gemini Models

### DIFF
--- a/py/genai_client/text_generation/google_clients/abstract_vertex_textgen_client.py
+++ b/py/genai_client/text_generation/google_clients/abstract_vertex_textgen_client.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Optional
 from abc import abstractclassmethod
 from vertexai.language_models import ChatMessage
 
@@ -19,6 +19,7 @@ class AbstractVertextAiTextGeneration(AbstractTextGenerationClient):
         service_account_key_file: str = None,
         region: str = None,
         project: str = None,
+        safety_settings: Optional[Dict] = None,
         **kwargs,
     ):
 
@@ -37,6 +38,7 @@ class AbstractVertextAiTextGeneration(AbstractTextGenerationClient):
 
         self.model_name = model_name
         self.client = self._get_client()
+        self.safety_settings = safety_settings or {}
 
     @abstractclassmethod
     def ask_call(self, **kwargs) -> AskModelEngineResponse:


### PR DESCRIPTION
This PR introduces enhancements to the VertexGenerativeModelClient and AbstractVertextAiTextGeneration classes to support the inclusion of safety settings. These settings can be passed directly in the Init Script text box of the Add Model user interface, allowing for dynamic configuration of safety parameters. The category names and thresholds are case-insensitive, ensuring flexibility in input.

**Changes Made**
**AbstractVertextAiTextGeneration** Class:
Added an optional safety_settings parameter to the constructor.
The safety_settings parameter is stored in the instance variable self.safety_settings.

**VertexGenerativeModelClient** Class:
Added logic to map the input safety settings to the corresponding enums (HarmCategory and HarmBlockThreshold) from gapic_content_types.
The input category names and thresholds are converted to uppercase to match the enum names, making the input case-insensitive.
Added error handling to ensure that invalid categories or thresholds do not break the logic. Invalid entries are logged, and the process continues with valid settings.

Sample Init Script with safety settings:
import genai_client;${VAR_NAME} = genai_client.VertexClient(model_name = '${MODEL}', service_account_key_file = '${SERVICE_ACCOUNT_FILE}', region='${GCP_REGION}', chat_type='${CHAT_TYPE}', **safety_settings={"HARM_CATEGORY_DANGEROUS_CONTENT": "BLOCK_NONE", "HARM_CATEGORY_HATE_SPEECH": "BLOCK_NONE", "HARM_CATEGORY_HARASSMENT": "BLOCK_NONE", "HARM_CATEGORY_SEXUALLY_EXPLICIT": "BLOCK_NONE"}**)
Note: safety_settings is optional and there is no restriction on the number of categories to be passed. You could choose to pass one or all the categories.

https://ai.google.dev/gemini-api/docs/safety-settings#code-examples