### PR TITLE
fix: removing token and limits on engine permission copy.

### DIFF
--- a/src/prerna/auth/utils/SecurityEngineUtils.java
+++ b/src/prerna/auth/utils/SecurityEngineUtils.java
@@ -1788,7 +1788,7 @@ public class SecurityEngineUtils extends AbstractSecurityUtils {
 	 * @param usageFrequency
 	 * @throws Exception
 	 */
-	public static void copyEnginePermissions(String sourceEngineId, String targetEngineId, int maxTokens, double maxResponseTime, String usageRestriction, String usageFrequency) throws Exception {
+	public static void copyEnginePermissions(String sourceEngineId, String targetEngineId) throws Exception {
 		
 		String insertTargetEnginePermissionSql = "INSERT INTO ENGINEPERMISSION (ENGINEID, USERID, PERMISSION, VISIBILITY, USAGERESTRICTION, USAGEFREQUENCY, MAXTOKENS, MAXRESPONSETIME) VALUES (?, ?, ?, ?, ?, ?, ?, ?)";
 		PreparedStatement insertTargetEnginePermissionStatement = securityDb.getPreparedStatement(insertTargetEnginePermissionSql);

--- a/src/prerna/reactor/engine/CopyEnginePermissionsReactor.java
+++ b/src/prerna/reactor/engine/CopyEnginePermissionsReactor.java
@@ -32,10 +32,6 @@ public class CopyEnginePermissionsReactor extends AbstractReactor {
 		organizeKeys();
 		String sourceEngineId = this.keyValue.get(this.keysToGet[0]);
 		String targetEngineId = this.keyValue.get(this.keysToGet[1]);
-		int maxTokens = Integer.parseInt(keyValue.get(this.keysToGet[2]));
-		double maxResponseTime = Double.parseDouble(this.keyValue.get(this.keysToGet[3]));
-		String usageRestriction = this.keyValue.get(this.keysToGet[4]);
-		String usageFrequency = this.keyValue.get(this.keysToGet[5]);
 
 		// must be an editor for both to run this
 		if(!SecurityEngineUtils.userCanEditEngine(this.insight.getUser(), sourceEngineId)) {
@@ -47,7 +43,7 @@ public class CopyEnginePermissionsReactor extends AbstractReactor {
 		
 		// now perform the operation
 		try {
-			SecurityEngineUtils.copyEnginePermissions(sourceEngineId, targetEngineId, maxTokens, maxResponseTime, usageRestriction, usageFrequency);
+			SecurityEngineUtils.copyEnginePermissions(sourceEngineId, targetEngineId);
 		} catch (Exception e) {
 			logger.error(Constants.STACKTRACE, e);
 			throw new IllegalArgumentException("An error occurred copying the engine permissions.  Detailed error: " + e.getMessage());
@@ -65,9 +61,9 @@ public class CopyEnginePermissionsReactor extends AbstractReactor {
 	@Override
 	protected String getDescriptionForKey(String key) {
 		if(key.equals(SOURCE_ENGINE)) {
-			return "The engine id that is used to provide information";
+			return "The engine id used to copy permissions from";
 		} else if(key.equals(TARGET_ENGINE)) {
-			return "The engine id that the operation is applied on";
+			return "The engine id to copy permissions to";
 		}
 		return ReactorKeysEnum.getDescriptionFromKey(key);
 	}


### PR DESCRIPTION
the restriction itself will still apply, but the user doesnt need to pass it here.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
CopyEnginePermissions(sourceEngine=["391defed-b8cf-4080-9c09-7e1f22beb80a"], targetEngine=["9e6a9d1f-f6e3-4711-9ff6-f63e11ae348a"])

## Notes
<!-- Any further notes regarding changes -->