### PR TITLE
Add warning when approaching context window limit 

### DIFF
--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -250,6 +250,12 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
         safety_margin = int(context_window * SAFETY_PERCENTAGE)
         safe_prompt_tokens = num_tokens_in_prompt + safety_margin
 
+        # Check if we are close to the context window limit of 80%
+        if safe_prompt_tokens >= int(context_window * 0.8):
+            warnings.append(
+                "Prompt has already reached 80% of the model's context window."
+            )
+
         # 4. Check if we need to truncate
         if safe_prompt_tokens > (context_window * TRUNCATION_THRESHOLD):
             token_counter = 0


### PR DESCRIPTION
**Description**

- Added a check in check_token_limits() to show a warning when the prompt reaches 80% of the context window.

**Changes Made** openai_chat_completion_client.py
- Updated check_token_limits() to detect when the prompt exceeds 80% of the context window.
- Stored the warning message in model_engine_response.warning