### PR TITLE
Update room name

### DIFF
--- a/src/prerna/engine/impl/model/RoomUtils.java
+++ b/src/prerna/engine/impl/model/RoomUtils.java
@@ -101,7 +101,7 @@ public class RoomUtils {
                 IProject project = Utility.getProject(projectId);
                 projectName = project != null ? project.getProjectName() : null;
             }
-            String roomName = (question != null) ? question.substring(0, Math.min(question.length(), 100)) : "untitled";
+            String roomName = (question != null) ? question.substring(0, Math.min(question.length(), 100)) : null;
             ModelInferenceLogsUtils.doCreateNewConversation(
             		insight.getInsightId(), 
                     roomId,


### PR DESCRIPTION
Room name was being set to "untitled" when CreateRoom() is called. Added logic to change the room name when pulling an existing untitled room.