### PR TITLE
Updating getNodePoolsInfo() to parse and return zk info and models active actual

### DIFF
--- a/src/prerna/engine/impl/model/KubernetesModelScaler.java
+++ b/src/prerna/engine/impl/model/KubernetesModelScaler.java
@@ -109,6 +109,12 @@ public class KubernetesModelScaler {
 	                    result.put("message", jsonResponse.getString("message"));
 	                }
 	                
+	                if (jsonResponse.has("zk_info")) {
+	                    JSONObject zkInfoObj = jsonResponse.getJSONObject("zk_info");
+	                    Map<String, Object> zkInfoMap = jsonToMap(zkInfoObj);
+	                    result.put("zk_info", zkInfoMap);
+	                }
+	                
 	                if (jsonResponse.has("pools")) {
 	                    JSONArray poolsArray = jsonResponse.getJSONArray("pools");
 	                    List<Map<String, Object>> poolsList = new ArrayList<>();
@@ -120,6 +126,12 @@ public class KubernetesModelScaler {
 	                    }
 	                    
 	                    result.put("pools", poolsList);
+	                }
+	                
+	                if (jsonResponse.has("active_models_actual")) {
+	                    JSONObject activeModelsObj = jsonResponse.getJSONObject("active_models_actual");
+	                    Map<String, Object> activeModelsMap = jsonToMap(activeModelsObj);
+	                    result.put("active_models_actual", activeModelsMap);
 	                }
 	                
 	                classLogger.info("Successfully retrieved node pool information");

--- a/src/prerna/engine/impl/model/KubernetesModelScaler.java
+++ b/src/prerna/engine/impl/model/KubernetesModelScaler.java
@@ -178,6 +178,61 @@ public class KubernetesModelScaler {
 	    return map;
 	}
 	
+	/**
+	 * Retrieve the cached (or freshly re-loaded) KServe deployment configs
+	 * from the model-scaler service.
+	 *
+	 * @param refresh if {@code true}, tells the micro-service to reload the
+	 *                configs from GCS before returning the response.
+	 * @return a Map keyed by model-name, where each value is a nested Map
+	 *         representing the InferenceService spec for that model.
+	 * @throws Exception on any HTTP or parse failure.
+	 */
+	public Map<String, Object> getModelDeploymentConfigs(boolean refresh) throws Exception {
+	    // Build the URL – keep the same /api/resources prefix you use elsewhere
+	    String endpoint = "/api/resources/model-deploy-configs";
+	    String serviceUrl = this.kmsUrl + endpoint + (refresh ? "?refresh=true" : "");
+
+	    RequestConfig requestConfig = RequestConfig.custom()
+	            .setConnectTimeout(5000)
+	            .setSocketTimeout(5000)
+	            .build();
+
+	    try (CloseableHttpClient httpClient = HttpClients.custom()
+	            .setDefaultRequestConfig(requestConfig)
+	            .build()) {
+
+	        HttpGet httpGet = new HttpGet(serviceUrl);
+	        httpGet.setHeader("Accept", "application/json");
+
+	        try (CloseableHttpResponse response = httpClient.execute(httpGet)) {
+	            int statusCode = response.getStatusLine().getStatusCode();
+	            String responseBody = EntityUtils.toString(response.getEntity());
+
+	            if (statusCode == 200) {
+	                JSONObject jsonResponse = new JSONObject(responseBody);
+	                Map<String, Object> configs = jsonToMap(jsonResponse);
+
+	                classLogger.info(
+	                        "Retrieved {} model deployment configs (refresh={})",
+	                        configs.size(), refresh);
+	                return configs;
+	            } else {
+	                classLogger.error(
+	                        "Failed to fetch model deployment configs: {} (status {})",
+	                        responseBody, statusCode);
+	                throw new RuntimeException(
+	                        "Failed to retrieve model deployment configs: " + responseBody);
+	            }
+	        }
+	    } catch (Exception e) {
+	        classLogger.error(
+	                "Error contacting model-scaler for deployment configs: {}", e.getMessage(), e);
+	        throw new RuntimeException("Failed to retrieve model deployment configs", e);
+	    }
+	}
+
+	
 	public Map<String, Object> canItRun(String hfModelId) throws Exception {
 	
 		String serviceUrl = this.kmsUrl + "/api/can-it-run";

--- a/src/prerna/reactor/model/GetRemoteModelDeployConfigsReactor.java
+++ b/src/prerna/reactor/model/GetRemoteModelDeployConfigsReactor.java
@@ -1,0 +1,61 @@
+package prerna.reactor.model;
+
+import java.util.Map;
+import java.util.List;
+
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.GenRowStruct;
+import prerna.engine.impl.model.KubernetesModelScaler;
+import prerna.auth.utils.SecurityAdminUtils;
+
+
+
+public class GetRemoteModelDeployConfigsReactor extends AbstractReactor {
+	
+	private static final Logger classLogger = LogManager.getLogger(GetRemoteModelDeployConfigsReactor.class);
+
+	public GetRemoteModelDeployConfigsReactor() {
+		this.keysToGet = new String[] {"refresh"};
+		this.keyRequired = new int [] { 0 };
+	}
+	
+	@Override
+	public NounMetadata execute() {
+		if (!SecurityAdminUtils.userIsAdmin(this.insight.getUser())) {
+			throw new IllegalArgumentException("User does not have permission to query this endpoint.");
+		}
+		
+		this.organizeKeys();
+		Boolean refresh = this.getRefreshBool();
+		
+		final KubernetesModelScaler kmsServer;
+		kmsServer = KubernetesModelScaler.getInstance();
+		
+		try {
+			Map<String, Object> nodePoolsInfo = kmsServer.getModelDeploymentConfigs(refresh);
+			return new NounMetadata(nodePoolsInfo, PixelDataType.MAP, PixelOperationType.OPERATION);
+		} catch (Exception e) {
+			classLogger.error("Error connecting to the Kubernetes Model Scaler endpoint for model deployment configurations..");
+			throw new RuntimeException("Failed to connect to Kubernetes Model Scaler endpoint: " + e.getMessage());
+		}
+	}
+	
+	private boolean getRefreshBool() {
+		GenRowStruct boolGrs = this.store.getNoun("refresh");
+		if (boolGrs != null) {
+			if (boolGrs.size() > 0) {
+				List<Object> val = boolGrs.getValuesOfType(PixelDataType.BOOLEAN);
+				return (boolean) val.get(0);
+			}
+		}
+		return false;
+	}
+
+}


### PR DESCRIPTION
…actual

## Description
<!-- Provide a brief description of the changes in this PR -->
Updating `getNodePoolsInfo()` to parse and return zk_info and models_active_actual from the KMS microservice.

## Changes Made
<!-- List the key changes made in this PR -->

The KMS microservice now returns information on the ZK deployment statuses and lists of models running in the node pool compared against models listed in ZK. 

## How to Test
<!-- Explain how reviewers can test your changes -->
```
GetNodePoolsInfo()
```

## Notes
<!-- Any further notes regarding changes -->