### PR TITLE
Change to selfhosted runner for ubuntu, tomcat and python images

### DIFF
--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -42,7 +42,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     env:
       PYTHON_VERSION: "3.12"

--- a/.github/workflows/python-builder.yml
+++ b/.github/workflows/python-builder.yml
@@ -29,7 +29,7 @@ on:
         required: true
         default: '22.04'
   push:
-    branches: [ "dev", "main",  "26-cloud-Fix_docker_builds"]
+    branches: [ "dev", "main",  "26-dynamic-variables-semoss-builder"]
     paths:
       - 'docker/Dockerfile.python'
       - '.github/workflows/python-builder.yml'

--- a/.github/workflows/tomcat-builder.yml
+++ b/.github/workflows/tomcat-builder.yml
@@ -27,7 +27,7 @@ on:
 jobs:
   build:
     
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     env:
       TOMCAT_VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/ubuntu2204.yml
+++ b/.github/workflows/ubuntu2204.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     env:
       PYTHON_VERSION: "3.12"

--- a/.github/workflows/ubuntu2204_cuda.yml
+++ b/.github/workflows/ubuntu2204_cuda.yml
@@ -22,7 +22,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ubuntu2204_cuda.yml
+++ b/.github/workflows/ubuntu2204_cuda.yml
@@ -7,7 +7,7 @@ name: Semoss Ubuntu-CUDA Builder
 
 on:
   push:
-    branches: [ "26-cloud-Fix_docker_builds" ]      #TODO: When merging to dev, main replace branch names
+    branches: [ "26-cloud-Fix_docker_builds", "change-to-selfhosted-runner" ]      #TODO: When merging to dev, main replace branch names
     paths:
       - 'docker/Dockerfile.nvidia.cuda.12.5.1.ubuntu22.04'
       - '.github/workflows/ubuntu2204_cuda.yml'


### PR DESCRIPTION
## Description
Changed the agent from ubuntu-latest to self-hosted agent

## Changes Made
The "runs-on" value was changed from "ubuntu-latest" to "self-hosted" for the following workflows:
- python-builder.yml
- tomcat-builder.yml
- ubuntu2204.yml
- ubuntu2204_cuda.yml

## How to Test
1. Execute workflow
2. Set up stage should now show the agent as "Runner name: 'CICD-GitHubRunner-m6a.4xlarge-1' "

## Notes
N/A