### PR TITLE
feat: Add Minio support to AWSNativeBlobStorageEngine

### DIFF
--- a/src/prerna/engine/impl/storage/AWSNativeBlobStorageEngine.java
+++ b/src/prerna/engine/impl/storage/AWSNativeBlobStorageEngine.java
@@ -51,11 +51,15 @@ public class AWSNativeBlobStorageEngine extends AbstractStorageEngine {
 	public static final String S3_BUCKET_KEY = "S3_BUCKET";
 	public static final String S3_ACCESS_KEY = "S3_ACCESS";
 	public static final String S3_SECRET_KEY = "S3_SECRET";
+	public static final String S3_ENDPOINT_KEY = "S3_ENDPOINT";
+	public static final String S3_PATH_STYLE_ACCESS_KEY = "S3_PATH_STYLE_ACCESS";
 
 	private String accessKey;
 	private String secretKey;
 	private String region;
 	private String bucket;
+	private String endpoint;
+	private boolean pathStyleAccess = false;
 
 	private S3Client client = null;
 
@@ -67,6 +71,11 @@ public class AWSNativeBlobStorageEngine extends AbstractStorageEngine {
 		this.secretKey = smssProp.getProperty(S3_SECRET_KEY);
 		this.region = smssProp.getProperty(S3_REGION_KEY);
 		this.bucket = smssProp.getProperty(S3_BUCKET_KEY);
+		this.endpoint = smssProp.getProperty(S3_ENDPOINT_KEY);
+		String pathStyleAccessStr = smssProp.getProperty(S3_PATH_STYLE_ACCESS_KEY);
+		if (pathStyleAccessStr != null && !pathStyleAccessStr.isEmpty()) {
+			this.pathStyleAccess = Boolean.parseBoolean(pathStyleAccessStr);
+		}
 
 		if (this.accessKey == null || this.accessKey.isEmpty()) {
 			throw new RuntimeException("Must pass in an access key");
@@ -84,9 +93,24 @@ public class AWSNativeBlobStorageEngine extends AbstractStorageEngine {
 	}
 
 	public void createServiceClient() {
-		this.client = S3Client.builder().region(Region.of(this.region))
-				.credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)))
-				.build();
+		software.amazon.awssdk.services.s3.S3ClientBuilder builder = S3Client.builder();
+		builder.region(Region.of(this.region))
+				.credentialsProvider(StaticCredentialsProvider.create(AwsBasicCredentials.create(accessKey, secretKey)));
+
+		if (this.endpoint != null && !this.endpoint.isEmpty()) {
+			try {
+				builder.endpointOverride(new java.net.URI(this.endpoint));
+				if (this.pathStyleAccess) {
+					builder.forcePathStyle(true);
+				}
+				classLogger.info("Using S3 endpoint override: " + this.endpoint);
+			} catch (java.net.URISyntaxException e) {
+				classLogger.error("Invalid S3 endpoint URI: " + this.endpoint, e);
+				throw new RuntimeException("Invalid S3 endpoint URI: " + this.endpoint, e);
+			}
+		}
+
+		this.client = builder.build();
 		classLogger.info("S3 Blob Service client created successfully.");
 	}
 


### PR DESCRIPTION
This change allows the AWSNativeBlobStorageEngine to be used with a Minio S3-compatible object storage server.

New properties:
- S3_ENDPOINT: The endpoint URL for the Minio server.
- S3_PATH_STYLE_ACCESS: A boolean flag to enable path-style access.

The createServiceClient method was modified to conditionally set the endpoint and path-style access if the S3_ENDPOINT property is provided. If S3_ENDPOINT is not provided, it defaults to standard AWS S3 behavior.

## Description
<!-- Provide a brief description of the changes in this PR -->

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->