### PR TITLE
Delete file from document and indexedfiles when exception occur

### DIFF
--- a/src/prerna/engine/impl/vector/AbstractVectorDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/AbstractVectorDatabaseEngine.java
@@ -329,7 +329,17 @@ public abstract class AbstractVectorDatabaseEngine implements IVectorDatabaseEng
 							functionInputs.put("parameters", parameters);
 							rowsCreated = (int) functionEngine.execute(functionInputs);
 						} else {
-							rowsCreated = VectorDatabaseUtils.convertFilesToCSV(extractedFile.getAbsolutePath(), document);
+							try {
+								rowsCreated = VectorDatabaseUtils.convertFilesToCSV(extractedFile.getAbsolutePath(), document);
+							}
+							catch(Exception e) {
+								classLogger.error(Constants.STACKTRACE, e);
+								FileUtils.forceDelete(extractedFile);
+								FileUtils.forceDelete(document);
+								classLogger.error(document.getName()+":"+e.getMessage());
+								continue;
+							}
+							classLogger.error(document.getName()+": No Error");
 						}
 
 						// check to see if the file data was extracted

--- a/src/prerna/engine/impl/vector/AbstractVectorDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/AbstractVectorDatabaseEngine.java
@@ -333,13 +333,12 @@ public abstract class AbstractVectorDatabaseEngine implements IVectorDatabaseEng
 								rowsCreated = VectorDatabaseUtils.convertFilesToCSV(extractedFile.getAbsolutePath(), document);
 							}
 							catch(Exception e) {
-								classLogger.error(Constants.STACKTRACE, e);
 								FileUtils.forceDelete(extractedFile);
 								FileUtils.forceDelete(document);
-								classLogger.error(document.getName()+":"+e.getMessage());
+								classLogger.error(document.getName()+" : "+e.getMessage());
 								continue;
 							}
-							classLogger.error(document.getName()+": No Error");
+							classLogger.info(document.getName()+" : No Error");
 						}
 
 						// check to see if the file data was extracted


### PR DESCRIPTION
Delete file from document and indexed files when exception occur.

Scenario: When we upload a corrupted file (renaming a file from .docx to .pptx) and upload to vector db, then it does throw error but also doesn't remove file from document folder. This change removes that file from document folder whenever there is a error thrown while reading a corrupted file. 
That's why kept inside try-catch block to handle. 