### PR TITLE
feat: Add support for Anthropic multi-tool calling

### DIFF
--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -29,7 +29,8 @@ class AnthropicMessageBuilder:
         anthropic_messages = []
         param_map = {}
         
-        pending_tool_response = False
+        pending_tool_calls = []
+        pending_tool_results = []
         
         for i, message in enumerate(semoss_messages):
             is_last = i == len(semoss_messages) - 1
@@ -60,13 +61,14 @@ class AnthropicMessageBuilder:
                 # Handle assistant tool calls
                 if message.tool_calls:
                     for tool_call in message.tool_calls:
-                        content_parts.append(
-                            AnthropicToolUseContentPart(
-                                id=tool_call["id"],
-                                name=tool_call["function"]["name"],
-                                input=tool_call["function"]["arguments"],
-                            )
+                        tool_use_part = AnthropicToolUseContentPart(
+                            id=tool_call["id"],
+                            name=tool_call["function"]["name"],
+                            input=tool_call["function"]["arguments"],
                         )
+                        content_parts.append(tool_use_part)
+                        # Track this tool call as pending
+                        pending_tool_calls.append(tool_call["id"])
 
                     anthropic_messages.append(
                         AnthropicMessage(
@@ -74,58 +76,39 @@ class AnthropicMessageBuilder:
                             content=content_parts,
                         )
                     )
-                    pending_tool_response = True
 
             elif message.type == SEMOSSMessageType.INPUT_TOOL_EXEC:
                 # Handle tool execution results
-                if pending_tool_response:
-                    content_parts.append(
-                        AnthropicToolResultContentPart(
-                            tool_use_id=message.tool_call_id,
-                            content=message.content,
-                        )
+                if message.tool_call_id:
+                    tool_result = AnthropicToolResultContentPart(
+                        tool_use_id=message.tool_call_id,
+                        content=message.content,
                     )
-
+                    pending_tool_results.append(tool_result)
+                    
+                    if message.tool_call_id in pending_tool_calls:
+                        pending_tool_calls.remove(message.tool_call_id)
+                
+                # Check if we have all tool results for pending tool calls
+                # or if this is the last message or next message is not INPUT_TOOL_EXEC
+                should_flush = (
+                    len(pending_tool_calls) == 0 or  # All tool calls have results
+                    is_last or  # This is the last message
+                    (i + 1 < len(semoss_messages) and 
+                     semoss_messages[i + 1].type != SEMOSSMessageType.INPUT_TOOL_EXEC)  # Next message is not tool exec
+                )
+                
+                if should_flush and pending_tool_results:
                     anthropic_messages.append(
                         AnthropicMessage(
                             role=AnthropicRoles.USER,
-                            content=content_parts,
+                            content=pending_tool_results.copy(),
                         )
                     )
-                    pending_tool_response = False
-
-            elif message.type == SEMOSSMessageType.INPUT_TOOL_EXEC:
-                # Handle tool execution results
-                if pending_tool_response:
-                    # Check if this message contains multiple tool results
-                    if hasattr(message, 'tool_results') and message.tool_results:
-                        # Handle multiple tool results in one message (for Anthropic multi-tool support)
-                        for tool_result in message.tool_results:
-                            content_parts.append(
-                                AnthropicToolResultContentPart(
-                                    tool_use_id=tool_result.get('tool_call_id') or tool_result.get('tool_use_id'),
-                                    content=str(tool_result.get('content') or tool_result.get('tool_response', '')),
-                                )
-                            )
-                    else:
-                        # Single tool result (backward compatibility)
-                        content_parts.append(
-                            AnthropicToolResultContentPart(
-                                tool_use_id=message.tool_call_id,
-                                content=message.content,
-                            )
-                        )
-
-                    anthropic_messages.append(
-                        AnthropicMessage(
-                            role=AnthropicRoles.USER,
-                            content=content_parts,
-                        )
-                    )
-                    pending_tool_response = False
+                    pending_tool_results.clear()
+                    pending_tool_calls.clear()
 
             elif message.type == SEMOSSMessageType.RESPONSE_TEXT:
-                # Handle regular assistant text responses
                 if message.content:
                     content_parts.append(self._build_text_content_part(message.content))
 
@@ -140,7 +123,6 @@ class AnthropicMessageBuilder:
                 param_map = message.param_map
                 param_map = self._clean_param_map(param_map)
                 
-                # Convert tools to Anthropic format if present
                 if "tools" in param_map:
                     param_map["tools"] = self._convert_mcp_to_anthropic_tools(param_map["tools"])
 
@@ -252,7 +234,6 @@ class AnthropicMessageBuilder:
                 },
             }
 
