### PR TITLE
Get Node Pool Information for Remote Models

### DIFF
--- a/src/prerna/engine/impl/model/KubernetesModelScaler.java
+++ b/src/prerna/engine/impl/model/KubernetesModelScaler.java
@@ -1,11 +1,14 @@
 package prerna.engine.impl.model;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -13,6 +16,7 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.util.EntityUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import prerna.cluster.util.IRemoteClientServer;
@@ -74,6 +78,92 @@ public class KubernetesModelScaler {
 			this.kmsUrl = zkClient.getModelScalerIp();
 		}
 		
+	}
+	
+	public Map<String, Object> getNodePoolsInfo() throws Exception {
+	    String serviceUrl = this.kmsUrl + "/api/resources/node-pools-info";
+	    
+	    RequestConfig requestConfig = RequestConfig.custom()
+	            .setConnectTimeout(5000)
+	            .setSocketTimeout(5000)
+	            .build();
+
+	    try (CloseableHttpClient httpClient = HttpClients.custom()
+	            .setDefaultRequestConfig(requestConfig)
+	            .build()) {
+
+	        HttpGet httpGet = new HttpGet(serviceUrl);
+	        httpGet.setHeader("Accept", "application/json");
+
+	        try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
+	            int statusCode = response.getStatusLine().getStatusCode();
+	            HttpEntity responseEntity = response.getEntity();
+	            String responseString = EntityUtils.toString(responseEntity);
+
+	            if (statusCode == 200) {
+	                JSONObject jsonResponse = new JSONObject(responseString);
+	                
+	                Map<String, Object> result = new HashMap<>();
+	                
+	                if (jsonResponse.has("message")) {
+	                    result.put("message", jsonResponse.getString("message"));
+	                }
+	                
+	                if (jsonResponse.has("pools")) {
+	                    JSONArray poolsArray = jsonResponse.getJSONArray("pools");
+	                    List<Map<String, Object>> poolsList = new ArrayList<>();
+	                    
+	                    for (int i = 0; i < poolsArray.length(); i++) {
+	                        JSONObject poolObject = poolsArray.getJSONObject(i);
+	                        Map<String, Object> poolMap = jsonToMap(poolObject);
+	                        poolsList.add(poolMap);
+	                    }
+	                    
+	                    result.put("pools", poolsList);
+	                }
+	                
+	                classLogger.info("Successfully retrieved node pool information");
+	                return result;
+	            } else {
+	                classLogger.error("Error retrieving node pool information: {} (Status: {})", 
+	                    responseString, statusCode);
+	                throw new RuntimeException("Failed to retrieve node pool information: " + responseString);
+	            }
+	        }
+	    } catch (Exception e) {
+	        classLogger.error("Error making request to model scaler for node pool info: {}", e.getMessage(), e);
+	        throw new RuntimeException("Failed to retrieve node pool information", e);
+	    }
+	}
+
+	private Map<String, Object> jsonToMap(JSONObject json) {
+	    Map<String, Object> map = new HashMap<>();
+	    
+	    for (String key : json.keySet()) {
+	        Object value = json.get(key);
+	        
+	        if (value instanceof JSONObject) {
+	            map.put(key, jsonToMap((JSONObject) value));
+	        } else if (value instanceof JSONArray) {
+	            JSONArray array = (JSONArray) value;
+	            List<Object> list = new ArrayList<>();
+	            
+	            for (int i = 0; i < array.length(); i++) {
+	                Object item = array.get(i);
+	                if (item instanceof JSONObject) {
+	                    list.add(jsonToMap((JSONObject) item));
+	                } else {
+	                    list.add(item);
+	                }
+	            }
+	            
+	            map.put(key, list);
+	        } else {
+	            map.put(key, value);
+	        }
+	    }
+	    
+	    return map;
 	}
 	
 	public Map<String, Object> canItRun(String hfModelId) throws Exception {

--- a/src/prerna/reactor/model/CanItRunReactor.java
+++ b/src/prerna/reactor/model/CanItRunReactor.java
@@ -14,7 +14,7 @@ import prerna.engine.impl.model.KubernetesModelScaler;
 
 public class CanItRunReactor extends AbstractReactor {
 	
-	private static final Logger classLogger = LogManager.getLogger(MyRemoteModelsStatus.class);
+	private static final Logger classLogger = LogManager.getLogger(CanItRunReactor.class);
 	
 	public CanItRunReactor() {
 		this.keysToGet = new String[] { ReactorKeysEnum.HF_MODEL_ID.getKey()};

--- a/src/prerna/reactor/model/GetNodePoolsInfoReactor.java
+++ b/src/prerna/reactor/model/GetNodePoolsInfoReactor.java
@@ -1,0 +1,36 @@
+package prerna.reactor.model;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.engine.impl.model.KubernetesModelScaler;
+import prerna.auth.utils.SecurityAdminUtils;
+
+public class GetNodePoolsInfoReactor extends AbstractReactor {
+	
+	private static final Logger classLogger = LogManager.getLogger(GetNodePoolsInfoReactor.class);
+
+	@Override
+	public NounMetadata execute() {
+		if (!SecurityAdminUtils.userIsAdmin(this.insight.getUser())) {
+			throw new IllegalArgumentException("User does not have permission to query this endpoint.");
+		}
+		
+		final KubernetesModelScaler kmsServer;
+		kmsServer = KubernetesModelScaler.getInstance();
+		
+		try {
+			Map<String, Object> nodePoolsInfo = kmsServer.getNodePoolsInfo();
+			return new NounMetadata(nodePoolsInfo, PixelDataType.MAP, PixelOperationType.OPERATION);
+		} catch (Exception e) {
+			classLogger.error("Error connecting to the Kubernetes Model Scaler endpoint for Nodepool information..");
+			throw new RuntimeException("Failed to connect to Kubernetes Model Scaler endpoint: " + e.getMessage());
+		}
+	}
+}


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Adds a reactor that fetches data about the deployed models in the node pools from the Kubernetes model scaler. 

## Changes Made
<!-- List the key changes made in this PR -->

- Adding `GetNodePoolsInfoReactor`
- Adding a method to the `KubernetesModelScaler` class to fetch the data

## How to Test
<!-- Explain how reviewers can test your changes -->

`GetNodePoolsInfo()`

Note: Requires KMS ingress env variable and admin mode. 

## Notes
<!-- Any further notes regarding changes -->

Example return:

```json
{"pools": [{"machine_type": "c3-standard-8", "models": [{"node": "gke-cfgai-standard-n-cpu-sapphire-poo-cb209854-33pn", "name": "dinov2-large", "namespace": "huggingface-models", "resources": {"memory_requests_gi": 8.01, "gpu_requests": 0, "cpu_requests": 2.01}, "url": "http://dinov2-large-predictor.huggingface-models.svc.cluster.local", "status": "True"}], "memory_total_gi": 32, "gpu_count": 0, "gpu_type": {}, "name": "cpu-sapphire-pool", "memory_available_gi": 18.84, "cpu_total": 8, "cpu_available": 5.47, "gpu_available": 0}, {"machine_type": "n1-standard-16", "models": [{"node": "gke-cfgai-standard-new-t4-gpu-pool-c1b8a6fd-03n2", "name": "florence-2-large", "namespace": "huggingface-models", "resources": {"memory_requests_gi": 10.01, "gpu_requests": 1, "cpu_requests": 1.01}, "url": "http://florence-2-large-predictor.huggingface-models.svc.cluster.local", "status": "True"}, {"node": "gke-cfgai-standard-new-t4-gpu-pool-c1b8a6fd-kkz6", "name": "stable-diffusion-v1-5", "namespace": "huggingface-models", "resources": {"memory_requests_gi": 10, "gpu_requests": 1, "cpu_requests": 1}, "url": "http://stable-diffusion-v1-5-predictor.huggingface-models.svc.cluster.local", "status": "True"}], "memory_total_gi": 240, "gpu_count": 1, "gpu_type": "nvidia.com/gpu", "name": "t4-gpu-pool", "memory_available_gi": 190.52, "cpu_total": 64, "cpu_available": 59.72, "gpu_available": 2}, {"machine_type": "g2-standard-12", "models": [], "memory_total_gi": 48, "gpu_count": 1, "gpu_type": "nvidia.com/gpu", "name": "l4-gpu-pool", "memory_available_gi": 41.58, "cpu_total": 12, "cpu_available": 11.46, "gpu_available": 1}], "message": "Successfully retrieved node pool information"}
```