### PR TITLE
Updating Python OpenAI Chat Completions JSON Schema Call

### DIFF
--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -1,5 +1,5 @@
 import math
-from typing import List, Optional, Tuple, Any
+from typing import List, Tuple, Any
 import json
 from pydantic import BaseModel
 from .operations.instruct import Instruct
@@ -9,7 +9,6 @@ from ...constants import (
     AskModelEngineResponse,
     InstructModelEngineResponse,
 )
-from ...model_limits import ModelLimits
 
 
 class OpenAiChatCompletion(AbstractOpenAiClient):
@@ -76,7 +75,7 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
             # For vLLM it is the same for both dict and Pydantic model
             return ("extra_body", {"guided_json": schema})
 
-    def _get_structured_output_response(self, params):
+    def _get_structured_output_response(self, params) -> Tuple[str, int, str]:
         """
         Make the structured output call to the correct endpoint based on model type.
         vLLM requires a different endpoint...
@@ -87,11 +86,13 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
             else self.client.chat.completions.create(model=self.model_name, **params)
         )
         try:
-            return response.choices[0].message.content
+            content = response.choices[0].message.content
+            response_tokens = response.usage.completion_tokens
+            return content, response_tokens, "CHAT"
         except Exception as e:
             raise ValueError(f"Failed to extract structured output: {e}")
 
-    def _structured_output_call(self, **kwargs):
+    def _structured_output_call(self, **kwargs) -> Tuple[str, int, str]:
         """
         1. Validate the schema and identify the schema type
         2. Create the structured response format with the correct parameter name


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Updating the Python OpenAI Chat Completions class to properly return the response, token count and message type in the JSON schema call.

## Changes Made
<!-- List the key changes made in this PR -->

- `openai_chat_completion_client.py`
    - `_get_structured_output_response()`


## How to Test
<!-- Explain how reviewers can test your changes -->
```
from gaas_gpt_model import ModelEngine
question = 'Name a few Manchester United players you know with their positions, countries, and skill ratings.'
model = ModelEngine(engine_id = "4acbe913-df40-4ac0-b28a-daa5ad91b172", insight_id = '${i}')
json_schema = {
    "type": "object",
    "properties": {
        "players": {
            "type": "array",
            "items": {
                "type": "object",
                "properties": {
                    "name": {"type": "string"},
                    "position": {"type": "string"},
                    "country": {"type": "string"},
                    "skill": {"type": "integer"},
                },
                "required": ["name", "position", "country", "skill"],
            },
        }
    },
    "required": ["players"],
}
param_dict = {"schema": json_schema}
output = model.ask(question = question, param_dict=param_dict)
```
