### PR TITLE
Remote Model Shutdown Request

### DIFF
--- a/src/prerna/cluster/util/RemoteClientServerZK.java
+++ b/src/prerna/cluster/util/RemoteClientServerZK.java
@@ -501,29 +501,95 @@ public class RemoteClientServerZK {
 		}
 	}
 
-	/**
-	 * Gets a list of all active model IDs
-	 * @return List of active model IDs
-	 */
-	public List<String> getActiveModels() {
-		try {
-			return client.getChildren().forPath(ACTIVE_PATH);
-		} catch (Exception e) {
-			classLogger.error("Error getting active models", e);
-			return new ArrayList<>();
-		}
+	public class RemoteModelInfo {
+	    private final String id;
+	    private final String name;
+	    private final RemoteModelStateEnum state;
+
+	    public RemoteModelInfo(String id, String name, RemoteModelStateEnum state) {
+	        this.id = id;
+	        this.name = name;
+	        this.state = state;
+	    }
+
+	    // Getters
+	    public String getId() { return id; }
+	    public String getName() { return name; }
+	    public RemoteModelStateEnum getState() { return state; }
 	}
 
 	/**
-	 * Gets a list of all warming model IDs
-	 * @return List of warming model IDs
+	 * Gets a list of all active models with their associated information
+	 * @return List of ModelInfo objects containing model details
 	 */
-	public List<String> getWarmingModels() {
-		try {
-			return client.getChildren().forPath(WARMING_PATH);
-		} catch (Exception e) {
-			classLogger.error("Error getting warming models", e);
-			return new ArrayList<>();
-		}
+	public List<RemoteModelInfo> getActiveModels() {
+	    List<RemoteModelInfo> activeModels = new ArrayList<>();
+	    
+	    try {
+	        List<String> activeModelIds = client.getChildren().forPath(ACTIVE_PATH);
+	        
+	        for (String modelId : activeModelIds) {
+	            String name = modelNames.get(modelId);
+	            RemoteModelStateEnum state = modelStates.getOrDefault(modelId, RemoteModelStateEnum.COLD);
+	            
+	            if (name != null) {
+	                activeModels.add(new RemoteModelInfo(
+	                    modelId,
+	                    name,
+	                    state
+	                ));
+	            } else {
+	                classLogger.warn("Incomplete data for active model {}: name={}", modelId, name);
+	                    
+	                String fullPath = ACTIVE_PATH + "/" + modelId;
+	                byte[] data = client.getData().forPath(fullPath);
+	                if (data != null && data.length > 0) {
+	                    String rawData = new String(data, "UTF-8");
+	                    JSONObject jsonData = new JSONObject(rawData);
+	                    
+	                    name = jsonData.getString("model_name");
+	                    
+	                    activeModels.add(new RemoteModelInfo(
+	                        modelId,
+	                        name,
+	                        state
+	                    ));
+	                    
+	                    modelNames.put(modelId, name);
+	                }
+	            }
+	        }
+	    } catch (Exception e) {
+	        classLogger.error("Error getting active models with details", e);
+	    }
+	    
+	    return activeModels;
+	}
+
+	/**
+	 * Gets a list of all warming models with their associated information
+	 * @return List of RemoteModelInfo objects containing model details
+	 */
+	public List<RemoteModelInfo> getWarmingModels() {
+	    List<RemoteModelInfo> warmingModels = new ArrayList<>();
+	    
+	    try {
+	        List<String> warmingModelIds = client.getChildren().forPath(WARMING_PATH);
+	        
+	        for (String modelId : warmingModelIds) {
+	            String name = modelNames.get(modelId);
+	            RemoteModelStateEnum state = modelStates.getOrDefault(modelId, RemoteModelStateEnum.WARMING);
+	            
+	            warmingModels.add(new RemoteModelInfo(
+	                modelId,
+	                name != null ? name : "Warming...",
+	                state
+	            ));
+	        }
+	    } catch (Exception e) {
+	        classLogger.error("Error getting warming models with details", e);
+	    }
+	    
+	    return warmingModels;
 	}
 }

--- a/src/prerna/engine/impl/model/AbstractRemoteModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractRemoteModelEngine.java
@@ -161,6 +161,60 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 	    classLogger.error("Timeout waiting for model {} to enter warming state", this.engineId);
 	    return false;
 	}
