### PR TITLE
Bug fix for updating email for Edit User

### DIFF
--- a/src/prerna/auth/utils/SecurityAdminUtils.java
+++ b/src/prerna/auth/utils/SecurityAdminUtils.java
@@ -9,7 +9,6 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -657,7 +656,6 @@ public class SecurityAdminUtils extends AbstractSecurityUtils {
 		String newEmail = (String) userInfo.get("newEmail");
 		// always lower case emails
 		if (newEmail != null) {
-			classLogger.info("Email is not null");
 			newEmail = newEmail.toLowerCase();
 		}
 		Boolean adminChange = null;
@@ -828,8 +826,6 @@ public class SecurityAdminUtils extends AbstractSecurityUtils {
 		PreparedStatement editUserPs = null;
 		try {
 			editUserPs = securityDb.getPreparedStatement(editUserQuery);
-			classLogger.info("EditUserPs: " + editUserPs);
-			classLogger.info("colToUpdate: " + Arrays.toString(colToUpdate));
 			int i = 1;
 			if(newEmail != null && !newEmail.isEmpty()) {
 				editUserPs.setString(i++, newEmail);

--- a/src/prerna/auth/utils/SecurityAdminUtils.java
+++ b/src/prerna/auth/utils/SecurityAdminUtils.java
@@ -49,7 +49,6 @@ import prerna.util.ConnectionUtils;
 import prerna.util.Constants;
 import prerna.util.QueryExecutionUtility;
 import prerna.util.Utility;
-//import prerna.web.services.util.WebUtility;
 
 public class SecurityAdminUtils extends AbstractSecurityUtils {
 
@@ -688,7 +687,6 @@ public class SecurityAdminUtils extends AbstractSecurityUtils {
 		String newSalt = null;
 		String newHashPass = null;
 
-
 		// cannot edit a user to match another user when native... would cause some
 		// serious issues :/
 		// so we will check if you are switching to a native
@@ -721,8 +719,6 @@ public class SecurityAdminUtils extends AbstractSecurityUtils {
 				throw new IllegalArgumentException("The new user id already exists. Please enter a unique user id.");
 			}
 		}
-
-
 
 		/**
 		 * validate and add the columns we wish to update to list
@@ -827,11 +823,11 @@ public class SecurityAdminUtils extends AbstractSecurityUtils {
 		try {
 			editUserPs = securityDb.getPreparedStatement(editUserQuery);
 			int i = 1;
-			if(newEmail != null && !newEmail.isEmpty()) {
-				editUserPs.setString(i++, newEmail);
-			}
 			if (newUserId != null && !newUserId.isEmpty()) {
 				editUserPs.setString(i++, newUserId);
+			}
+			if(newEmail != null && !newEmail.isEmpty()) {
+				editUserPs.setString(i++, newEmail);
 			}
 			if (newUsername != null && !newUsername.isEmpty()) {
 				editUserPs.setString(i++, newUsername);

--- a/src/prerna/auth/utils/SecurityAdminUtils.java
+++ b/src/prerna/auth/utils/SecurityAdminUtils.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -656,6 +657,7 @@ public class SecurityAdminUtils extends AbstractSecurityUtils {
 		String newEmail = (String) userInfo.get("newEmail");
 		// always lower case emails
 		if (newEmail != null) {
+			classLogger.info("Email is not null");
 			newEmail = newEmail.toLowerCase();
 		}
 		Boolean adminChange = null;
@@ -826,7 +828,12 @@ public class SecurityAdminUtils extends AbstractSecurityUtils {
 		PreparedStatement editUserPs = null;
 		try {
 			editUserPs = securityDb.getPreparedStatement(editUserQuery);
+			classLogger.info("EditUserPs: " + editUserPs);
+			classLogger.info("colToUpdate: " + Arrays.toString(colToUpdate));
 			int i = 1;
+			if(newEmail != null && !newEmail.isEmpty()) {
+				editUserPs.setString(i++, newEmail);
+			}
 			if (newUserId != null && !newUserId.isEmpty()) {
 				editUserPs.setString(i++, newUserId);
 			}


### PR DESCRIPTION
SemossWeb will send in a 'newEmail' field - originally this code looks unfinished as it was never added to the prepared statment, despite being added to the columns & value lists provided to the editUser PreparedStatement (lines 739-748)

This is in relation to [semoss-ui ticket](https://github.com/SEMOSS/semoss-ui/issues/284) and [pull request](https://github.com/SEMOSS/semoss-ui/pull/303)