### PR TITLE
fix: don't close unowned classloader

### DIFF
--- a/src/prerna/om/Insight.java
+++ b/src/prerna/om/Insight.java
@@ -1367,11 +1367,7 @@ public class Insight implements Serializable {
 	private URL[] getUrlsFromClassLoader(ClassLoader cl) {
 		URL[] urls = null;
 		if (cl instanceof URLClassLoader) {
-			try (URLClassLoader urlCl = (URLClassLoader) cl) {
-				urls = urlCl.getURLs();
-			} catch (IOException e) {
-				logger.error(Constants.STACKTRACE, e);
-			}
+			urls = ((URLClassLoader) cl).getURLs();
 		} else {
 			try (URLClassLoader urlCl = new URLClassLoader(new URL[] {}, cl)) {
 				urls = urlCl.getURLs();


### PR DESCRIPTION
## Description
I don't want to close an unowned class loader. 

## Changes Made
Closing classloader that is casted

## How to Test
This reverts back to original behavior, should be fine. 

## Notes
Original behavior for server is returned, class loader is no longer closed after cast.