### PR TITLE
fix: unit tests need to initialize class loader instead of casting

### DIFF
--- a/src/prerna/om/Insight.java
+++ b/src/prerna/om/Insight.java
@@ -28,6 +28,7 @@
 package prerna.om;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.Serializable;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -1301,8 +1302,9 @@ public class Insight implements Serializable {
 		
 		StringBuilder retClassPath = new StringBuilder("");
 		ClassLoader cl = getClass().getClassLoader();
-
-        URL[] urls = ((URLClassLoader)cl).getURLs();
+		
+		// Fix for differing class loaders during runtime in tomcat server and unit tests. 
+		URL[] urls = getUrlsFromClassLoader(cl);
 
         if(System.getProperty("os.name").toLowerCase().contains("win")) {
 	        for(URL url: urls){
@@ -1351,6 +1353,33 @@ public class Insight implements Serializable {
         // we should also add to sys.path for py and then also remove it
         // sys.path.add
         // sys.path.remove - the remove is tricky however
+	}
+
+	/**
+	 * Either casts to or creates a URLClassLoader from default class loader
+	 * This is needed because during runtime of unit tests, the default class loader
+	 * is not an instance of URLClassLoader in Java 9+. Also, this now closes the URLClassLoader
+	 * to prevent resource leaks. 
+	 * 
+	 * @param cl Class loader to get URLs from
+	 * @return array of URL
+	 */
+	private URL[] getUrlsFromClassLoader(ClassLoader cl) {
+		URL[] urls = null;
+		if (cl instanceof URLClassLoader) {
+			try (URLClassLoader urlCl = (URLClassLoader) cl) {
+				urls = urlCl.getURLs();
+			} catch (IOException e) {
+				logger.error(Constants.STACKTRACE, e);
+			}
+		} else {
+			try (URLClassLoader urlCl = new URLClassLoader(new URL[] {}, cl)) {
+				urls = urlCl.getURLs();
+			} catch (IOException e) {
+				logger.error(Constants.STACKTRACE, e);
+			}
+		}
+		return urls;
 	}
 	
 	public void setLastPanelId(String panelId) {


### PR DESCRIPTION
## Description
Unit tests defautl to a different class loader due to the jdk update that isn't a URLClassloader

## Changes Made
for normal runtime cast to the classloader and close it to prevent resources from leaking

## How to Test
run api tests that call reactors
use the ui that calls reactors

## Notes
- quick fix, server runtime should remain unchanged while testing runtime should be able to work properly again, after the jdk update. 