### PR TITLE
Python Deterministic Token Trimming for Message Truncation

### DIFF
--- a/py/genai_client/model_limits.py
+++ b/py/genai_client/model_limits.py
@@ -20,6 +20,10 @@ MODEL_LIMITS_CONFIG = {
         "context_window": 128000,
         "max_completion_tokens": 4096,
     },
+    "meta-llama/Llama-3.1-8B-Instruct": {
+        "context_window": 128000,
+        "max_completion_tokens": 4096,
+    },
 }
 
 FALLBACK_CONFIG = {"context_window": 8192, "max_completion_tokens": 2048}

--- a/py/genai_client/text_generation/openai_clients/openai_api_inference_server.py
+++ b/py/genai_client/text_generation/openai_clients/openai_api_inference_server.py
@@ -17,6 +17,8 @@ class OpenAiChatCompletionServer(OpenAiChatCompletion):
             encoder_name=self.model_name,
             max_tokens=init_args.pop(MAX_TOKENS, None),
             max_input_tokens=init_args.pop(MAX_INPUT_TOKENS, None),
+            max_completion_tokens=init_args.pop("max_completion_tokens", None),
+            context_window=init_args.pop("context_window", None),
         )
 
 

--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -252,10 +252,16 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
         keep_flags = [True] * len(messages)
 
         # --- Build truncation order ---------------------------------
-        # oldest->newest, but leave system message till the end
+        # oldest->newest
+        # if keep_system, then we will maintain it up until the last message
         order = list(range(len(messages)))
         if keep_system and messages and messages[0]["role"] == "system":
-            order = order[1:] + [0]
+            # assuming we have [system_prompt, message2, message3, message4]
+            # Process order: message2, message3, system_prompt, message4
+            order = list(range(1, len(messages) - 1)) + [
+                0,
+                len(messages) - 1,
+            ]
 
         # --- Drop or trim -------------------------------------------
         for idx in order:

--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -217,91 +217,62 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
 
         return final_query, response_tokens, messageType
 
