### PR TITLE
Reads max_input_tokens from smss file for chatgpt generative model

### DIFF
--- a/py/genai_client/text_generation/openai_clients/abstract_openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/abstract_openai_client.py
@@ -29,6 +29,7 @@ class AbstractOpenAiClient(AbstractTextGenerationClient, ABC):
         return OpenAiTokenizer(
             encoder_name=init_args.pop("tokenizer_name", None) or self.model_name,
             max_tokens=init_args.pop("max_tokens", None),
+            max_input_tokens=init_args.pop("max_input_tokens", None)
         )
 
     def _get_client(self, api_key, **kwargs):


### PR DESCRIPTION
Issue - When we are adding max_input_tokens in INIT_MODEL_ENGINE as param we are getting an error "got an unexpected keyword argument 'max_input_tokens'".
Fix - initialized the max_input_tokens in open_ai_tokenizer and poping it from the args before initializing Azureopenai.