### PR TITLE
Adding logic to check if remote models can run on our instances

### DIFF
--- a/src/prerna/cluster/util/RemoteClientServerZK.java
+++ b/src/prerna/cluster/util/RemoteClientServerZK.java
@@ -1,6 +1,7 @@
 package prerna.cluster.util;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -14,6 +15,8 @@ import org.apache.curator.framework.recipes.cache.CuratorCacheListener;
 import org.apache.curator.framework.state.ConnectionState;
 import org.apache.curator.retry.RetryOneTime;
 import org.apache.http.HttpEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -591,5 +594,67 @@ public class RemoteClientServerZK {
 	    }
 	    
 	    return warmingModels;
+	}
+	
+	public Map<String, Object> canItRun(String hfModelId) throws Exception {
+	    String modelScalerIp = getModelScalerIp();
+	    if (modelScalerIp == null) {
+	        classLogger.error("Unable to get model scaler IP from ZooKeeper");
+	        throw new RuntimeException("Failed to get model scaler IP");
+	    }
+	    
+	    String canItRunUrl;
+	    if (devPortFowarding) {
+	        canItRunUrl = "http://localhost:8000/api/can-it-run";
+	    } else {
+	        canItRunUrl = String.format("http://%s/api/can-it-run", modelScalerIp);
+	    }
+
+	    RequestConfig requestConfig = RequestConfig.custom()
+	            .setConnectTimeout(5000)
+	            .setSocketTimeout(5000)
+	            .build();
+
+	    try (CloseableHttpClient httpClient = HttpClients.custom()
+	            .setDefaultRequestConfig(requestConfig)
+	            .build()) {
+
+	        HttpPost httpPost = new HttpPost(canItRunUrl);
+	        httpPost.setHeader("Content-Type", "application/json");
+
+	        JSONObject requestBody = new JSONObject();
+	        requestBody.put("model_id", hfModelId);
+
+	        StringEntity entity = new StringEntity(requestBody.toString());
+	        httpPost.setEntity(entity);
+
+	        try (CloseableHttpResponse response = httpClient.execute(httpPost)) {
+	            int statusCode = response.getStatusLine().getStatusCode();
+	            HttpEntity responseEntity = response.getEntity();
+	            String responseString = EntityUtils.toString(responseEntity);
+
+	            if (statusCode == 200) {
+	                JSONObject jsonResponse = new JSONObject(responseString);
+	                
+	                Map<String, Object> result = new HashMap<>();
+	                for (String key : jsonResponse.keySet()) {
+	                    result.put(key, jsonResponse.get(key));
+	                }
+	                
+	                classLogger.info("Successfully checked compatibility for model: {} - Can run: {}", 
+	                    hfModelId, result.get("can_run"));
+	                return result;
+	            } else {
+	                JSONObject errorResponse = new JSONObject(responseString);
+	                String errorMessage = errorResponse.getJSONObject("detail").getString("message");
+	                classLogger.error("Error checking model compatibility: {} (Status: {})", 
+	                    errorMessage, statusCode);
+	                throw new RuntimeException("Failed to check model compatibility: " + errorMessage);
+	            }
+	        }
+	    } catch (Exception e) {
+	        classLogger.error("Error making request to model scaler: {}", e.getMessage(), e);
+	        throw new RuntimeException("Failed to check model compatibility", e);
+	    }
 	}
 }

--- a/src/prerna/reactor/model/CanItRunReactor.java
+++ b/src/prerna/reactor/model/CanItRunReactor.java
@@ -1,0 +1,42 @@
+package prerna.reactor.model;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.cluster.util.RemoteClientServerZK;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+
+public class CanItRunReactor extends AbstractReactor {
+	
+	private static final Logger classLogger = LogManager.getLogger(MyRemoteModelsStatus.class);
+	
+	public CanItRunReactor() {
+		this.keysToGet = new String[] { ReactorKeysEnum.HF_MODEL_ID.getKey()};
+		this.keyRequired = new int[] { 1 };
+	}
+	
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		String hfModelId = this.keyValue.get(this.keysToGet[0]);
+		
+		final RemoteClientServerZK zkClient;
+		zkClient = RemoteClientServerZK.getInstance();
+		
+		try {
+			Map<String, Object> canRun = zkClient.canItRun(hfModelId);
+			return new NounMetadata(canRun, PixelDataType.MAP, PixelOperationType.OPERATION);
+		} catch (Exception e) {
+			classLogger.error("Error checking if model can run: " + hfModelId, e);
+			throw new RuntimeException("Failed to check if model can run: " + e.getMessage());
+		}
+		
+	}
+
+}

--- a/src/prerna/sablecc2/om/ReactorKeysEnum.java
+++ b/src/prerna/sablecc2/om/ReactorKeysEnum.java
@@ -98,6 +98,7 @@ public enum ReactorKeysEnum {
 	HEADERS("headers",                                      	"All the headers strings we want to push as part of the header on the excel / powerpoint export"),
 	HEADERS_MAP("headersMap", 									"Map containing key-value pairs to send in the headers of a request"),		
 	HEIGHT("height", 											"The height to use for screenshot capture."),
+	HF_MODEL_ID("hfModelId", 									"The model id for the HF model"),
 	HOST("host",                    	                        "The host URL"),
 	HTML("html",                        	                    "The html"),
 	ID("id", 													"This key can represent the unique id of the insight instance or the unique id of the saved insight relative to the app"),


### PR DESCRIPTION
Adding a `CanItRunReactor` that accepts HuggingFace model id's and hits the Kubernetes scaler endpoint, `/can-it-run` which checks if the model can run on our instances. This only works for transformer based models right now. 

```
CanItRun ( hfModelId = "microsoft/Phi-3.5-mini-instruct" ) ;

{"mode": "inference", "required_memory_gb": 8.540778350830077, "can_run": true, "gpu_memory_gb": 16, "dtype": "float16", "model_id": "microsoft/Phi-3.5-mini-instruct", "available_memory_gb": 16, "model_parameters_b": 3.821079552}
```

```
CanItRun ( hfModelId = "Qwen/QwQ-32B-Preview" ) ;

{"mode": "inference", "required_memory_gb": 71.49273619651794, "can_run": false, "gpu_memory_gb": 16, "dtype": "float16", "model_id": "Qwen/QwQ-32B-Preview", "available_memory_gb": 16, "model_parameters_b": 31.985308672}
```