### PR TITLE
getCmdUtil Fix

### DIFF
--- a/src/prerna/auth/User.java
+++ b/src/prerna/auth/User.java
@@ -999,10 +999,15 @@ public class User implements Serializable {
 	}
 	
 	public CmdExecUtil getCmdUtil() {
-		if(cmdUtil != null && this.cpw.getSocketClient() != null || !this.cpw.getSocketClient().isConnected()) {
-			cmdUtil.setTcpClient(this.cpw.getSocketClient());
-		}
-		return this.cmdUtil;
+	    if (this.cpw.getSocketClient() == null) {
+	        this.getPyTranslator();
+	    }
+	    if (cmdUtil != null) {
+	        if (this.cpw.getSocketClient() != null && !this.cpw.getSocketClient().isConnected()) {
+	            cmdUtil.setTcpClient(this.cpw.getSocketClient());
+	        }
+	    }
+	    return this.cmdUtil;
 	}
 	
 	public MountHelper getUserMountHelper() {


### PR DESCRIPTION
Updating the `getCmdUtil()` method in `User` class.

### Issue
The current implementation of this method looks to set the socket client but does not try to spin up an instance of the py server if it is not running. This throws a null error. This part `!this.cpw.getSocketClient().isConnected()` in particular is the problem because if `cpw.getSocketClient()` is null we cannot call `isConnected()` on it. 

### Solution

Check if the socket client is null first and if it is, we call `getPyTranslator()` to spin up the py server first. Update second conditional to make sure `getSocketClient` is not null before calling `isConnected()`.


### Recreate Issue
1. Start Server
2. Open UI to System Terminal
3. In Pixel run `SetContext("your-proj-id")`
4. In the Shell console run `ls`
5. You should get a `null` error (This is the bug)
6. Open Python console and run `1 + 1` (This starts Py Server)
7.  Go back to Shell and run `ls` and now it will work (evidence that it needs the py server running)