### PR TITLE
Handle use_max_tokens smss setting to be compatible with max_tokens settings in APIs

### DIFF
--- a/py/genai_client/text_generation/openai_clients/abstract_openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/abstract_openai_client.py
@@ -23,6 +23,8 @@ class AbstractOpenAiClient(AbstractTextGenerationClient, ABC):
 
         self.model_name = model_name
         self.model_type = model_type
+        self.use_max_tokens_param = kwargs.pop("use_max_tokens", False)
+
         self.tokenizer = self._get_tokenizer(kwargs)
         self.client = self._get_client(api_key=api_key, **kwargs)
         if self.model_type == None:

--- a/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_chat_completion_client.py
@@ -9,6 +9,7 @@ from ...constants import (
     AskModelEngineResponse,
     InstructModelEngineResponse,
 )
+from utils.util import string_to_bool
 
 
 class OpenAiChatCompletion(AbstractOpenAiClient):
@@ -156,6 +157,33 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
 
         return updated_kwargs
 
+    def resolve_token_param_naming(self, **kwargs) -> dict:
+        """
+        Resolves the token parameter naming for different OpenAI-compatible APIs.
+        Some APIs use max_tokens while others use max_completion_tokens.
+        Set use_max_tokens=True in config to use max_tokens parameter.
+        """
+        use_max_tokens_param = self.use_max_tokens_param
+        if isinstance(use_max_tokens_param, str):
+            use_max_tokens_param = string_to_bool(use_max_tokens_param)
+
+        max_completion_tokens = kwargs.pop("max_completion_tokens", None)
+        max_tokens = kwargs.pop("max_tokens", None)
+
+        # Determine which value to use (prefer the one that was actually set)
+        token_limit = max_completion_tokens or max_tokens
+
+        if not token_limit:
+            return kwargs
+
+        # Set the appropriate parameter based on API preference
+        if use_max_tokens_param:
+            kwargs["max_tokens"] = token_limit
+        else:
+            kwargs["max_completion_tokens"] = token_limit
+
+        return kwargs
+
     def inference_call(self, prefix: str, **kwargs) -> Tuple[str, int, str]:
         final_query = ""
         response_tokens = None
@@ -182,11 +210,8 @@ class OpenAiChatCompletion(AbstractOpenAiClient):
         if "tool_choice" in kwargs:
             kwargs["stream"] = False
 
-        # Check if 'max_tokens' exists in kwargs and remove it, saving its value
-        max_tokens = kwargs.pop("max_tokens", None)
-        # If 'max_tokens' was found and 'max_completion_tokens' is not already in kwargs, set it
-        if max_tokens is not None and "max_completion_tokens" not in kwargs:
-            kwargs["max_completion_tokens"] = max_tokens
+        # Checking if use_max_tokens was set in SMSS to support non-updated API's (e.g. nvidia nims)
+        kwargs = self.resolve_token_param_naming(**kwargs)
 
         # Update model specific kwargs
         kwargs = self._update_model_specific_kwargs(**kwargs)

--- a/py/utils/util.py
+++ b/py/utils/util.py
@@ -1,0 +1,25 @@
+def string_to_bool(value: str) -> bool:
+    """
+    Convert a string representation of a boolean to a boolean value.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return bool(value)
+    if isinstance(value, str):
+        value = value.lower()
+        if value in [
+            "true",
+            "t",
+            "yes",
+            "y",
+            "1",
+        ]:
+            return True
+        else:
+            return False
+    else:
+        instance_type = type(value)
+        raise ValueError(
+            f"Invalid value type: {instance_type}. Expected str, int, or bool."
+        )


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Updating the OpenAI wrapper to handle a setting in the SMSS called `USE_MAX_TOKENS` which determines whether to name the token limitting parameter as `max_tokens` or `max_completion_tokens`. Most APIs accept and prefer `max_completion_tokens` now but we still need to support some that use `max_tokens`. 

## Changes Made
<!-- List the key changes made in this PR -->
Added `resolve_token_param_naming()` method to handle logic related to selecting the correct param name. 

## How to Test
<!-- Explain how reviewers can test your changes -->
Add this setting to your SMSS and add to the init script
`USE_MAX_TOKENS true`

Run an ask call with the model (assuming it uses the OpenAiClient class. 
