### PR TITLE
feat: adding to the return of GetEngineMetadata to include the latest…

### DIFF
--- a/src/prerna/auth/utils/SecurityEngineUtils.java
+++ b/src/prerna/auth/utils/SecurityEngineUtils.java
@@ -2504,6 +2504,11 @@ public class SecurityEngineUtils extends AbstractSecurityUtils {
 		return QueryExecutionUtility.flushToListString(securityDb, qs1);
 	}
 	
+	/**
+	 * Get the latest updated author for the engine
+	 * @param engineId
+	 * @return a map with the author and date added
+	 */
 	public static Map<String, Object> getLatestUpdatedAuthor(String engineId) {
 		SelectQueryStruct qs = new SelectQueryStruct();
         qs.addSelector(new QueryColumnSelector("ENGINEPERMISSION__PERMISSIONGRANTEDBY"));
@@ -2512,17 +2517,14 @@ public class SecurityEngineUtils extends AbstractSecurityUtils {
         qs.addOrderBy(new QueryColumnOrderBySelector("ENGINEPERMISSION__DATEADDED","DESC"));
         qs.setLimit(1);
 
-        //RDBMSNativeEngine securityDb = (RDBMSNativeEngine) Utility.getDatabase(Constants.SECURITY_DB);
-
         List<Map<String, Object>> list = (List<Map<String, Object>>) QueryExecutionUtility.flushRsToMap(securityDb, qs);
-		Map<String, Object> map = list.get(0);
-        
-		if(list.size() > 0){
-            return map;
-        } else {
-            throw new IllegalArgumentException("No author found for the engine id: " + engineId); 
-        }
+		if (list.isEmpty()) {
+    		throw new IllegalArgumentException("No author found for the engine id: " + engineId);
+		}
+
+        return list.get(0);
 	}
+
     /**
      * Get all the available engine metadata and their counts for given keys
      * @param engineFilters

--- a/src/prerna/auth/utils/SecurityEngineUtils.java
+++ b/src/prerna/auth/utils/SecurityEngineUtils.java
@@ -29,7 +29,6 @@ import prerna.auth.User;
 import prerna.engine.api.IEngine;
 import prerna.engine.api.IRawSelectWrapper;
 import prerna.engine.impl.SmssUtilities;
-import prerna.engine.impl.rdbms.RDBMSNativeEngine;
 import prerna.query.querystruct.SelectQueryStruct;
 import prerna.query.querystruct.filters.AndQueryFilter;
 import prerna.query.querystruct.filters.OrQueryFilter;
@@ -44,7 +43,6 @@ import prerna.query.querystruct.selectors.QueryIfSelector;
 import prerna.rdf.engine.wrappers.WrapperManager;
 import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.execptions.SemossPixelException;
-import prerna.sablecc2.om.nounmeta.NounMetadata;
 import prerna.util.ConnectionUtils;
 import prerna.util.Constants;
 import prerna.util.DIHelper;
@@ -2514,7 +2512,7 @@ public class SecurityEngineUtils extends AbstractSecurityUtils {
         qs.addOrderBy(new QueryColumnOrderBySelector("ENGINEPERMISSION__DATEADDED","DESC"));
         qs.setLimit(1);
 
-        RDBMSNativeEngine securityDb = (RDBMSNativeEngine) Utility.getDatabase(Constants.SECURITY_DB);
+        //RDBMSNativeEngine securityDb = (RDBMSNativeEngine) Utility.getDatabase(Constants.SECURITY_DB);
 
         List<Map<String, Object>> list = (List<Map<String, Object>>) QueryExecutionUtility.flushRsToMap(securityDb, qs);
 		Map<String, Object> map = list.get(0);

--- a/src/prerna/auth/utils/SecurityEngineUtils.java
+++ b/src/prerna/auth/utils/SecurityEngineUtils.java
@@ -29,6 +29,7 @@ import prerna.auth.User;
 import prerna.engine.api.IEngine;
 import prerna.engine.api.IRawSelectWrapper;
 import prerna.engine.impl.SmssUtilities;
+import prerna.engine.impl.rdbms.RDBMSNativeEngine;
 import prerna.query.querystruct.SelectQueryStruct;
 import prerna.query.querystruct.filters.AndQueryFilter;
 import prerna.query.querystruct.filters.OrQueryFilter;
@@ -43,6 +44,7 @@ import prerna.query.querystruct.selectors.QueryIfSelector;
 import prerna.rdf.engine.wrappers.WrapperManager;
 import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.execptions.SemossPixelException;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
 import prerna.util.ConnectionUtils;
 import prerna.util.Constants;
 import prerna.util.DIHelper;
@@ -2504,6 +2506,25 @@ public class SecurityEngineUtils extends AbstractSecurityUtils {
 		return QueryExecutionUtility.flushToListString(securityDb, qs1);
 	}
 	
+	public static Map<String, Object> getLatestUpdatedAuthor(String engineId) {
+		SelectQueryStruct qs = new SelectQueryStruct();
+        qs.addSelector(new QueryColumnSelector("ENGINEPERMISSION__PERMISSIONGRANTEDBY"));
+        qs.addSelector(new QueryColumnSelector("ENGINEPERMISSION__DATEADDED"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("ENGINEPERMISSION__ENGINEID", "==", engineId));
+        qs.addOrderBy(new QueryColumnOrderBySelector("ENGINEPERMISSION__DATEADDED","DESC"));
+        qs.setLimit(1);
+
+        RDBMSNativeEngine securityDb = (RDBMSNativeEngine) Utility.getDatabase(Constants.SECURITY_DB);
+
+        List<Map<String, Object>> list = (List<Map<String, Object>>) QueryExecutionUtility.flushRsToMap(securityDb, qs);
+		Map<String, Object> map = list.get(0);
+        
+		if(list.size() > 0){
+            return map;
+        } else {
+            throw new IllegalArgumentException("No author found for the engine id: " + engineId); 
+        }
+	}
     /**
      * Get all the available engine metadata and their counts for given keys
      * @param engineFilters

--- a/src/prerna/reactor/security/GetEngineMetadataReactor.java
+++ b/src/prerna/reactor/security/GetEngineMetadataReactor.java
@@ -65,6 +65,8 @@ public class GetEngineMetadataReactor extends AbstractReactor {
 		if(pendingRequest > 0) {
 			databaseInfo.put("pending_access_request", pendingRequest);
 		}
+
+		databaseInfo.putAll(SecurityEngineUtils.getLatestUpdatedAuthor(engineId));
 		return new NounMetadata(databaseInfo, PixelDataType.CUSTOM_DATA_STRUCTURE, PixelOperationType.ENGINE_INFO);
 	}
 	


### PR DESCRIPTION

## Description
Adding 2 fields from ENGINEPERMISSIONS Table that give the time and the person who last updated user roles given an engine id

## Changes Made
a function in  SecurityEngineUtils and a modification in GetEngineMetadata

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Call GetEngineMetadata() with an engineID that has at least 2 users 
2. see that DATEADDED and PERMISSIONGRANTEDBY are now in the return map

## Notes
<!-- Any further notes regarding changes -->