### PR TITLE
Reads max token from smss file for vertex generative model

### DIFF
--- a/py/genai_client/text_generation/google_clients/abstract_vertex_textgen_client.py
+++ b/py/genai_client/text_generation/google_clients/abstract_vertex_textgen_client.py
@@ -19,6 +19,7 @@ class AbstractVertextAiTextGeneration(AbstractTextGenerationClient):
         service_account_key_file: str = None,
         region: str = None,
         project: str = None,
+        max_tokens: int = None,
         safety_settings: Optional[Dict] = None,
         **kwargs,
     ):
@@ -38,6 +39,7 @@ class AbstractVertextAiTextGeneration(AbstractTextGenerationClient):
 
         self.model_name = model_name
         self.client = self._get_client()
+        self.max_tokens = max_tokens
         self.safety_settings = safety_settings or {}
 
     @abstractclassmethod

--- a/py/genai_client/text_generation/google_clients/vertex_generative_model.py
+++ b/py/genai_client/text_generation/google_clients/vertex_generative_model.py
@@ -32,6 +32,9 @@ class VertexGenerativeModelClient(AbstractVertextAiTextGeneration):
         **kwargs
     ):
         assert self.client != None
+        
+        if self.max_tokens != None:
+            max_new_tokens = self.max_tokens
 
         chat = None
         if FULL_PROMPT in kwargs.keys():


### PR DESCRIPTION
Current flow for vertex gen ai defaults the value of max_tokens to 500 and does not consider the value mentioned in smss file. This pr has changes after which the value for max_tokens will be taken from smss file and if the value the is not defined in the smss file then it will take 500 as default value.