### PR TITLE
UPDATE ::: exposing filter and metafilter on python and usage

### DIFF
--- a/py/gaas_gpt_vector.py
+++ b/py/gaas_gpt_vector.py
@@ -143,6 +143,8 @@ class VectorEngine(ServerProxy):
         search_statement: str,
         limit: Optional[int] = 5,
         param_dict: Optional[Dict] = {},
+        filter_str: Optional[str] = None,
+        metafilter_str: Optional[str] = None,
         insight_id: Optional[str] = None,
     ) -> List[Dict]:
         """
@@ -165,8 +167,11 @@ class VectorEngine(ServerProxy):
         optionalParams = (
             f",paramValues=[{param_dict}]" if param_dict is not None else ""
         )
+        
+        optionalFilter = f",filter=[{filter_str}]" if filter is not None else ""
+        optionalMetaFilter = f",metaFilters=[{metafilter_str}]" if filter is not None else ""
 
-        pixel = f'VectorDatabaseQuery(engine="{self.engine_id}",command=["<encode>{search_statement}</encode>"]{optionalLimit}{optionalParams});'
+        pixel = f'VectorDatabaseQuery(engine="{self.engine_id}",command=["<encode>{search_statement}</encode>"]{optionalLimit}{optionalParams}{optionalFilter}{optionalMetaFilter});'
         epoc = super().get_next_epoc()
 
         pixelReturn = super().callReactor(

--- a/src/prerna/reactor/utils/GetEngineUsageReactor.java
+++ b/src/prerna/reactor/utils/GetEngineUsageReactor.java
@@ -259,7 +259,9 @@ public class GetEngineUsageReactor extends AbstractReactor {
 							"CreateEmbeddingsFromVectorCSVFile (engine = \""+engineId+"\", filePaths = [\"fileName1.csv\", \"fileName2.csv\", ..., \"fileNameX.csv\"]);\r\n" +
 
 							"\n## Perform a nearest neighbor search on the embedded documents ##\r\n" +
-							"VectorDatabaseQuery (engine = \""+engineId+"\", command = \"Sample Search Statement\", limit = 5);\r\n" +
+							"# filters of the form Filter(Source == [\"your document name 1\", \"your document name 2\"])\r\n" +
+							"# metaFilters of the form Filter( MetadataKey == \"Metadata Value\" )\r\n" +
+							"VectorDatabaseQuery (engine = \""+engineId+"\", command = \"Sample Search Statement\", limit = 5, filters=[], metaFilters=[]);\r\n" +
 							
 							"\n## Remove document(s) from the vector database ##\r\n" +
 							"RemoveDocumentFromVectorDatabase (engine = \""+engineId+"\", filePaths = [\"fileName1.pdf\", \"fileName2.pdf\", ..., \"fileNameX.pdf\"]);"
@@ -283,7 +285,9 @@ public class GetEngineUsageReactor extends AbstractReactor {
 							"vectorEngine.addVectorCSVFile(file_paths = ['fileName1.csv', 'fileName2.csv', ..., 'fileNameX.csv'])\r\n" + 
 							
 							"\n# Perform a nearest neighbor search on the embedded documents\r\n" +
-							"vectorEngine.nearestNeighbor(search_statement = 'Sample Search Statement', limit = 5)\r\n" + 
+							"# filter_str of the form 'Filter(Source == [\"your document name 1\", \"your document name 2\"])'\r\n" +
+							"# metafilter_str of the form 'Filter( MetadataKey == \"Metadata Value\" )'\r\n" +
+							"vectorEngine.nearestNeighbor(search_statement = 'Sample Search Statement', limit = 5, param_dict={}, filter_str='', metafilter_str='')\r\n" + 
 							
 							"\n# Remove document(s) from the vector database\r\n" +
 							"vectorEngine.removeDocument(file_names = ['fileName1.pdf', 'fileName2.pdf', ..., 'fileNameX.pdf'])"


### PR DESCRIPTION
Should have done this closely after https://github.com/SEMOSS/Semoss/pull/89

Python equivalent. Example code:

from gaas_gpt_vector import VectorEngine
vectorEngine = VectorEngine(engine_id = "49cc9bd9-c089-4e93-8353-fc9cc653b929", insight_id = '${i}', insight_folder = '${if}')
vectorEngine.nearestNeighbor(search_statement = 'Sample Search Statement', limit = 5, param_dict={}, filter_str='Filter(Source == "Executive Order on the Safe, Secure, and Trustworthy Development and Use of Artificial Intelligence _ The White House.pdf")', metafilter_str="Filter(age>5)")

Also now exposed in usage tab