### PR TITLE
Converting Python model methods to use reactors

### DIFF
--- a/py/gaas_gpt_model.py
+++ b/py/gaas_gpt_model.py
@@ -84,22 +84,19 @@ class TomcatModelEngine(AbstractModelEngine, ServerProxy):
 
         epoc = super().get_next_epoc()
 
-        model_response = super().call(
+        pixel = f'LLM(engine="{self.engine_id}", command="{question}", context="{context}", paramValues={param_dict});'
+
+        pixelReturn = super().callReactor(
             epoc=epoc,
-            engine_type="Model",
-            engine_id=self.engine_id,
-            method_name="ask",
-            method_args=[question, context, insight_id, param_dict],
-            method_arg_types=[
-                "java.lang.String",
-                "java.lang.String",
-                "prerna.om.Insight",
-                "java.util.Map",
-            ],
+            pixel=pixel,
             insight_id=insight_id,
         )
 
-        return model_response
+        if pixelReturn is not None and len(pixelReturn) > 0:
+            output = pixelReturn[0]["pixelReturn"][0]
+            return output["output"]
+
+        return pixelReturn
 
     def ner(
         self,
@@ -116,7 +113,6 @@ class TomcatModelEngine(AbstractModelEngine, ServerProxy):
 
         pixel = f'NER(engine="{self.engine_id}", prompt="{text}", entities={entities}, maskEntities={mask_entities});'
 
-        print(f"Pixel: {pixel}")
         pixelReturn = super().callReactor(
             epoc=epoc,
             pixel=pixel,
@@ -226,17 +222,20 @@ class TomcatModelEngine(AbstractModelEngine, ServerProxy):
         assert isinstance(strings_to_embed, list)
 
         epoc = super().get_next_epoc()
-        model_response = super().call(
+
+        pixel = f'Embeddings(engine="{self.engine_id}", values={strings_to_embed}, paramValues={param_dict});'
+
+        pixelReturn = super().callReactor(
             epoc=epoc,
-            engine_type="Model",
-            engine_id=self.engine_id,
-            method_name="embeddings",
-            method_args=[strings_to_embed, insight_id, param_dict],
-            method_arg_types=["java.util.List", "prerna.om.Insight", "java.util.Map"],
+            pixel=pixel,
             insight_id=insight_id,
         )
 
-        return model_response
+        if pixelReturn is not None and len(pixelReturn) > 0:
+            output = pixelReturn[0]["pixelReturn"][0]
+            return output["output"]
+
+        return pixelReturn
 
     def image_embeddings(
         self,
@@ -253,17 +252,20 @@ class TomcatModelEngine(AbstractModelEngine, ServerProxy):
         assert isinstance(images_to_embed, list)
 
         epoc = super().get_next_epoc()
-        model_response = super().call(
+
+        pixel = f'ImageEmbeddings(engine="{self.engine_id}", values={images_to_embed}, paramValues={param_dict});'
+
+        pixelReturn = super().callReactor(
             epoc=epoc,
-            engine_type="Model",
-            engine_id=self.engine_id,
-            method_name="imageEmbeddings",
-            method_args=[images_to_embed, insight_id, param_dict],
-            method_arg_types=["java.util.List", "prerna.om.Insight", "java.util.Map"],
+            pixel=pixel,
             insight_id=insight_id,
         )
 
-        return model_response
+        if pixelReturn is not None and len(pixelReturn) > 0:
+            output = pixelReturn[0]["pixelReturn"][0]
+            return output["output"]
+
+        return pixelReturn
 
     def model(
         self,
@@ -275,32 +277,20 @@ class TomcatModelEngine(AbstractModelEngine, ServerProxy):
             insight_id = self.insight_id
 
         epoc = super().get_next_epoc()
-        model_response = super().call(
+
+        pixel = f"Model(input={input}, paramValues={param_dict});"
+
+        pixelReturn = super().callReactor(
             epoc=epoc,
-            engine_type="Model",
-            engine_id=self.engine_id,
-            method_name="model",
-            method_args=[input, insight_id, param_dict],
-            method_arg_types=["java.lang.Object", "prerna.om.Insight", "java.util.Map"],
+            pixel=pixel,
             insight_id=insight_id,
         )
 
-        return model_response
+        if pixelReturn is not None and len(pixelReturn) > 0:
+            output = pixelReturn[0]["pixelReturn"][0]
+            return output["output"]
 
-    def get_model_type(self, insight_id: Optional[str] = None):
-        if insight_id is None:
-            insight_id = self.insight_id
-
-        epoc = super().get_next_epoc()
-        return super().call(
-            epoc=epoc,
-            engine_type="Model",
-            engine_id=self.engine_id,
-            method_name="getModelType",
-            method_args=[],
-            method_arg_types=[],
-            insight_id=insight_id,
-        )
+        return pixelReturn
 
     # this is a little bit of get out of jail free card
     def do_call(self, method_name: str, input: Any, **kwargs) -> Any:
@@ -378,11 +368,6 @@ class HuggingFacePipelineModelEngine(AbstractModelEngine):
     ):
         return self.pipe(input)
 
-    def get_model_type(
-        self,
-    ):
-        return self.pipeline_type
-
     # this is a little bit of get out of jail free card
     def do_call(self, method_name: str, input: Any, **kwargs) -> Any:
         call_maker = getattr(self, method_name, None)
@@ -446,10 +431,6 @@ class LocalModelEngine(AbstractModelEngine):
 
     def model(self, **kwargs):
         return [self.local_model_engine.model(**kwargs)]
-
-    def get_model_type(self, **kwargs):
-        # TODO add model type in python as well
-        return ["TEXT_GENERATION"]
 
     def do_call(self, method_name: str, input: Any, **kwargs) -> Any:
         call_maker = getattr(self, method_name, None)
@@ -595,9 +576,6 @@ class ModelEngine(AbstractModelEngine):
     ):
         return self.model_engine.ner(**kwargs)
 
-    def get_model_type(self, **kwargs):
-        return self.model_engine.get_model_type(**kwargs)
-
     def do_call(self, **kwargs: Any) -> Any:
         return self.model_engine.embeddings(**kwargs)
 
@@ -650,7 +628,7 @@ class ModelEngine(AbstractModelEngine):
                 data = {
                     "engine_id": model_engine.get_model_engine_id(),
                     "model_engine": model_engine,
-                    "model_type": model_engine.get_model_type()[0],
+                    "model_type": model_engine,
                 }
 
                 super().__init__(**data)


### PR DESCRIPTION
Updating the methods in `gaas_gpt_model` to call reactors instead of engine workers. 