### PR TITLE
move tomcat and java scripts to semoss-artifacts project

### DIFF
--- a/docker/Dockerfile.tomcat
+++ b/docker/Dockerfile.tomcat
@@ -44,14 +44,22 @@ ENV PATH=$PATH:$MAVEN_HOME/bin:$TOMCAT_HOME/bin:$JAVA_HOME/bin
 
 RUN printenv | grep -E '^(JAVA_HOME|TOMCAT_HOME|MAVEN_HOME|PATH)=' | awk '{print "export " $0}' >> /opt/set_env.env
 
-COPY . /root/
-RUN apt-get update \
-	&& apt-get -y install apt-transport-https ca-certificates git wget dirmngr gnupg software-properties-common \
-	&& apt-get update \
+#COPY . /root/
+# Pulling files from the SEMOSS/semoss-artifacts project
+RUN apt-get update -y \
+	&& apt-get install -y lsof git \
+	&& cd tmp/ && git clone --branch 26-cloud-Fix_docker_builds https://github.com/SEMOSS/semoss-artifacts \
+	&& cd semoss-artifacts \
+	&& pwd \
+	&& ls -als artifacts/ \
+	&& chmod 777 artifacts/dockerBuilder_scripts/*
+
+RUN apt-get -y install apt-transport-https ca-certificates git wget dirmngr gnupg software-properties-common \
 	&& cd ~/ \
 	&& apt-get -y install wget procps git \
 	&& echo "Creating directory for ${JAVA_HOME}.." \
 	&& mkdir -p $JAVA_HOME \
+	&& cd /tmp/semoss-artifacts/artifacts/dockerBuilder_scripts/ \
 	&& chmod +x install_java.sh \
 	&& /bin/bash install_java.sh \
 	&& java -version \
@@ -85,8 +93,7 @@ RUN apt-get update \
 	&& chmod 777 /opt/apache-maven-3.8.5/bin/*.cmd \
 	&& apt-get clean all
 
-# FROM scratch AS final
-
+FROM scratch AS final
 ARG JAVA_HOME
 ARG TOMCAT_HOME
 ARG MAVEN_HOME


### PR DESCRIPTION
## Description
Tomcat config and java install scripts need to be pulled from the semoss-artifacts project

## Changes Made
Docker tomcat pulls configs files from a different project

## How to Test
<!-- Explain how reviewers can test your changes -->
1. docker build --no-cache -t tomcat-builder:test-pull -f ./Dockerfile.tomcat .
2. Config files should be pulled a different project instead of copying from the local folder

## Notes
<!-- Any further notes regarding changes -->
N/A