### PR TITLE
Added empty check for keywordGeneratorEngineId

### DIFF
--- a/src/prerna/engine/impl/vector/PGVectorDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/PGVectorDatabaseEngine.java
@@ -1090,7 +1090,7 @@ public class PGVectorDatabaseEngine extends RDBMSNativeEngine implements IVector
 			}
 		}
 		
-		if(this.keywordGeneratorEngineId != null) {
+		if(this.keywordGeneratorEngineId != null && !this.keywordGeneratorEngineId.trim().isEmpty()) {
 			if(!SecurityEngineUtils.userCanViewEngine(user, this.keywordGeneratorEngineId)) {
 				throw new IllegalArgumentException("Keyword model " + this.keywordGeneratorEngineId + " does not exist or user does not have access to this model");
 			}


### PR DESCRIPTION
<img width="619" alt="Screenshot 2024-12-12 125922" src="https://github.com/user-attachments/assets/dbe6c48d-d243-485a-8cae-f1f7e993d93b" />

As shown in the above code once keywordGeneratorEngineId is found to be null it is then set to "" which is  causing the error  
```Keyword model does not exist or user does not have access to this model.``` intermittently when more than one call is happening to PGVectorDBEngine in parallel.
Hence, adding an empty check to prevent this error.