### PR TITLE
fix: Remove system prompts on o1 models

### DIFF
--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -111,6 +111,45 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
         params = {structured_param_name: param_value, **kwargs}
         return self._get_structured_output_response(params)
 
+    def _update_model_specific_kwargs(self, **kwargs) -> dict:
+        """
+        Update the kwargs based on the model name to ensure compatibility with the model's capabilities.
+        Returns:
+            dict: Updated kwargs
+        """
+        updated_kwargs = kwargs.copy()
+
+        if (
+            self.model_name.startswith("o1-preview")
+            or self.model_name.startswith("o1-mini")
+            or self.model_name == "o1"
+        ):
+            if "temperature" in updated_kwargs:
+                del updated_kwargs["temperature"]
+
+            updated_kwargs["stream"] = False
+
+            # These models do NOT support system messages
+            if "messages" in updated_kwargs:
+                # Convert system messages to user messages
+                messages = updated_kwargs["messages"]
+                for i, msg in enumerate(messages):
+                    if msg.get("role") == "system":
+                        messages[i]["role"] = "user"
+                        # Adding formatting to make it clear it was a system message
+                        messages[i]["content"] = (
+                            "SYSTEM INSTRUCTION: " + messages[i]["content"]
+                        )
+                updated_kwargs["messages"] = messages
+
+        elif self.model_name.startswith("o3-mini"):
+            if "temperature" in updated_kwargs:
+                del updated_kwargs["temperature"]
+
+            updated_kwargs["stream"] = False
+
+        return updated_kwargs
+
     def inference_call(self, prefix: str, **kwargs) -> str:
         final_query = ""
         # For Remote Client Server Models
@@ -133,22 +172,8 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
         if max_tokens is not None and "max_completion_tokens" not in kwargs:
             kwargs["max_completion_tokens"] = max_tokens
 
-        if (
-            self.model_name.startswith("o1-preview")
-            or self.model_name.startswith("o1-mini")
-            or self.model_name.startswith("o3-mini")
-            or self.model_name == "o1"
-        ):
-            # Check and remove "temperature" if it exists as its not supported
-            if "temperature" in kwargs:
-                del kwargs["temperature"]
-
-        if (
-            self.model_name.startswith("o1-preview")
-            or self.model_name.startswith("o1-mini")
-            or self.model_name == "o1"
-        ):
-            kwargs["stream"] = False
+        # Update model specific kwargs
+        kwargs = self._update_model_specific_kwargs(**kwargs)
 
         openai_response = self.client.chat.completions.create(
             model=self.model_name, **kwargs

--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -119,31 +119,38 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
         """
         updated_kwargs = kwargs.copy()
 
-        if (
-            self.model_name.startswith("o1-preview")
-            or self.model_name.startswith("o1-mini")
-            or self.model_name == "o1"
-        ):
-            if "temperature" in updated_kwargs:
+        # Handle o1-mini (doesn't support system/developer roles)
+        if self.model_name.startswith("o1-mini"):
+            # Remove temperature - only 1.0 is supported
+            if "temperature" in updated_kwargs and updated_kwargs["temperature"] != 1.0:
                 del updated_kwargs["temperature"]
 
             updated_kwargs["stream"] = False
 
-            # These models do NOT support system messages
+            # Convert system/developer messages to user messages
             if "messages" in updated_kwargs:
-                # Convert system messages to user messages
                 messages = updated_kwargs["messages"]
                 for i, msg in enumerate(messages):
-                    if msg.get("role") == "system":
+                    if msg.get("role") in ["system", "developer"]:
+                        original_role = msg.get("role").upper()
                         messages[i]["role"] = "user"
-                        # Adding formatting to make it clear it was a system message
-                        messages[i]["content"] = (
-                            "SYSTEM INSTRUCTION: " + messages[i]["content"]
-                        )
+                        messages[i][
+                            "content"
+                        ] = f"{original_role}: {messages[i]['content']}"
                 updated_kwargs["messages"] = messages
 
+        # Handle regular o1 models
+        elif self.model_name == "o1" or self.model_name.startswith("o1-preview"):
+            # Temperature - only 1.0 is supported
+            if "temperature" in updated_kwargs and updated_kwargs["temperature"] != 1.0:
+                del updated_kwargs["temperature"]
+
+            updated_kwargs["stream"] = False
+
+        # Handle o3-mini
         elif self.model_name.startswith("o3-mini"):
-            if "temperature" in updated_kwargs:
+            # Remove temperature - only 1.0 is supported
+            if "temperature" in updated_kwargs and updated_kwargs["temperature"] != 1.0:
                 del updated_kwargs["temperature"]
 
             updated_kwargs["stream"] = False


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
OpenAI's o1 models do not support system prompts. On calls to this model, updating any system prompts to user prompts. Formatting the message to append it with "SYSTEM INSTRUCTION" so the model is aware. 

## Changes Made
<!-- List the key changes made in this PR -->
Added `_update_model_specific_kwargs()` method to `openai_chat_completion_client.py` to handle model specific kwargs changes like updating system prompts & removing temperature for models that do not support. 

## How to Test
<!-- Explain how reviewers can test your changes -->
```python
from gaas_gpt_model import ModelEngine
# Azure o1 model id..
model = ModelEngine(engine_id = "488c043b-8839-4d27-a099-050bbd260bdf", insight_id = '${i}')

question = 'What is the capital of Connecticut?'
output = model.ask(question = question)
```

## Notes
<!-- Any further notes regarding changes -->