+	
+	public String shutdownModelRequest() throws Exception {
+	    RemoteModelStateEnum currentState = zkClient.getModelState(this.engineId);
+	    
+	    if (currentState == RemoteModelStateEnum.COLD) {
+	        classLogger.info("Model {} is already cold", this.engineId);
+	        return String.format("Model %s is already cold", this.engineId);
+	    }
+	    
+	    String modelScalerIp = zkClient.getModelScalerIp();
+	    if (modelScalerIp == null) {
+	        classLogger.error("Unable to get model scaler IP from ZooKeeper");
+	        return "Failed to get model scaler IP";
+	    }
+	    
+	    String shutdownUrl;
+	    if (devPortFowarding) {
+	        shutdownUrl = String.format("http://localhost:8000/api/stop?model_id=%s&model=%s", 
+	            this.engineId, this.model);
+	    } else {
+	        shutdownUrl = String.format("http://%s/api/stop?model_id=%s&model=%s", 
+	            modelScalerIp, this.engineId, this.model);
+	    }
+
+	    RequestConfig requestConfig = RequestConfig.custom()
+	            .setConnectTimeout(30000)
+	            .setSocketTimeout(30000)
+	            .build();
+
+	    try (CloseableHttpClient httpClient = HttpClients.custom()
+	            .setDefaultRequestConfig(requestConfig)
+	            .build()) {
+
+	    	HttpPost httpPost = new HttpPost(shutdownUrl);
+
+	        try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
+	            int statusCode = response.getStatusLine().getStatusCode();
+	            if (statusCode != 200) {
+	                String error = String.format("Shutdown request failed with status code: %d", statusCode);
+	                classLogger.error(error);
+	                return error;
+	            }
+
+	            String message = String.format("Successfully initiated shutdown for model %s", this.engineId);
+	            classLogger.info(message);
+	            return message;
+	        }
+	    } catch (Exception e) {
+	        String error = String.format("Error making shutdown request for model %s: %s", 
+	            this.engineId, e.getMessage());
+	        classLogger.error(error, e);
+	        return error;
+	    }
+	}
 
 	protected JSONObject makeModelRequest(JSONObject requestPayload) throws Exception {
 		// Get current state and handle warming/cold states

--- a/src/prerna/engine/impl/model/AbstractRemoteModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractRemoteModelEngine.java
@@ -96,7 +96,7 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 		}
 	}
 	
