### PR TITLE
closing connection when pooling

### DIFF
--- a/src/prerna/util/ConnectionUtils.java
+++ b/src/prerna/util/ConnectionUtils.java
@@ -51,10 +51,10 @@ public class ConnectionUtils {
 		}
 		if(engine!=null && engine.isConnectionPooling()) {
 			try{
-				Connection conn;
-				conn = ps.getConnection();
-				if(conn != null)
-					conn.close();
+				if(con == null && ps != null)
+					con = ps.getConnection();
+				if(con != null)
+					con.close();
 			} catch (Exception e){
 				classLogger.error(Constants.STACKTRACE, e);
 			}

--- a/src/prerna/util/ConnectionUtils.java
+++ b/src/prerna/util/ConnectionUtils.java
@@ -41,10 +41,20 @@ public class ConnectionUtils {
 
 	private static final Logger classLogger = LogManager.getLogger(ConnectionUtils.class);
 
-	public static void closeAllConnectionsIfPooling(IRDBMSEngine engine, Connection con, Statement ps, ResultSet rs){
+	public static void closeAllConnectionsIfPooling(IRDBMSEngine engine, Connection con, Statement ps, ResultSet rs) {
 		if(rs!=null){
 			try{
 				rs.close();
+			} catch (Exception e){
+				classLogger.error(Constants.STACKTRACE, e);
+			}
+		}
+		if(engine!=null && engine.isConnectionPooling()) {
+			try{
+				Connection conn;
+				conn = ps.getConnection();
+				if(conn != null)
+					conn.close();
 			} catch (Exception e){
 				classLogger.error(Constants.STACKTRACE, e);
 			}
@@ -56,15 +66,7 @@ public class ConnectionUtils {
 				classLogger.error(Constants.STACKTRACE, e);
 			}
 		}
-		if(engine!=null && engine.isConnectionPooling()) {
-			if(con!=null){
-				try{
-					con.close();
-				} catch (Exception e){
-					classLogger.error(Constants.STACKTRACE, e);
-				}
-			}
-		}
+		
 	}
 
 	public static void closeAllConnectionsIfPooling(IRDBMSEngine engine, Statement ps, ResultSet rs){

--- a/src/prerna/util/ConnectionUtils.java
+++ b/src/prerna/util/ConnectionUtils.java
@@ -49,24 +49,25 @@ public class ConnectionUtils {
 				classLogger.error(Constants.STACKTRACE, e);
 			}
 		}
-		if(engine!=null && engine.isConnectionPooling()) {
-			try{
-				if(con == null && ps != null)
-					con = ps.getConnection();
-				if(con != null)
-					con.close();
-			} catch (Exception e){
-				classLogger.error(Constants.STACKTRACE, e);
-			}
-		}
 		if(ps!=null){
 			try{
+				if(engine!=null && engine.isConnectionPooling() && con == null) {
+					con = ps.getConnection();
+				}
 				ps.close();
 			} catch (Exception e){
 				classLogger.error(Constants.STACKTRACE, e);
 			}
 		}
-		
+		if(engine!=null && engine.isConnectionPooling()) {
+			try{
+				if(con != null) {
+					con.close();
+				}
+			} catch (Exception e){
+				classLogger.error(Constants.STACKTRACE, e);
+			}
+		}
 	}
 
 	public static void closeAllConnectionsIfPooling(IRDBMSEngine engine, Statement ps, ResultSet rs){


### PR DESCRIPTION
Connection was not getting closed properly which was resulting in connection timeout error for new queries. There is param for connection but it is getting passed as null in the function call. So, we are taking the connection from prepared statement.