### PR TITLE
466 - PYTHON BUG OPENAI USAGE FAILING FOR BEDROCK MODELS

### DIFF
--- a/py/genai_client/text_generation/bedrock_client.py
+++ b/py/genai_client/text_generation/bedrock_client.py
@@ -254,26 +254,20 @@ class BedrockClient(AbstractTextGenerationClient):
             should_stream = stream if stream is not None else self.response_stream
             should_stream = should_stream in (True, "true")
 
+            request_params = self._create_request_params(
+                messages, inference_config, guardrail_config, system_prompt
+            )
+
             if should_stream:
                 try:
-                    response = client.converse_stream(
-                        **self._create_request_params(
-                            messages, inference_config, guardrail_config, system_prompt
-                        )
-                    )
+                    response = client.converse_stream(**request_params)
                 except botocore.exceptions.ParamValidationError as e:
-                    import json
-
-                    logger.info(f"PARAM VALIDATION ERROR EXCEPION OCCURED: {e}")
-                    # converting list into string format
-                    messages[0]["content"][0]["text"] = json.dumps(
+                    logger.info(f"Param Validation Error Occurred: {e}")
+                    messages[0]["content"][0]["text"] = str(
                         messages[0]["content"][0]["text"]
-                    )
-                    response = client.converse_stream(
-                        **self._create_request_params(
-                            messages, inference_config, guardrail_config, system_prompt
-                        )
-                    )
+                    )  # convert to valid format
+                    response = client.converse_stream(**request_params)
+
                 final_response = self._handle_stream_response(
                     prefix, response.get("stream", [])
                 )

--- a/py/genai_client/text_generation/bedrock_client.py
+++ b/py/genai_client/text_generation/bedrock_client.py
@@ -1,4 +1,5 @@
 import boto3
+import botocore.exceptions
 import logging
 from .abstract_text_generation_client import AbstractTextGenerationClient
 from ..tokenizers.huggingface_tokenizer import HuggingfaceTokenizer
@@ -254,11 +255,25 @@ class BedrockClient(AbstractTextGenerationClient):
             should_stream = should_stream in (True, "true")
 
             if should_stream:
-                response = client.converse_stream(
-                    **self._create_request_params(
-                        messages, inference_config, guardrail_config, system_prompt
+                try:
+                    response = client.converse_stream(
+                        **self._create_request_params(
+                            messages, inference_config, guardrail_config, system_prompt
+                        )
                     )
-                )
+                except botocore.exceptions.ParamValidationError as e:
+                    import json
+
+                    logger.info(f"PARAM VALIDATION ERROR EXCEPION OCCURED: {e}")
+                    # converting list into string format
+                    messages[0]["content"][0]["text"] = json.dumps(
+                        messages[0]["content"][0]["text"]
+                    )
+                    response = client.converse_stream(
+                        **self._create_request_params(
+                            messages, inference_config, guardrail_config, system_prompt
+                        )
+                    )
                 final_response = self._handle_stream_response(
                     prefix, response.get("stream", [])
                 )


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Bug - OpenAI usage examples are getting failed for BedRock models. Due to some format mismatch issue. Fixed that issue and Tested using SEMOSS Terminal App with Pixels and Python.

## Changes Made
<!-- List the key changes made in this PR -->
`bedrock_client.py` - Made the code changes to convert and respond the openai usage code for bedrock model

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Open the SEMOSS UI and go to the model section.
2. Choose the bedrock model which is llamabedrock. Take the example codes from usage tab.
3. On the other side, open the Terminal App.
4. Paste the Pixels, Python and OpenAI API codes and test it separately in terminal app.

## Notes
<!-- Any further notes regarding changes -->