### PR TITLE
fix: added date added column to enginepermission table

### DIFF
--- a/src/prerna/auth/utils/SecurityEngineUtils.java
+++ b/src/prerna/auth/utils/SecurityEngineUtils.java
@@ -246,7 +246,7 @@ public class SecurityEngineUtils extends AbstractSecurityUtils {
 	}
 	
 	public static void addEngineOwner(String engineId, String userId) {
-		String query = "INSERT INTO ENGINEPERMISSION (USERID, PERMISSION, ENGINEID, VISIBILITY) VALUES (?,?,?,?)";
+		String query = "INSERT INTO ENGINEPERMISSION (USERID, PERMISSION, ENGINEID, VISIBILITY, DATEADDED) VALUES (?,?,?,?,?)";
 
 		PreparedStatement ps = null;
 		try {
@@ -256,6 +256,7 @@ public class SecurityEngineUtils extends AbstractSecurityUtils {
 			ps.setInt(parameterIndex++, AccessPermissionEnum.OWNER.getId());
 			ps.setString(parameterIndex++, engineId);
 			ps.setBoolean(parameterIndex++, true);
+			ps.setTimestamp(parameterIndex++, Utility.getCurrentSqlTimestampUTC());
 			ps.execute();
 			if(!ps.getConnection().getAutoCommit()) {
 				ps.getConnection().commit();


### PR DESCRIPTION
## Description
Modified an update statement to include date added for when a engine is created

## Changes Made
added to the update statement and set the value

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Create an engine 
2. see if the date added column is populated

## Notes
<!-- Any further notes regarding changes -->