### PR TITLE
Updates to Remote Model Startup

### DIFF
--- a/src/prerna/cluster/util/RemoteClientServerZK.java
+++ b/src/prerna/cluster/util/RemoteClientServerZK.java
@@ -64,7 +64,7 @@ public class RemoteClientServerZK implements IRemoteClientServer {
 
 	public String modelScalerIp;
 
-	private Boolean devPortFowarding = false;
+	private Boolean devPortForwarding = false;
 	
 	private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 
@@ -419,98 +419,23 @@ public class RemoteClientServerZK implements IRemoteClientServer {
 	    }
 	}
 
-	// I need this because there is a period of time between when the model is on the active path but the FastAPI service is not quite ready
-	private boolean checkModelHealth(String modelId) {
-	    String clusterIp = modelClusterIps.get(modelId);
-	    String modelName = modelNames.get(modelId);
-	    
-	    if (clusterIp == null || clusterIp.trim().isEmpty()) {
-	        classLogger.error("No valid cluster IP available for health check of model {} ({})", 
-	                modelId, modelName);
-	        return false;
-	    }
-	    
-	    String healthUrl = devPortFowarding ? 
-	        "http://localhost:8888/v2/health/ready" :
-	        String.format("http://%s/v2/health/ready", clusterIp);
-	        
-	    classLogger.info("Attempting health check at URL: {}", healthUrl);
-	    
-		RequestConfig requestConfig = RequestConfig.custom()
-				.setConnectTimeout(1000)
-				.setSocketTimeout(1000)
-				.build();
-
-		try (CloseableHttpClient httpClient = HttpClients.custom()
-				.setDefaultRequestConfig(requestConfig)
-				.build()) {
-
-			HttpGet httpGet = new HttpGet(healthUrl);
-
-			try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
-				int statusCode = response.getStatusLine().getStatusCode();
-				if (statusCode == 200) {
-					HttpEntity entity = response.getEntity();
-					if (entity != null) {
-						String responseString = EntityUtils.toString(entity);
-						JSONObject healthResponse = new JSONObject(responseString);
-						if ("ok".equals(healthResponse.optString("status"))) {
-							return true;
-						}
-					}
-				}
-			}
-		} catch (Exception e) {
-			classLogger.error("Health check failed for model {} ({}): {}", 
-					modelId, modelName, e.getMessage());
-		}
-		return false;
-	}
-
 	public boolean waitForModelActive(String modelId, long timeoutMs) {
 		try {
 			long startTime = System.currentTimeMillis();
-			boolean foundInActivePath = false;
-			boolean isHealthy = false;
 
 			// Waiting for model to appear in active path
 			while (System.currentTimeMillis() - startTime < timeoutMs) {
 				if (isModelActive(modelId)) {
 					classLogger.info("Model {} was found in the active path", modelId);
-					foundInActivePath = true;
-					break;
+					return true;
 				} else {
 					classLogger.info("Model {} in a warming wait loop..", modelId);
 				}
 				Thread.sleep(3000);
 			}
-
-			if (!foundInActivePath) {
-				classLogger.warn("Timeout waiting for model {} to appear in active path after {}ms", 
-						modelId, timeoutMs);
-				return false;
-			}
-
-			// Wait for container to be healthy
-			long healthCheckStart = System.currentTimeMillis();
-			long remainingTimeout = timeoutMs - (healthCheckStart - startTime);
-
-			while (System.currentTimeMillis() - healthCheckStart < remainingTimeout) {
-				if (checkModelHealth(modelId)) {
-					classLogger.info("Model {} health check passed", modelId);
-					isHealthy = true;
-					break;
-				}
-				Thread.sleep(1000);
-			}
-
-			if (!isHealthy) {
-				classLogger.warn("Timeout waiting for model {} to become healthy after appearing in active path", 
-						modelId);
-				return false;
-			}
-
-			return true;
+			
+			classLogger.warn("Timeout waiting for model {} to appear in active path after {}ms", modelId, timeoutMs);
+			return false;
 
 		} catch (Exception e) {
 			classLogger.error("Error waiting for model {} to become active", modelId, e);
@@ -633,7 +558,7 @@ public class RemoteClientServerZK implements IRemoteClientServer {
 	    }
 	    
 	    String canItRunUrl;
-	    if (devPortFowarding) {
+	    if (devPortForwarding) {
 	        canItRunUrl = "http://localhost:8000/api/can-it-run";
 	    } else {
 	        canItRunUrl = String.format("http://%s/api/can-it-run", modelScalerIp);

--- a/src/prerna/cluster/util/RemoteClientServerZKRESTProxy.java
+++ b/src/prerna/cluster/util/RemoteClientServerZKRESTProxy.java
@@ -490,47 +490,21 @@ public class RemoteClientServerZKRESTProxy implements IRemoteClientServer {
     public boolean waitForModelActive(String modelId, long timeoutMs) {
         try {
             long startTime = System.currentTimeMillis();
-            boolean foundInActivePath = false;
-            boolean isHealthy = false;
-            
+   
             while (System.currentTimeMillis() - startTime < timeoutMs) {
                 if (isModelActive(modelId)) {
                     classLogger.info("Model {} was found in the active path", modelId);
-                    foundInActivePath = true;
-                    break;
+                    modelStates.put(modelId, RemoteModelStateEnum.ACTIVE);
+                    return true;
                 } else {
                     classLogger.info("Model {} in a warming wait loop..", modelId);
                 }
                 Thread.sleep(3000);
             }
-            
-            if (!foundInActivePath) {
-                classLogger.warn("Timeout waiting for model {} to appear in active path after {}ms", 
-                        modelId, timeoutMs);
-                return false;
-            }
-            
-            long healthCheckStart = System.currentTimeMillis();
-            long remainingTimeout = timeoutMs - (healthCheckStart - startTime);
-            
-            String clusterIp = getModelClusterIp(modelId);
-            if (clusterIp == null) {
-                classLogger.error("No cluster IP available for model {}", modelId);
-                return false;
-            }
-            
-            try {
-                long waitTime = Math.min(remainingTimeout, 1000000);
-                Thread.sleep(waitTime);
-                isHealthy = true;
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                classLogger.warn("Interrupted while waiting for model to become healthy");
-            }
-            
-            modelStates.put(modelId, RemoteModelStateEnum.ACTIVE);
-            return isHealthy;
-            
+            classLogger.warn("Timeout waiting for model {} to appear in active path after {}ms", 
+                    modelId, timeoutMs);
+            return false;
+
         } catch (Exception e) {
             classLogger.error("Error waiting for model {} to become active", modelId, e);
             return false;

--- a/src/prerna/cluster/util/ZKClientFactory.java
+++ b/src/prerna/cluster/util/ZKClientFactory.java
@@ -16,10 +16,10 @@ public class ZKClientFactory {
      * 
      * @return An implementation of IRemoteClientServer
      */
-    public static IRemoteClientServer getZKClient() {
+    public static IRemoteClientServer getZKClient(Boolean devPortForwarding) {
         String zkIngress = System.getenv("ZK_INGRESS");
         
-        if (zkIngress != null && !zkIngress.isEmpty()) {
+        if (zkIngress != null && !zkIngress.isEmpty() && !devPortForwarding) {
             classLogger.info("ZK_INGRESS found, using REST proxy connection for ZooKeeper");
             
             // When using ZK REST proxy, KMS_INGRESS is required

--- a/src/prerna/engine/impl/model/AbstractRemoteModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractRemoteModelEngine.java
@@ -51,7 +51,7 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 	protected String modelType;
 	private IRemoteClientServer zkClient;
 	// Use this to simulate the cluster environment
-	private Boolean devPortFowarding = false;
+	private Boolean devPortForwarding = false;
 	// For normal development
 	private String kmsIngressUrl = null;
 	private String modelIngressUrl = null;
@@ -88,7 +88,7 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 		}
 
 		// Get the appropriate ZK client implementation based on environment
-		this.zkClient = ZKClientFactory.getZKClient();
+		this.zkClient = ZKClientFactory.getZKClient(this.devPortForwarding);
 		
 		// Check if we're using the REST proxy (for KMS_INGRESS validation)
 		boolean usingRestProxy = this.zkClient instanceof RemoteClientServerZKRESTProxy;
@@ -99,7 +99,7 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 			if (!this.kmsIngressUrl.endsWith("/")) {
 				this.kmsIngressUrl += "/";
 			}
-		} else if (this.devPortFowarding) {
+		} else if (this.devPortForwarding) {
 			classLogger.info("Using devPortforwarding for KMS URL with localhost:8000/");
 		} else {
 			classLogger.info("KMS_INGRESS environment variable not found and devPortforwarding not set, using ZooKeeper for KMS IP resolution. This is correct for production deployments.");
@@ -111,7 +111,7 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 			if (!this.modelIngressUrl.endsWith("/")) {
 				this.modelIngressUrl += "/";
 			}
-		} else if (this.devPortFowarding) {
+		} else if (this.devPortForwarding) {
 			classLogger.info("Using devPortForwarding for model URLs with localhost:8888/");
 		} else {
 			classLogger.info("MODEL_INGRESS environment variable not found and devPortforwarding not set, using ZooKeeper for Model IP resolution. This is correct for production deployments.");
@@ -145,7 +145,7 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 		
 		// KMS SHUTDOWN
 		if (service == Services.KMS_SHUTDOWN) {
-		    if (devPortFowarding) {
+		    if (devPortForwarding) {
 		    	serviceUrl = String.format("http://localhost:8000/api/v2/stop?model_id=%s&model=%s", 
 		            this.engineId, this.model);
 		    } else if (kmsIngressUrl != null) {
@@ -167,7 +167,7 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 		    }
 		// KMS START
 		} else if (service == Services.KMS_START) {
-		    if (devPortFowarding) {
+		    if (devPortForwarding) {
 		    	serviceUrl = "http://localhost:8000/api/v2/start";
 		    } else if (kmsIngressUrl != null) {
 		    	serviceUrl = kmsIngressUrl + "api/v2/start";
@@ -194,7 +194,7 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 				throw new IllegalStateException("Unable to get cluster ip for model.");
 			}
 			// LOCAL DEV W/ PF
-			if (devPortFowarding) {
+			if (devPortForwarding) {
 				if (isModelTypeOpenAI) {
 					serviceUrl = "http://localhost:8080/openai/v1";
 				} else {

--- a/src/prerna/reactor/model/MyRemoteModelsStatus.java
+++ b/src/prerna/reactor/model/MyRemoteModelsStatus.java
@@ -24,7 +24,7 @@ public class MyRemoteModelsStatus extends AbstractReactor {
 	
 	@Override
 	public NounMetadata execute() {
-		final IRemoteClientServer zkClient = ZKClientFactory.getZKClient();
+		final IRemoteClientServer zkClient = ZKClientFactory.getZKClient(false);
 		
 		List<RemoteModelInfo> activeModels = zkClient.getActiveModels();
 	    List<RemoteModelInfo> warmingModels = zkClient.getWarmingModels();


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Making updates to the remote model start up process. Leaving the handling of model health checking after deployment to the k8s side. SEMOSS can now trust that the model health is ready when the model has entered the active path. This improves model startup time. 

## Changes Made
<!-- List the key changes made in this PR -->

Removing the `checkModelHealth()` method from the ZK client and ZK REST proxy client.
