### PR TITLE
Pinning PyArrow to v20 in pyproject.toml

### DIFF
--- a/py/install_config/pyproject.toml
+++ b/py/install_config/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "pdfplumber>=0.11.5",
     "peft>=0.14.0",
     "protobuf>=5.29.3",
+    "pyarrow==20.0.0",
     "pydantic>=1.10.21",
     "pyenchant>=3.2.2",
     "pyjarowinkler>=2.0.0",


### PR DESCRIPTION
Addressing the Python package issue when trying to upload a file to a vector database. The current version of `datasets` that we are using (`2.14.3`) requires `PyArrow` version of `20.0.0` or less. Pinning `PyArrow` in our pyproject.toml until we eventually update our version of `datasets`.