### PR TITLE
Fix for empty Max Tokens being sent into init script for PGVectorEngine 

### DIFF
--- a/src/prerna/engine/impl/vector/PGVectorDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/PGVectorDatabaseEngine.java
@@ -265,7 +265,12 @@ public class PGVectorDatabaseEngine extends RDBMSNativeEngine implements IVector
 		if (!modelProperties.containsKey(Constants.MAX_TOKENS)) {
 			this.smssProp.put(Constants.MAX_TOKENS, "None");
 		} else {
-			this.smssProp.put(Constants.MAX_TOKENS, modelProperties.getProperty(Constants.MAX_TOKENS));
+			String modelMaxTokens = modelProperties.getProperty(Constants.MAX_TOKENS);
+			if(modelMaxTokens == null || (modelMaxTokens=modelMaxTokens.trim()).isEmpty()) {
+				this.smssProp.put(Constants.MAX_TOKENS, "None");
+			} else {
+				this.smssProp.put(Constants.MAX_TOKENS, modelMaxTokens);
+			}
 		}
 
 		// model engine responsible for creating keywords


### PR DESCRIPTION
## Description
If MAX_TOKENS is empty or the smss is not pulling its value properly, the init script will fail since it passes in an empty string. This fixes by sending in "None"

## Changes Made
Changes logic if the values for MAX_TOKENS is empty

## Notes
