### PR TITLE
Updating KServe Image Embedding class

### DIFF
--- a/src/prerna/engine/impl/model/KServeImageEmbedEngine.java
+++ b/src/prerna/engine/impl/model/KServeImageEmbedEngine.java
@@ -47,6 +47,36 @@ public class KServeImageEmbedEngine extends AbstractRemoteModelEngine {
 	}
 	
 	@Override
+	public EmbeddingsModelEngineResponse imageEmbeddingsCall(List<String> imagesToEmbed, Insight insight, Map<String, Object> parameters) {
+		classLogger.debug("Handling KServeImageEmbed Request..");
+		
+		JSONObject payload = new JSONObject();
+		
+		payload.put("image", imagesToEmbed);
+		
+	    if (parameters != null && parameters.containsKey("pooling_strategy")) {
+	        String poolingStrategy = (String) parameters.get("pooling_strategy");
+	        payload.put("pooling_strategy", poolingStrategy);
+	    }
+	    
+		classLogger.debug("KServeVision embeddingsCall payload: {}", payload.toString(2));
+
+		try {
+            JSONObject modelResponse = makeModelRequest(payload);
+            if (modelResponse != null) {
+                return EmbeddingsModelEngineResponse.fromJson(modelResponse);
+            } else {
+                classLogger.error("Received null response from model");
+                List<List<Double>> emptyEmbeddings = new ArrayList<>();
+                return new EmbeddingsModelEngineResponse(emptyEmbeddings, 0, 0);
+            }
+		} catch (Exception e) {
+            classLogger.error("Error making model request", e);
+            List<List<Double>> emptyEmbeddings = new ArrayList<>();
+            return new EmbeddingsModelEngineResponse(emptyEmbeddings, 0, 0);
+        }
+	}
+	@Override
 	public ModelTypeEnum getModelType() {
 		return ModelTypeEnum.KSERVE_IMAGE_EMBED;
 	}


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Updating the KServeImageEmbeddings class so that it is callable through the embeddings and image_embeddings methods. 

## Changes Made
<!-- List the key changes made in this PR -->

Adding an imageEmbeddingsCall method to the KServeImageEmbeddings class. 

## How to Test
<!-- Explain how reviewers can test your changes -->
```python
from gaas_gpt_model import ModelEngine
model = ModelEngine(engine_id = "a6203471-5118-4e76-986f-05d2c2c2568e", insight_id = '${i}')
images_to_embed= ['https://d2x51gyc4ptf2q.cloudfront.net/content/uploads/2023/04/10140915/Harry-Maguire-Victor-Lindelof-Man-Utd-F365.jpg']
model.image_embeddings(images_to_embed= images_to_embed)
```

## Notes
<!-- Any further notes regarding changes -->