### PR TITLE
Explicitly set chatml as chat template in tokenizer

### DIFF
--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -150,7 +150,6 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
 
         specific_tokenizer = self.tokenizer._get_tokenizer(self.model_name)
         if hasattr(specific_tokenizer, "apply_chat_template"):
-            print("specific_tokenzier: ", specific_tokenizer.chat_template)
             # Apply the chat template to the prompt if no chat template was provided
             if specific_tokenizer.chat_template == None:
                 specific_tokenizer.chat_template = "chatml"

--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -150,7 +150,10 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
 
         specific_tokenizer = self.tokenizer._get_tokenizer(self.model_name)
         if hasattr(specific_tokenizer, "apply_chat_template"):
-            specific_tokenizer.chat_template = "chatml"
+            print("specific_tokenzier: ", specific_tokenizer.chat_template)
+            # Apply the chat template to the prompt if no chat template was provided
+            if specific_tokenizer.chat_template == None:
+                specific_tokenizer.chat_template = "chatml"
             # there is a apply chat template available for this model - transformers tokenizer
             prompt = specific_tokenizer.apply_chat_template(
                 prompt_payload, tokenize=False

--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -150,6 +150,7 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
 
         specific_tokenizer = self.tokenizer._get_tokenizer(self.model_name)
         if hasattr(specific_tokenizer, "apply_chat_template"):
+            specific_tokenizer.chat_template = "chatml"
             # there is a apply chat template available for this model - transformers tokenizer
             prompt = specific_tokenizer.apply_chat_template(
                 prompt_payload, tokenize=False


### PR DESCRIPTION
Updating the `_check_token_limits` method in the `OpenAiChatCompletion` class to work with the latest version of transformers `4.45.1`. This will also work with any of the previous versions of transformers we are using. 