### PR TITLE
Convert image URLs to base64 && skip image content in token counting

### DIFF
--- a/py/genai_client/constants.py
+++ b/py/genai_client/constants.py
@@ -11,6 +11,7 @@ TEMPLATE = "template"
 TEMPLATE_NAME = "template_name"
 FULL_PROMPT = "full_prompt"
 IMAGE_ENCODED = "image_encoded"
+IMAGE_URL = "image_url"
 
 
 @dataclasses.dataclass

--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -165,11 +165,7 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
         warnings = []
 
         # 1. Get our prompt token count
-        num_tokens_in_prompt = len(
-            self.tokenizer._get_tokenizer(self.model_name).encode(
-                self.tokenizer.format_with_chat_template(prompt_payload)
-            )
-        )
+        num_tokens_in_prompt = self.tokenizer.count_tokens(prompt_payload)
 
         # 2. Get model limits
         model_limits = self.tokenizer.get_model_limits(self.model_name)

--- a/py/genai_client/text_generation/openai_clients/operations/chat.py
+++ b/py/genai_client/text_generation/openai_clients/operations/chat.py
@@ -1,7 +1,10 @@
 from typing import List, Dict
+import requests
+import base64
 from ....constants import (
     FULL_PROMPT,
     IMAGE_ENCODED,
+    IMAGE_URL,
     AskModelEngineResponse,
 )
 
@@ -110,7 +113,7 @@ class Chat:
         if history is not None:
             message_payload.extend(history)
 
-        # check if images are in the fill args
+        # If the image is already base64 encoded we can add it to the payload
         if IMAGE_ENCODED in fill_variables:
             # add the new question to the payload
             if question != None and len(question) > 0:
@@ -120,6 +123,15 @@ class Chat:
                 image_url["url"] = (
                     f"data:image/png;base64,{fill_variables.pop(IMAGE_ENCODED)}"
                 )
+                image_payload.append({"type": "image_url", "image_url": image_url})
+                message_payload.append({"role": "user", "content": image_payload})
+        # If the image is a URL we need to convert it to base64
+        elif IMAGE_URL in fill_variables:
+            if question != None and len(question) > 0:
+                image_payload = []
+                image_payload.append({"type": "text", "text": question})
+                image_url = {}
+                image_url["url"] = self.url_to_base64(fill_variables.pop(IMAGE_URL))
                 image_payload.append({"type": "image_url", "image_url": image_url})
                 message_payload.append({"role": "user", "content": image_payload})
         else:
@@ -146,3 +158,16 @@ class Chat:
             raise TypeError(
                 "Please make sure the full prompt for OpenAI Chat-Completion is a list"
             )
+
+    def url_to_base64(self, image_url: str):
+        try:
+            response = requests.get(image_url)
+            response.raise_for_status()
+
+            base64_string = base64.b64encode(response.content).decode("utf-8")
+
+            return f"data:image/{response.headers['Content-Type'].split('/')[-1]};base64,{base64_string}"
+
+        except requests.exceptions.RequestException as e:
+            print(f"Error fetching image: {e}")
+            return None

--- a/py/genai_client/tokenizers/openai_tokenizer.py
+++ b/py/genai_client/tokenizers/openai_tokenizer.py
@@ -53,11 +53,17 @@ class OpenAiTokenizer(AbstractTokenizer):
     def format_with_chat_template(self, messages: List[Dict]) -> str:
         """
         Applies the appropriate chat template for OpenAI models.
-        Args:
-            messages: List of message dictionaries with 'role' and 'content'
-        Returns:
-            str: Formatted prompt string
+        Handles both regular messages and messages with image content.
         """
+        # Check if any message contains image content
+        has_image_content = any(
+            isinstance(msg.get("content"), list) for msg in messages
+        )
+
+        # We can't use the chat template for messages with image content
+        if has_image_content:
+            return ""  # Return empty since we can't be using this for token counting
+
         if hasattr(self.tokenizer, "apply_chat_template"):
             if self.tokenizer.chat_template is None:
                 self.tokenizer.chat_template = "chatml"
@@ -70,22 +76,22 @@ class OpenAiTokenizer(AbstractTokenizer):
             for message in input:
                 num_tokens += self.tokens_per_message
                 for key, value in message.items():
-                    num_tokens += len(self.get_tokens_ids(input=str(value)))
-
-                    if key == "name":
+                    if key == "content":
+                        if isinstance(value, list):
+                            # Handle structured content with images
+                            for content_item in value:
+                                if content_item["type"] == "text":
+                                    num_tokens += len(
+                                        self.get_tokens_ids(content_item["text"])
+                                    )
+                                # Skip token counting for image_url content
+                        else:
+                            num_tokens += len(self.get_tokens_ids(str(value)))
+                    elif key == "name":
                         num_tokens += self.tokens_per_name
             num_tokens += 3  # every reply is primed with <|start|>assistant<|message|>
-        elif isinstance(input, dict):
-            num_tokens += self.tokens_per_message
-            for key, value in input.items():
-                num_tokens += len(self.get_tokens_ids(input=value))
-
-                if key == "name":
-                    num_tokens += self.tokens_per_name
-
-            num_tokens += 3  # every reply is primed with <|start|>assistant<|message|>
         elif isinstance(input, str):
-            num_tokens = len(self.get_tokens_ids(input=input))
+            num_tokens = len(self.get_tokens_ids(input))
 
         return num_tokens
 


### PR DESCRIPTION
- Adding image URL conversion to base64 when provided in the `image_url` parameter of ask call. 
- Updating tokenizer token counting to skip image content 