### PR TITLE
fix: Catch errors when calling pixels from Python

### DIFF
--- a/src/prerna/tcp/client/NativePySocketClient.java
+++ b/src/prerna/tcp/client/NativePySocketClient.java
@@ -21,12 +21,17 @@ import javax.ws.rs.core.StreamingOutput;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import com.google.gson.ToNumberPolicy;
 
+import io.burt.jmespath.Expression;
+import io.burt.jmespath.JmesPath;
+import io.burt.jmespath.jackson.JacksonRuntime;
 import prerna.auth.User;
 import prerna.om.Insight;
 import prerna.om.InsightStore;
@@ -343,7 +348,21 @@ public class NativePySocketClient extends SocketClient implements Runnable, Clos
 						            PixelRunner pixelRunner = insight.runPixel(pixelOp);
 						            StreamingOutput streamedOutput = PixelStreamUtility.collectPixelData(pixelRunner, null);
 						            streamedOutput.write(output);
-						            JsonElement json = JsonParser.parseString(new String(output.toByteArray(),"UTF-8"));
+						            //checks oprationType 
+						            String jsonOutputString = new String(output.toByteArray(),"UTF-8");
+						            ObjectMapper mapper = new ObjectMapper();
+						            JsonNode jsonNode = mapper.readTree(jsonOutputString);
+						            
+						            //JMESPath to check for any ERROR in operationType
+						            JmesPath<JsonNode> jmespath = new JacksonRuntime();
+						            Expression<JsonNode> expression = jmespath.compile("length(pixelReturn[?contains(operationType, 'ERROR')]) > `0`");
+						            JsonNode result = expression.search(jsonNode);
+
+						            if(result.asBoolean()) {
+						            	throw new IllegalArgumentException("Pixel execution returned ERROR operationType");
+						            }
+						            
+						            JsonElement json = JsonParser.parseString(jsonOutputString);
 						            finalPs.payload = new Object[] {json};
 						            finalPs.response = true;
 						            executeCommand(finalPs);


### PR DESCRIPTION
## Description
This PR fixes an issue of operationType, so now, when we run a reactor that does not exist, it returns operationType as "ERROR". not  "CODE_EXECUTION".

## Changes Made
-Made changes in Java class before sending the result.
-In `NativePySocketClient.Class` detected pixel operation as error in JSON, so evaluated "ERROR" presence via JMESPath expression and threw IllegalArgumentException on getting error.
-JMESPath library is used for JMESPath expression and Jackson is used to parse pixel output JSON. 

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Create a drag and drop app and run Python pixel calls in the notebook cells.
2. Mention reactor that does not exist and  press `Run All`.
Bad pixel call example to test-
```
from semoss import Insight
insight = Insight()
insight.run_pixel(pixel="vLLM ( engine = [ '4801422a-5c62-421e-a00c-05c6a9e15de8' ] , command = [ '<encode>What is the capital of Connecticut</encode>' ] )", insight_id = '${i}')
``` 
4. In `network` tab, the response is visible with the given operationType.

## Notes
<!-- Any further notes regarding changes -->