-            # Copy properties, excluding 'title' if present
             for prop_name, prop_def in tool["inputSchema"]["properties"].items():
                 anthropic_tool["input_schema"]["properties"][prop_name] = {
                     k: v for k, v in prop_def.items() if k != "title"

--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -9,6 +9,8 @@ from .anthropic_models import (
     AnthropicImageSourceBase64,
     AnthropicImageContentPart,
     AnthropicTextContentPart,
+    AnthropicToolUseContentPart,
+    AnthropicToolResultContentPart,
 )
 from ..semoss_base.semoss_models import (
     SEMOSSMessage,
@@ -26,32 +28,121 @@ class AnthropicMessageBuilder:
         """Convert SEMOSS messages to Anthropic messages and return the param map from the latest message"""
         anthropic_messages = []
         param_map = {}
+        
+        pending_tool_response = False
+        
         for i, message in enumerate(semoss_messages):
             is_last = i == len(semoss_messages) - 1
-            # Get the role based on the SEMOSS message type
-            role = self._message_type_to_role(message.type)
-
             content_parts = []
-            # Handle text content
-            if message.content:
-                content_parts.append(self._build_text_content_part(message.content))
 
-            if message.image_content:
-                image_contents_parts = self._build_image_content_part(
-                    message.image_content
-                )
-                content_parts.extend(image_contents_parts)
+            if (
+                message.type == SEMOSSMessageType.INPUT_TEXT
+                or message.type == SEMOSSMessageType.INPUT_MEDIA
+            ):
+                # Handle user input (text/media)
+                if message.content:
+                    content_parts.append(self._build_text_content_part(message.content))
 
-            anthropic_messages.append(
-                AnthropicMessage(
-                    role=role,
-                    content=content_parts,
+                if message.image_content:
+                    image_contents_parts = self._build_image_content_part(
+                        message.image_content
+                    )
+                    content_parts.extend(image_contents_parts)
+
+                anthropic_messages.append(
+                    AnthropicMessage(
+                        role=AnthropicRoles.USER,
+                        content=content_parts,
+                    )
                 )
-            )
+
+            elif message.type == SEMOSSMessageType.RESPONSE_TOOL:
+                # Handle assistant tool calls
+                if message.tool_calls:
+                    for tool_call in message.tool_calls:
+                        content_parts.append(
+                            AnthropicToolUseContentPart(
+                                id=tool_call["id"],
+                                name=tool_call["function"]["name"],
+                                input=tool_call["function"]["arguments"],
+                            )
+                        )
+
+                    anthropic_messages.append(
+                        AnthropicMessage(
+                            role=AnthropicRoles.ASSISTANT,
+                            content=content_parts,
+                        )
+                    )
+                    pending_tool_response = True
+
+            elif message.type == SEMOSSMessageType.INPUT_TOOL_EXEC:
+                # Handle tool execution results
+                if pending_tool_response:
+                    content_parts.append(
+                        AnthropicToolResultContentPart(
+                            tool_use_id=message.tool_call_id,
+                            content=message.content,
+                        )
+                    )
+
+                    anthropic_messages.append(
+                        AnthropicMessage(
+                            role=AnthropicRoles.USER,
+                            content=content_parts,
+                        )
+                    )
+                    pending_tool_response = False
+
+            elif message.type == SEMOSSMessageType.INPUT_TOOL_EXEC:
+                # Handle tool execution results
+                if pending_tool_response:
+                    # Check if this message contains multiple tool results
+                    if hasattr(message, 'tool_results') and message.tool_results:
+                        # Handle multiple tool results in one message (for Anthropic multi-tool support)
+                        for tool_result in message.tool_results:
+                            content_parts.append(
+                                AnthropicToolResultContentPart(
+                                    tool_use_id=tool_result.get('tool_call_id') or tool_result.get('tool_use_id'),
+                                    content=str(tool_result.get('content') or tool_result.get('tool_response', '')),
+                                )
+                            )
+                    else:
+                        # Single tool result (backward compatibility)
+                        content_parts.append(
+                            AnthropicToolResultContentPart(
+                                tool_use_id=message.tool_call_id,
+                                content=message.content,
+                            )
+                        )
+
+                    anthropic_messages.append(
+                        AnthropicMessage(
+                            role=AnthropicRoles.USER,
+                            content=content_parts,
+                        )
+                    )
+                    pending_tool_response = False
+
+            elif message.type == SEMOSSMessageType.RESPONSE_TEXT:
+                # Handle regular assistant text responses
+                if message.content:
+                    content_parts.append(self._build_text_content_part(message.content))
+
+                anthropic_messages.append(
+                    AnthropicMessage(
+                        role=AnthropicRoles.ASSISTANT,
+                        content=content_parts,
+                    )
+                )
 
             if is_last:
                 param_map = message.param_map
                 param_map = self._clean_param_map(param_map)
+                
+                # Convert tools to Anthropic format if present
+                if "tools" in param_map:
+                    param_map["tools"] = self._convert_mcp_to_anthropic_tools(param_map["tools"])
 
         return anthropic_messages, param_map
 
@@ -141,3 +232,32 @@ class AnthropicMessageBuilder:
         )
 
         return AnthropicImageContentPart(source=image_source)
+
+    def _convert_mcp_to_anthropic_tools(
+        self, mcp_tools: List[Dict]
+    ) -> List[Dict]:
+        """
+        Convert MCP-formatted tools to Anthropic tool format.
+        """
+        anthropic_tools = []
+
+        for tool in mcp_tools:
+            anthropic_tool = {
+                "name": tool["name"],
+                "description": tool["description"],
+                "input_schema": {
+                    "type": tool["inputSchema"]["type"],
+                    "properties": {},
+                    "required": tool["inputSchema"].get("required", []),
+                },
+            }
+
+            # Copy properties, excluding 'title' if present
+            for prop_name, prop_def in tool["inputSchema"]["properties"].items():
+                anthropic_tool["input_schema"]["properties"][prop_name] = {
+                    k: v for k, v in prop_def.items() if k != "title"
+                }
+
+            anthropic_tools.append(anthropic_tool)
+
+        return anthropic_tools

--- a/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
+++ b/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
@@ -145,7 +145,7 @@ class AnthropicTextClient(AbstractTextGenerationClient):
         )
 
     def _handle_semoss_msgs(self):
-        """When we update everything to the new history format this will be the only method we need"""
+        """Handle SEMOSS messages through AnthropicMessageBuilder"""
         try:
             msg_history, param_map = AnthropicMessageBuilder().build_messages(
                 semoss_messages=self.ask_settings.semoss_messages,
@@ -155,12 +155,38 @@ class AnthropicTextClient(AbstractTextGenerationClient):
                 f"Failed to build messages in Anthropic format from SEMOSS format: {e}"
             )
 
+        # Create request config with tools from param_map
         self.request_config = self._convert_args_to_provider_config(
             history=msg_history,
             **param_map,
         )
 
-        return msg_history
+        if self.ask_settings.streaming:
+            response = self._handle_streaming(prefix="", msg_history=msg_history)
+            response_text = response.text
+            usage = response.usage
+        else:
+            response = self.client.messages.create(
+                **self.request_config.model_dump(exclude_none=True),
+            )
+            if response.stop_reason == "tool_use":
+                return self._parse_tools_call_response(
+                    response,
+                    prompt_tokens=response.usage.input_tokens,
+                    response_tokens=response.usage.output_tokens,
+                )
+            response_text = response.content[0].text
+            usage = Usage(
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+            )
+
+        return AskModelEngineResponse(
+            response=response_text,
+            response_tokens=usage.output_tokens,
+            prompt_tokens=usage.input_tokens,
+            messageType="CHAT",
+        )
 
     def _handle_full_prompt_msgs(self, **kwargs):
         """
@@ -261,8 +287,8 @@ class AnthropicTextClient(AbstractTextGenerationClient):
 
         tools = kwargs.pop("tools", None)
         if tools is not None:
-            tools = self._handle_tools_conversion(tools)
-            tools = [tools.model_dump(mode="json") for tools in tools]
+            # Tools are already in Anthropic format from the message builder
+            # Disable streaming when tools are present
             self.ask_settings.streaming = False
 
         return AnthropicRequestConfig(


### PR DESCRIPTION
## Description
Implements robust tool calling support for Anthropic Claude, including correct handling of both single and multi-tool call flows as required by the Anthropic API.

## Changes Made
- **anthropic_message_builder.py**
  - Added detection of tool_use and tool_result message types.
  - Batches tool_result blocks after multi-tool tool_use responses.
  - Converts SEMOSS tool schemas to Anthropic format.

- **anthropic_text_client.py**
  - Integrates new builder for proper message sequencing.
  - Disables streaming for tool calls.
  - Ensures tool_result batching after tool_use.

## How to Test
- Performed manual tests with both single and multi-tool calls using the ai-server SDK
- Verified that Anthropic’s API did not return 400 errors.
- Confirmed that tool results are delivered in the correct order for multi-tool calls.

## Notes
- Each time the assistant issues multiple tool_use blocks, the next user message generated by AnthropicMessageBuilder will contain a matching tool_result block for each, in order.
- The builder converts all MCP tool definitions to Anthropic’s required schema, including name, description, and input_schema.
- The client disables streaming on tool calls as required by Anthropic.
- All relevant functions and logic paths are documented inline.