### PR TITLE
Google GenAI message builder base64 fix

### DIFF
--- a/py/genai_client/message_builders/google_genai/google_genai_builder.py
+++ b/py/genai_client/message_builders/google_genai/google_genai_builder.py
@@ -74,7 +74,13 @@ class GoogleGenAIMessageBuilder:
             if image.type == SEMOSSImageType.URL and image.url:
                 google_image_parts.append(Part.from_uri(file_uri=image.url))
             elif image.type == SEMOSSImageType.BASE64:
-                google_image_parts.append(Part.from_bytes(data=image.data))
+                if not image.mime_type or not image.data:
+                    raise ValueError(
+                        f"Missing required base64 data or mime type when building Google GenAI image part."
+                    )
+                google_image_parts.append(
+                    Part.from_bytes(data=image.data, mime_type=image.mime_type)
+                )
             else:
                 raise ValueError(f"Unsupported SEMOSSImageContent type: {image.type}")
         return google_image_parts


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Updating the Google GenAI Python message builder to pass the mime type to the image part when adding a base64 image to a message. 