### PR TITLE
fix(engine): correctly set type as 'directory' for folders

### DIFF
--- a/src/prerna/reactor/engine/BrowseEngineAssetsReactor.java
+++ b/src/prerna/reactor/engine/BrowseEngineAssetsReactor.java
@@ -78,7 +78,11 @@ public class BrowseEngineAssetsReactor extends AbstractReactor {
 			}
 			Map<String, Object> fileMap = new HashMap<>();
 			fileMap.put("name", f.getName());
-			fileMap.put("type", FilenameUtils.getExtension(f.getName()));
+			if (f.isDirectory()) {
+				fileMap.put("type", "directory");
+			} else {
+				fileMap.put("type", FilenameUtils.getExtension(f.getName()));
+			}
 			fileMap.put("lastModified", dateFormat.format(f.lastModified()));
 			fileMap.put("path", f.getAbsolutePath().substring(pathSubstringIndex));
 			retObj.add(fileMap);

--- a/src/prerna/reactor/engine/BrowseEngineAssetsReactor.java
+++ b/src/prerna/reactor/engine/BrowseEngineAssetsReactor.java
@@ -22,8 +22,7 @@ import prerna.util.EngineUtility;
 public class BrowseEngineAssetsReactor extends AbstractReactor {
 
 	public BrowseEngineAssetsReactor() {
-		this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey(), 
-				ReactorKeysEnum.FILE_PATH.getKey() };
+		this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey(), ReactorKeysEnum.FILE_PATH.getKey() };
 		this.keyRequired = new int[] {1,0};
 	}
 

--- a/src/prerna/reactor/project/BrowseAppAssetsReactor.java
+++ b/src/prerna/reactor/project/BrowseAppAssetsReactor.java
@@ -24,8 +24,7 @@ import prerna.util.Utility;
 public class BrowseAppAssetsReactor extends AbstractReactor {
 
 	public BrowseAppAssetsReactor() {
-		this.keysToGet = new String[] { ReactorKeysEnum.PROJECT.getKey(), 
-				ReactorKeysEnum.FILE_PATH.getKey() };
+		this.keysToGet = new String[] { ReactorKeysEnum.PROJECT.getKey(), ReactorKeysEnum.FILE_PATH.getKey() };
 		this.keyRequired = new int[] {1,0};
 	}
 
@@ -82,7 +81,11 @@ public class BrowseAppAssetsReactor extends AbstractReactor {
 			}
 			Map<String, Object> fileMap = new HashMap<>();
 			fileMap.put("name", f.getName());
-			fileMap.put("type", FilenameUtils.getExtension(f.getName()));
+			if (f.isDirectory()) {
+				fileMap.put("type", "directory");
+			} else {
+				fileMap.put("type", FilenameUtils.getExtension(f.getName()));
+			}
 			fileMap.put("lastModified", dateFormat.format(f.lastModified()));
 			fileMap.put("path", f.getAbsolutePath().substring(pathSubstringIndex));
 			retObj.add(fileMap);


### PR DESCRIPTION
### Description:
The **BrowseEngineAssetsReactor** was using **FilenameUtils.getExtension()** to detect whether an item is a file or folder. But this method doesn’t work for folders it returns an empty string. Because of that, folders in the response had no proper **type** value, which caused confusion in the UI.
### What was fixed:
I have updated the logic to check if the item is a folder using **f.isDirectory()**, and now set the type to **directory** when it is. This helps the frontend correctly identify and show folders.
