### PR TITLE
Setting default Python chunking method as recursive

### DIFF
--- a/py/vector_database/utils/text_splitting.py
+++ b/py/vector_database/utils/text_splitting.py
@@ -85,7 +85,7 @@ def split_text(
     chunk_size: int,
     chunk_overlap: int,
     chunking_strategy: Optional[Union[str, List[int]]] = [],
-    chunking_method: Optional[str] = "tokens",
+    chunking_method: Optional[str] = "recursive",
 ) -> None:
     """
     Splits text content in a CSV file into chunks based on specified parameters.


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Setting the default Python chunking method as recursive to match the default on the Java side. 

## Changes Made
<!-- List the key changes made in this PR -->

Updating the default param in `split_text()` of `text_splitting.py` for the param `chunking_method` to use `recursive` as default. 