-	protected boolean initiateAndWaitForDeployment(long timeoutMs) throws Exception {
+	public boolean initiateAndWaitForDeployment(long timeoutMs) throws Exception {
 	    if (zkClient.isModelActive(this.engineId)) {
 	        classLogger.info("Model {} is already active", this.engineId);
 	        return true;

--- a/src/prerna/reactor/model/MyRemoteModelsStatus.java
+++ b/src/prerna/reactor/model/MyRemoteModelsStatus.java
@@ -1,0 +1,53 @@
+package prerna.reactor.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.utils.SecurityEngineUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.cluster.util.RemoteClientServerZK;
+import prerna.cluster.util.RemoteClientServerZK.RemoteModelInfo;
+
+
+public class MyRemoteModelsStatus extends AbstractReactor {
+	
+	private static final Logger classLogger = LogManager.getLogger(MyRemoteModelsStatus.class);
+	
+	@Override
+	public NounMetadata execute() {
+		final RemoteClientServerZK zkClient;
+		zkClient = RemoteClientServerZK.getInstance();
+		List<RemoteModelInfo> activeModels = zkClient.getActiveModels();
+	    List<RemoteModelInfo> warmingModels = zkClient.getWarmingModels();
+	    
+	    List<RemoteModelInfo> myActiveModels = new ArrayList<>();
+	    List<RemoteModelInfo> myWarmingModels = new ArrayList<>();
+	    
+		for (RemoteModelInfo model : activeModels) {
+			if (SecurityEngineUtils.userCanViewEngine(this.insight.getUser(), model.getId())) {
+				myActiveModels.add(model);
+			}
+		}
+		
+		for (RemoteModelInfo model : warmingModels) {
+			if (SecurityEngineUtils.userCanViewEngine(this.insight.getUser(), model.getId())) {
+				myWarmingModels.add(model);
+			}
+		}
+		
+        Map<String, List<RemoteModelInfo>> modelsMap = new HashMap<>();
+        modelsMap.put("activeModels", myActiveModels);
+        modelsMap.put("warmingModels", myWarmingModels);
+
+		return new NounMetadata(modelsMap, PixelDataType.MAP, PixelOperationType.OPERATION);
+	}
+
+}

--- a/src/prerna/reactor/model/RemoteModelShutdownReactor.java
+++ b/src/prerna/reactor/model/RemoteModelShutdownReactor.java
@@ -1,0 +1,46 @@
+package prerna.reactor.model;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.utils.SecurityEngineUtils;
+import prerna.engine.api.IModelEngine;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.util.Utility;
+import prerna.engine.impl.model.AbstractRemoteModelEngine;
+
+public class RemoteModelShutdownReactor extends AbstractReactor {
+	
+	private static final Logger classLogger = LogManager.getLogger(RemoteModelShutdownReactor.class);
+
+	public RemoteModelShutdownReactor() {
+		this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey()};
+		this.keyRequired = new int[] { 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+	    organizeKeys();
+	    String engineId = this.keyValue.get(this.keysToGet[0]);
+	    
+	    if(!SecurityEngineUtils.userIsOwner(this.insight.getUser(), engineId)) {
+	        throw new IllegalArgumentException("Only the owner can shutdown the model");
+	    }
+	    
+	    try {
+	    	IModelEngine targetModel = Utility.getModel(engineId);
+	    	AbstractRemoteModelEngine targetEngine = (AbstractRemoteModelEngine) targetModel;
+
+	        String shutdownResult = targetEngine.shutdownModelRequest();
+	        
+	        return new NounMetadata(shutdownResult, PixelDataType.CONST_STRING, PixelOperationType.OPERATION);
+	    } catch (Exception e) {
+	        classLogger.error("Error shutting down model: " + engineId, e);
+	        throw new RuntimeException("Failed to shutdown model: " + e.getMessage());
+	    }
+	}
+}

--- a/src/prerna/reactor/model/RemoteModelStartReactor.java
+++ b/src/prerna/reactor/model/RemoteModelStartReactor.java
@@ -1,0 +1,56 @@
+package prerna.reactor.model;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.utils.SecurityEngineUtils;
+import prerna.engine.api.IModelEngine;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.util.Utility;
+import prerna.engine.impl.model.AbstractRemoteModelEngine;
+
+public class RemoteModelStartReactor extends AbstractReactor {
+	
+	private static final Logger classLogger = LogManager.getLogger(RemoteModelStartReactor.class);
+	
+	public RemoteModelStartReactor() {
+		this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey()};
+		this.keyRequired = new int[] { 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+	    organizeKeys();
+	    String engineId = this.keyValue.get(this.keysToGet[0]);
+	    
+		if(!SecurityEngineUtils.userCanViewEngine(this.insight.getUser(), engineId)) {
+			throw new IllegalArgumentException("Model " + engineId + " does not exist or user does not have access to this model");
+		}
+	    
+	    try {
+	    	IModelEngine targetModel = Utility.getModel(engineId);
+	    	AbstractRemoteModelEngine targetEngine = (AbstractRemoteModelEngine) targetModel;
+
+	        Boolean startUpResult = targetEngine.initiateAndWaitForDeployment(200000);
+	        
+	        String result;
+	        
+			if (startUpResult) {
+				result = "Model started successfully";
+			} else {
+				result = "Model failed to start";
+			}
+	        
+	        
+	        return new NounMetadata(result, PixelDataType.CONST_STRING, PixelOperationType.OPERATION);
+	    } catch (Exception e) {
+	        classLogger.error("Error starting model: " + engineId, e);
+	        throw new RuntimeException("Failed to start model: " + e.getMessage());
+	    }
+	}
+
+}


### PR DESCRIPTION
- Adding reactor to handle requests to shutdown a model running on the Remote Client Server. Only allowed by model owners.

Ex: `RemoteModelShutdown(engine="f7dd0ae0-b31c-45d4-906c-044bd217d829")`

- Adding reactor to list active/warming remote models registered in ZK

Ex: `MyRemoteModelsStatus()`

- Adding reactor to start remote models without making initial request or holding onto connection while container loads

Ex: `RemoteModelStart(engine="f7dd0ae0-b31c-45d4-906c-044bd217d829")`