### PR TITLE
tokenizer update for gpt-4o

### DIFF
--- a/py/genai_client/tokenizers/openai_tokenizer.py
+++ b/py/genai_client/tokenizers/openai_tokenizer.py
@@ -47,9 +47,12 @@ class OpenAiTokenizer(AbstractTokenizer):
             try:
                 return tiktoken.encoding_for_model(encoder_name)
             except KeyError:
-                logger.warning("Warning: model not found. Using WordCountTokenizer.")
+                # Handle gpt-4o model explicitly if not recognized in older tiktoken versions
+                if "gpt-4o" in encoder_name:
+                    return tiktoken.get_encoding("o200k_base")
+                logger.warning("Model not found. Using WordCountTokenizer fallback.")
+                # Standard model
                 from .word_count_tokenizer import WordCountTokenizer
-
                 return WordCountTokenizer()
 
     def format_with_chat_template(self, messages: List[Dict]) -> str:


### PR DESCRIPTION
Handled gpt-4o model explicitly if not recognized in older tiktoken versions

## Description
Handled gpt-4o model explicitly if not recognized in older tiktoken versions

## Changes Made
if "gpt-4o" in encoder_name:
    return tiktoken.get_encoding("o200k_base")
         
## How to Test
Call gpt-4o model using terminal-reactor/python