### PR TITLE
fix: Updating Model kwargs for non-OpenAI models

### DIFF
--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -119,6 +119,14 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
             dict: Updated kwargs
         """
         updated_kwargs = kwargs.copy()
+        # Token checks apply to ALL OpenAI models
+        # Check if 'max_tokens' exists in kwargs and remove it, saving its value
+        max_tokens = kwargs.pop("max_tokens", None)
+
+        # If 'max_tokens' was found and 'max_completion_tokens' is not already in kwargs, set it
+        if max_tokens is not None and "max_completion_tokens" not in kwargs:
+            kwargs["max_completion_tokens"] = max_tokens
+
         # Handle o1-mini (doesn't support system/developer roles)
         if self.model_name.startswith("o1-mini"):
             # Remove temperature - only 1.0 is supported
@@ -192,14 +200,7 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
 
         kwargs["stream"] = kwargs.get("stream", True)
 
-        # Check if 'max_tokens' exists in kwargs and remove it, saving its value
-        max_tokens = kwargs.pop("max_tokens", None)
-
-        # If 'max_tokens' was found and 'max_completion_tokens' is not already in kwargs, set it
-        if max_tokens is not None and "max_completion_tokens" not in kwargs:
-            kwargs["max_completion_tokens"] = max_tokens
-
-        # Update model specific kwargs
+        # Updating model specific kwargs
         kwargs = self._update_model_specific_kwargs(**kwargs)
 
         openai_response = self.client.chat.completions.create(

--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -8,6 +8,7 @@ from ...constants import (
     AskModelEngineResponse,
     InstructModelEngineResponse,
 )
+from ..utils import is_openai_native_model
 
 
 class OpenAiChatCompletion(AbstractOpenAiClient):
@@ -111,14 +112,13 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
         params = {structured_param_name: param_value, **kwargs}
         return self._get_structured_output_response(params)
 
-    def _update_model_specific_kwargs(self, **kwargs) -> dict:
+    def _update_openai_model_specific_kwargs(self, **kwargs) -> dict:
         """
-        Update the kwargs based on the model name to ensure compatibility with the model's capabilities.
+        Update the kwargs for OpenAI native models based on the model name to ensure compatibility with the model's capabilities.
         Returns:
             dict: Updated kwargs
         """
         updated_kwargs = kwargs.copy()
-
         # Handle o1-mini (doesn't support system/developer roles)
         if self.model_name.startswith("o1-mini"):
             # Remove temperature - only 1.0 is supported
@@ -152,8 +152,28 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
             # Remove temperature - only 1.0 is supported
             if "temperature" in updated_kwargs and updated_kwargs["temperature"] != 1.0:
                 del updated_kwargs["temperature"]
-
             updated_kwargs["stream"] = False
+
+        return updated_kwargs
+
+    def _update_model_specific_kwargs(self, **kwargs) -> dict:
+        """
+        Update the kwargs based on the model name to ensure compatibility with the model's capabilities.
+        Returns:
+            dict: Updated kwargs
+        """
+
+        is_openai_model = is_openai_native_model(self.model_name)
+
+        if is_openai_model:
+            return self._update_openai_model_specific_kwargs(**kwargs)
+        else:
+            updated_kwargs = kwargs.copy()
+
+            if "max_completion_tokens" in updated_kwargs:
+                updated_kwargs["max_tokens"] = updated_kwargs.pop(
+                    "max_completion_tokens"
+                )
 
         return updated_kwargs
 

--- a/py/genai_client/text_generation/utils.py
+++ b/py/genai_client/text_generation/utils.py
@@ -1,0 +1,57 @@
+def is_openai_native_model(model_name: str) -> bool:
+    """
+    Determines if a model is a native OpenAI model based on its name pattern.
+    Accommodates Azure OpenAI naming patterns and other variations.
+
+    Args:
+        model_name (str): The name of the model to check
+
+    Returns:
+        bool: True if the model is a native OpenAI model, False otherwise
+    """
+    model_name_lower = model_name.lower()
+
+    if "azure" in model_name_lower and any(
+        x in model_name_lower for x in ["gpt", "davinci", "o1", "o3"]
+    ):
+        return True
+
+    openai_identifiers = [
+        "gpt-",
+        "gpt4",
+        "gpt4o",
+        "gpt-4",
+        "gpt-3.5",
+        "text-davinci",
+        "text-curie",
+        "text-babbage",
+        "text-ada",
+        "davinci",
+        "curie",
+        "babbage",
+        "ada",
+        "whisper",
+        "tts-",
+        "dall-e",
+        "o1",
+        "o3",
+    ]
+
+    for identifier in openai_identifiers:
+        if identifier in model_name_lower:
+            return True
+
+    if "-vision-" in model_name_lower and (
+        "gpt" in model_name_lower or "davinci" in model_name_lower
+    ):
+        return True
+
+    if ":ft-openai:" in model_name_lower or "ft:gpt" in model_name_lower:
+        return True
+
+    if "deployment" in model_name_lower and any(
+        x in model_name_lower for x in ["gpt", "davinci", "o1", "o3"]
+    ):
+        return True
+
+    return False


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Models such as `Mixtral-8x7B` would throw errors on inference calls because we were trying to pass `max_completion_tokens` as a parameter. This parameter has not been widely adopted yet by non-OpenAI models. Defaulting back to `max_tokens` for non-OpenAI models. 

## Changes Made
<!-- List the key changes made in this PR -->
Added a `utils.py` file and a `is_openai_native_model()` method to detect native OpenAI models. Updated the `_update_model_specific_kwargs()` to use `max_tokens` for non-OpenAI models. 

## How to Test
<!-- Explain how reviewers can test your changes -->
```python
# Inference with Mixtral
from gaas_gpt_model import ModelEngine
question = 'What is the capital of Connecticut?'
model = ModelEngine(engine_id = "17753d59-4536-4415-a6ac-f673b1a90a87", param_dict={"temperature": .1}, insight_id = '${i}')
output = model.ask(question = question)
```