-    def _truncate_messages(
+    def _truncate_by_tokens(
         self,
         messages: List[dict],
-        tokens_over_limit: int,
-        char_multiplier: int,
-        truncation_strategy: str = "standard",
+        safe_window: int,
+        keep_system: bool = True,
     ) -> List[dict]:
         """
-        Truncate messages in the ChatML format based on the number of tokens exceeding the safe context window.
-        This accepts a character multiplier to determine how many characters to remove from the message content.
-        The multiplier is used to estimate the number of characters to remove based on the number of tokens over the limit.
-        The truncation strategy is set to "standard" by default, but can be changed to other strategies in the future.
-        - The standard strategy always attempts to truncate the oldest messages first. It will remove an entire message if it is oldest and truncation would not be enough to fit the context window.
-        - Otherwise it will truncate the message content from the end of the message until it is under the limit.
-
-        ChatML Example:
-        [{'role': 'system', 'content': 'You are a helpful assistant. '}, {'role': 'user', 'content': 'What weighs more, a pound of feathers or a pound of bricks?'}]
-
-        Args:
-            messages (List[dict]): ChatML history to be truncated
-            tokens_over_limit (int): The number of tokens exceeding the safe context window
-            char_multiplier (int): The multiplier for the number of characters to remove
-
-        Returns:
-            List[dict]: An updated list of ChatML messages with the truncated content
+        Returns a ChatML history whose **total** token count
+        is ≤ safe_window.
+        Oldest non-system messages are dropped first; when only
+        one message needs trimming we cut tokens from its *start*.
         """
-        chars_to_remove = char_multiplier * tokens_over_limit
-        updated_messages = []
-        if truncation_strategy.lower() == "standard":
-            # Determine if the first message is a system prompt
-            maintain_sys_prompt = messages and messages[0].get("role") == "system"
-            # assuming we have [message1, message2, message3, message4]
-            if maintain_sys_prompt:
-                # Process order: message2, message3, message1, message4
-                process_order = list(range(1, len(messages) - 1)) + [
-                    0,
-                    len(messages) - 1,
-                ]
+
+        # --- Tokenise *once* ----------------------------------------
+        toks_per_msg = []
+        total = 0
+        for m in messages:
+            toks = self.tokenizer._safe_encode(m["content"])
+            toks_per_msg.append(toks)
+            total += len(toks)
+
+        if total <= safe_window:
+            return messages  # nothing to do
+
+        to_cut = total - safe_window  # exact excess
+        keep_flags = [True] * len(messages)
+
+        # --- Build truncation order ---------------------------------
+        # oldest->newest, but leave system message till the end
+        order = list(range(len(messages)))
+        if keep_system and messages and messages[0]["role"] == "system":
+            order = order[1:] + [0]
+
+        # --- Drop or trim -------------------------------------------
+        for idx in order:
+            if to_cut == 0:
+                break
+            toks = toks_per_msg[idx]
+            if len(toks) <= to_cut:
+                # drop whole message
+                keep_flags[idx] = False
+                to_cut -= len(toks)
             else:
-                # Process order: message1, message2, message3, message4
-                process_order = list(range(len(messages)))
+                # keep tail part of this message
+                toks_per_msg[idx] = toks[-(len(toks) - to_cut) :]
+                to_cut = 0
 
-            for index, value in enumerate(process_order):
-                # note we use the value in this case
-                # since here we might have array [1,2,0,3]
-                # and we want to grab from the original message value
-                message = messages[value]
-                # Grabbing the content of the message
-                message_content = message.get("content", "")
-                # Measuring the length of the message content
-                message_length = len(message_content)
-
-                if message_length < chars_to_remove:
-                    # If the message length doesn't cover the character estimation, remove it
-                    # We remove the entire ChatML message by not adding it to the updated messages list
-                    chars_to_remove -= message_length
-                    continue
-                else:
-                    # If the message length is greater than the character estimation we truncate
-                    truncated_message = message_content[:-chars_to_remove]
-                    if message.get("role") == "system":
-                        updated_messages.insert(
-                            0, {"role": message["role"], "content": truncated_message}
-                        )
-                    else:
-                        updated_messages.append(
-                            {"role": message["role"], "content": truncated_message}
-                        )
-
-                    # Adding the remaining messages to the updated messages list
-                    # note here we only want to continue after this position
-                    # so via index, not value
-                    if index + 1 < len(messages):
-                        for j in range(index + 1, len(messages)):
-                            if messages[j].get("role") == "system":
-                                updated_messages.insert(0, messages[j])
-                            else:
-                                updated_messages.append(messages[j])
-
-                    return updated_messages
-        else:
-            # If the truncation strategy is not standard... we can implement other strategies here
-            # For now, we will just return the original messages
-            # FYI: We won't hit this block
-            return messages
+        # --- Re-build ChatML ----------------------------------------
+        new_messages = []
+        for keep, m, toks in zip(keep_flags, messages, toks_per_msg):
+            if not keep:
+                continue
+            m = m.copy()
+            m["content"] = self.tokenizer._safe_decode(toks)
+            new_messages.append(m)
+        return new_messages
 
     def check_token_limits(
         self,
@@ -334,34 +305,19 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
         tokens_over_limit = message_tokens - safe_window
 
         if tokens_over_limit > 0:
-            # This is a truncation strategy I am using to try to optimize the number of tokens we are removing
-            # We start with a conservative character multiplier of 3 and increase by 1 until we are under the limit
-            for i in range(3, 6, 1):
-                truncated_messages = self._truncate_messages(
-                    updated_messages, tokens_over_limit, i
-                )
-                updated_token_count = self.tokenizer.count_tokens(truncated_messages)
-                if updated_token_count <= safe_window:
-                    updated_messages = truncated_messages
-                    break
+            updated_messages = self._truncate_by_tokens(updated_messages, safe_window)
 
             updated_token_count = self.tokenizer.count_tokens(updated_messages)
 
-            # If we get here that means a 6 character multiplier was not enough to get under the limit
-            # There is likely some other problem with the messages
-            if updated_token_count > safe_window:
-                print(
-                    f"There is a problem. The updated token count is still over the limit after truncation."
-                )
-            else:
-                message_tokens = updated_token_count
+            message_tokens = updated_token_count
 
         # Calculating the max completion tokens we have available from the context window
         # I need a buffer of 5% to be safe due to discrepancies in the tokenization process
         final_max_tokens = math.floor(
             min(context_window - message_tokens, max_tokens) * 0.95
         )  # 5% buffer
-
+        # If the final max tokens is greater than the passed in max tokens, we set it to passed in max tokens
+        # This is to ensure we are not exceeding the max tokens set by the user or config
         if final_max_tokens > max_tokens:
             final_max_tokens = max_tokens
 

--- a/py/genai_client/tokenizers/huggingface_tokenizer.py
+++ b/py/genai_client/tokenizers/huggingface_tokenizer.py
@@ -167,3 +167,20 @@ class HuggingfaceTokenizer(AbstractTokenizer):
 
     def decode_token_ids(self, token_ids: List[int]) -> str:
         return self.tokenizer.decode(token_ids)
+
+    def _safe_encode(self, text: str) -> List:
+        """
+        Encode without special tokens; works for real HF tokenizers
+        and for the fallback WordCountTokenizer.
+        """
+        try:
+            return self.tokenizer.encode(text, add_special_tokens=False)
+        except TypeError:  # WordCountTokenizer accepts no kwarg
+            return self.tokenizer.encode(text)
+
+    def _safe_decode(self, tokens: List) -> str:
+        # WordCountTokenizer returns str tokens; join them
+        if tokens and isinstance(tokens[0], str):
+            return " ".join(tokens)
+        # HF tokenizer returns ints; use its native decode
+        return self.tokenizer.decode(tokens)

--- a/py/genai_client/tokenizers/openai_tokenizer.py
+++ b/py/genai_client/tokenizers/openai_tokenizer.py
@@ -127,3 +127,15 @@ class OpenAiTokenizer(AbstractTokenizer):
 
     def decode_token_ids(self, token_ids: List[int]) -> str:
         return self.tokenizer.decode(token_ids)
+
+    def _safe_encode(self, text: str) -> List[int]:
+        """
+        Convert text → list[int] without special tokens.
+        """
+        return self.tokenizer.encode(text)
+
+    def _safe_decode(self, tokens: List[int]) -> str:
+        """
+        Convert list[int] → text.  Just delegates to tiktoken.
+        """
+        return self.tokenizer.decode(tokens)

--- a/src/prerna/engine/impl/model/AbstractPythonModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractPythonModelEngine.java
@@ -31,7 +31,6 @@ import prerna.util.Constants;
 import prerna.util.Settings;
 import prerna.util.Utility;
 
-
 /**
  * This class is responsible for creating a {@code IModelEngine} class that is directly linked to 
  * a python process. The corresponding python class should handle all method implementations. This java class is 
@@ -40,7 +39,6 @@ import prerna.util.Utility;
 public abstract class AbstractPythonModelEngine extends AbstractModelEngine {
 	
 	private static final Logger classLogger = LogManager.getLogger(AbstractPythonModelEngine.class);
-
 	
 	// python server
 	protected String prefix = null;


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Updating the truncation strategy for messages exceeding the context window to use deterministic token trimming. 

## Changes Made
<!-- List the key changes made in this PR -->

Added the `_truncate_by_tokens()` method to the `OpenAIChatCompletionClient` class. 

The new truncation strategy works as follows:

1. Encode every message once
2. If over the safe window, drop oldest messages until only one needs trimming
3. Clip tokens from the front of that last message
4. Guaranteed ≤ safe window in a single pass



## How to Test
<!-- Explain how reviewers can test your changes -->

```
from ai_server import ModelEngine, ServerClient

server_connection = ServerClient(
    base="http://localhost:9090/Monolith/api",
    access_key="your_access_key",
    secret_key="your_secret_key",
)

is_connected = server_connection.connected
print(f"Am I connected to the server? {is_connected}")


model = ModelEngine(
    engine_id="4acbe913-df40-4ac0-b28a-daa5ad91b172",
    insight_id=server_connection.cur_insight,
)


def generate_large_token_string(target_tokens=130000):
    base_text = "This is a test sentence to generate many tokens. "

    large_string = base_text * (target_tokens // 6 + 100)

    print(f"Generated string length: {len(large_string)} characters")
    print(f"Estimated tokens: ~{len(large_string) // 4}")

    return large_string


question = "What weighs more, a pound of feathers or a pound of bricks?"
context = "You are a helpful assistant. " + generate_large_token_string(130000)

try:
    response = model.ask(
        question=question,
        context=context,
        param_dict={"stream": False},
    )
    print(response)
except Exception as e:
    print(f"Error: {e}")
```

## Notes
<!-- Any further notes regarding changes -->