### PR TITLE
EnginePy reactor to write directly python engine shell

### DIFF
--- a/src/prerna/engine/impl/model/AbstractPythonModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractPythonModelEngine.java
@@ -80,6 +80,61 @@ public abstract class AbstractPythonModelEngine extends AbstractModelEngine {
 			this.vars.put(key, this.smssProp.getProperty(key));
 		}
 	}
+	
+	/**
+	 * Gets a PyTranslator instance
+	 * 
+	 * @param insight The insight id
+	 * @return A configured PyTranslator instance
+	 * @throws IllegalArgumentException if insight is null
+	 * @throws IllegalStateException if the engine is not properly initialized or connection fails
+	 */
+	public PyTranslator getEnginePyTranslator(Insight insight) {
+	    if (insight == null) {
+	        throw new IllegalArgumentException("Insight parameter cannot be null");
+	    }
+	    
+	    try {
+	        this.checkSocketStatus();
+	        
+	        if (this.pyt == null) {
+	            classLogger.error("PyTranslator is null after socket status check for engine: " + this.getEngineName());
+	            throw new IllegalStateException("PyTranslator is not properly initialized");
+	        }
+	        
+	        if (this.cpw == null || this.cpw.getSocketClient() == null) {
+	            classLogger.error("ClientProcessWrapper or SocketClient is null for engine: " + this.getEngineName());
+	            throw new IllegalStateException("Socket connection is not available");
+	        }
+	        
+	        if (!this.cpw.getSocketClient().isConnected()) {
+	            classLogger.warn("Socket client reports as disconnected, attempting reconnection for engine: " + this.getEngineName());
+	            this.checkSocketStatus();
+	            if (!this.cpw.getSocketClient().isConnected()) {
+	                throw new IllegalStateException("Unable to establish socket connection");
+	            }
+	        }
+	        
+	        PyTranslator engineTranslator = this.pyt;
+	        engineTranslator.setSocketClient(this.cpw.getSocketClient());
+	        engineTranslator.setInsight(insight);
+	        
+	        classLogger.debug("Successfully created PyTranslator for engine: " + this.getEngineName() + 
+	                         ", insight ID: " + insight.getInsightId());
+	        
+	        return engineTranslator;
+	        
+	    } catch (Exception e) {
+	        classLogger.error("Failed to create PyTranslator for engine: " + this.getEngineName() + 
+	                         ", insight ID: " + (insight != null ? insight.getInsightId() : "null"), e);
+	        
+	        if (e instanceof RuntimeException) {
+	            throw e;
+	        }
+	        
+	        throw new IllegalStateException("Failed to create PyTranslator: " + e.getMessage(), e);
+	    }
+	}
 
 	
 	/**

--- a/src/prerna/reactor/project/EnginePyReactor.java
+++ b/src/prerna/reactor/project/EnginePyReactor.java
@@ -37,7 +37,7 @@ public class EnginePyReactor extends AbstractReactor  {
 		}
 		
 		User user = this.insight.getUser();
-		if (!SecurityEngineUtils.userCanViewEngine(user, engineId)) {
+		if (!SecurityEngineUtils.userCanEditEngine(user, engineId)) {
 			throw new IllegalArgumentException("Model " + engineId + " does not exist or user does not have access to this model");
 		}
 		

--- a/src/prerna/reactor/project/EnginePyReactor.java
+++ b/src/prerna/reactor/project/EnginePyReactor.java
@@ -38,7 +38,7 @@ public class EnginePyReactor extends AbstractReactor  {
 		
 		User user = this.insight.getUser();
 		if (!SecurityEngineUtils.userCanEditEngine(user, engineId)) {
-			throw new IllegalArgumentException("Model " + engineId + " does not exist or user does not have access to this model");
+			throw new IllegalArgumentException("Model " + engineId + " does not exist or user does not have editor access to this model");
 		}
 		
 		String code = Utility.decodeURIComponent(this.keyValue.get(ReactorKeysEnum.CODE.getKey()));

--- a/src/prerna/reactor/project/EnginePyReactor.java
+++ b/src/prerna/reactor/project/EnginePyReactor.java
@@ -1,0 +1,85 @@
+package prerna.reactor.project;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.User;
+import prerna.auth.utils.SecurityEngineUtils;
+import prerna.ds.py.PyTranslator;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.util.Utility;
+import prerna.engine.api.IEngine;
+import prerna.engine.impl.model.AbstractPythonModelEngine;
+
+public class EnginePyReactor extends AbstractReactor  {
+	
+	private static final Logger classLogger = LogManager.getLogger(EnginePyReactor.class);
+
+	
+	public EnginePyReactor() {
+		this.keysToGet = new String[]{ReactorKeysEnum.CODE.getKey(), ReactorKeysEnum.ENGINE.getKey()};
+	}
+	
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		String engineId = this.keyValue.get(ReactorKeysEnum.ENGINE.getKey());
+		
+		if(engineId == null || (engineId=engineId.trim()).isEmpty()) {
+			throw new IllegalArgumentException("Must input an engine id");
+		}
+		
+		User user = this.insight.getUser();
+		if (!SecurityEngineUtils.userCanViewEngine(user, engineId)) {
+			throw new IllegalArgumentException("Model " + engineId + " does not exist or user does not have access to this model");
+		}
+		
+		String code = Utility.decodeURIComponent(this.keyValue.get(ReactorKeysEnum.CODE.getKey()));
+		if (code == null || code.trim().isEmpty()) {
+			throw new IllegalArgumentException("Code parameter cannot be null or empty");
+		}
+		
+		IEngine rawEngine = Utility.getEngine(engineId);
+		if (!(rawEngine instanceof AbstractPythonModelEngine)) {
+		    throw new IllegalArgumentException("Engine " + engineId + " is not a Python model engine");
+		}
+		AbstractPythonModelEngine engine = (AbstractPythonModelEngine) rawEngine;
+		
+		PyTranslator enginePyTranslator = null;
+		String output = null;
+		
+		try {
+			enginePyTranslator = engine.getEnginePyTranslator(this.insight);
+			
+			output = enginePyTranslator.runSingle(code, this.insight);
+			
+		} catch (IllegalArgumentException e) {
+			classLogger.warn("Invalid argument when getting PyTranslator for engine {}: {}", engineId, e.getMessage());
+			throw e;
+			
+		} catch (IllegalStateException e) {
+			classLogger.error("Engine {} is not properly initialized or connection failed: {}", engineId, e.getMessage());
+			throw new IllegalArgumentException("Engine " + engineId + " is currently unavailable. Please try again later.", e);
+			
+		} catch (Exception e) {
+			classLogger.error("Unexpected error executing code on engine {}: {}", engineId, e.getMessage(), e);
+			throw new IllegalArgumentException("Failed to execute code on engine " + engineId + ": " + e.getMessage(), e);
+		}
+		
+		if (output == null) {
+			classLogger.warn("Code execution returned null output for engine {}", engineId);
+			output = "";
+		}
+		
+		List<NounMetadata> outputs = new ArrayList<>(1);
+		outputs.add(new NounMetadata(output, PixelDataType.CONST_STRING));
+		return new NounMetadata(outputs, PixelDataType.CODE, PixelOperationType.CODE_EXECUTION);
+	}
+}


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Adding an EnginePy reactor to be able to write directly to the Python shell running a model engine. 

## Changes Made
<!-- List the key changes made in this PR -->

- Added a `getEnginePyTranslator()` method to the `AbstractPythonModelEngine` class. 
- Added a `EnginePy` reactor that accepts a code param and an engine id param to write to the python shell running the model engine. 

## How to Test
<!-- Explain how reviewers can test your changes -->
```
EnginePy ( "<encode>my_var = 'ryan_weiler'</encode>" , "4acbe913-df40-4ac0-b28a-daa5ad91b172" ) ;
EnginePy ( "<encode>my_var</encode>" , "4acbe913-df40-4ac0-b28a-daa5ad91b172" ) ;
```

![image](https://github.com/user-attachments/assets/b4a9fcaf-1d36-4c70-bd8d-12a56e40dc06)


## Notes
<!-- Any further notes regarding changes -->