### PR TITLE
feat: support custom query and pagination handling on open search

### DIFF
--- a/src/prerna/engine/impl/vector/OpenSearchRestVectorDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/OpenSearchRestVectorDatabaseEngine.java
@@ -10,6 +10,8 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -18,20 +20,26 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringSubstitutor;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
+import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
-import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.spi.json.GsonJsonProvider;
 
 import prerna.cluster.util.ClusterUtil;
@@ -41,7 +49,9 @@ import prerna.engine.api.VectorDatabaseTypeEnum;
 import prerna.engine.impl.SmssUtilities;
 import prerna.engine.impl.model.responses.EmbeddingsModelEngineResponse;
 import prerna.om.Insight;
+import prerna.query.querystruct.filters.AndQueryFilter;
 import prerna.query.querystruct.filters.IQueryFilter;
+import prerna.query.querystruct.filters.SimpleQueryFilter;
 import prerna.security.HttpHelperUtility;
 import prerna.util.Constants;
 import prerna.util.Utility;
@@ -61,9 +71,6 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 	private static final String UPDATE_MAPPINGS_ENDPOINT = "/_mapping";
 	private static final String DELETE_BY_QUERY_ENDPOINT = "/_delete_by_query";
 	
-	private static final String UNIQUE_SOURCES = "unique_sources";
-	private static final String FILTERED_SOURCES = "filtered_sources";
-
 	private static final String EMBEDDINGS_COLUMN = "EMBEDDINGS_COLUMN";
 	private static final String DIMENSION_SIZE = "DIMENSION_SIZE";
 	private static final String METHOD_NAME = "METHOD_NAME";
@@ -71,7 +78,83 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 	private static final String EF_CONSTRUCTION = "EF_CONSTRUCTION";
 	private static final String M_VALUE = "M_VALUE";
 	private static final String ADDITIONAL_MAPPINGS = "ADDITIONAL_MAPPINGS";
-
+	
+	private static final String EXTERNALLY_MANAGED_INDEX = "EXTERNALLY_MANAGED_INDEX";
+	private static final String QUERY_LIMIT = "QUERY_LIMIT";
+	private static final String BATCH_LIMIT = "BATCH_LIMIT";
+	
+    private static final String LIST_DOCUMENTS_QUERY = "LIST_DOCUMENTS_QUERY";
+    private static final String LIST_DOCUMENTS_RESULTS_PATH = "LIST_DOCUMENTS_RESULTS_PATH";
+    private static final String LIST_ALL_RECORDS_QUERY = "LIST_ALL_RECORDS_QUERY";
+    private static final String LIST_ALL_RECORDS_RESULTS_PATH = "LIST_ALL_RECORDS_RESULTS_PATH";
+    private static final String NEAREST_NEIGHBOR_QUERY = "NEAREST_NEIGHBOR_QUERY";
+    private static final String NEAREST_NEIGHBOR_RESULTS_PATH = "NEAREST_NEIGHBOR_RESULTS_PATH";
+	
+    private static final String DEFAULT_LIST_DOCUMENTS_QUERY = """
+		{
+		  "size": 0,
+		  "aggs": {
+		    "unique_sources": {
+		      "filter": ${FILTER},
+		      "aggs": {
+		        "filtered_sources": {
+		          "terms": {
+		            "field": "%s",
+		            "min_doc_count": 1,
+		            "size": ${SIZE},
+		            "order": {
+		              "_key": "asc"
+		            }
+		          }
+		        }
+		      }
+		    }
+		  }
+		}
+	""".formatted(VectorDatabaseCSVTable.SOURCE);
+    private static final String DEFAULT_LIST_DOCUMENTS_RESULTS_PATH = "$..buckets[*].key";
+    private static final String DEFAULT_LIST_ALL_RECORDS_QUERY = """
+		{
+		  "fields": ["%s","%s","%s","%s","%s","%s"],
+		  "_source": false,
+		  "size": ${SIZE},
+		  "query": ${FILTER},
+		  "sort": [
+		    {"%s": "asc"},
+		    {
+		      "_script": {
+		        "type": "number",
+		        "script": {
+		          "source": "def idValue = doc['_id'].getValue(); return Integer.parseInt( idValue.substring( idValue.lastIndexOf('_')+1 ) );"
+		        },
+		        "order": "asc"
+		      }
+		    }
+		  ]
+		  ${SEARCH_AFTER}
+		}
+	""".formatted(VectorDatabaseCSVTable.SOURCE, VectorDatabaseCSVTable.MODALITY, 
+			VectorDatabaseCSVTable.DIVIDER, VectorDatabaseCSVTable.PART, 
+			VectorDatabaseCSVTable.TOKENS, VectorDatabaseCSVTable.CONTENT,
+			VectorDatabaseCSVTable.SOURCE);
+    private static final String DEFAULT_LIST_ALL_RECORDS_RESULTS_PATH = "$.hits.hits[*].fields";
+    private static final String DEFAULT_NEAREST_NEIGHBOR_QUERY = """
+    	{
+    	  "from": ${FROM},
+    	  "size": ${SIZE},
+    	  "query": {
+    	    "knn": {
+    	      "${EMBEDDINGS}": {
+    	        "vector": ${VECTOR},
+    	        "k": ${K},
+    	        "filter": ${FILTER}
+    	      }
+    	    }
+    	  }
+    	}
+    """;
+    private static final String DEFAULT_NEAREST_NEIGHBOR_RESULTS_PATH = "$.hits.hits[*]";
+    
 	private String clusterUrl = null;
 	private String username = null;
 	private String password = null;
@@ -85,10 +168,17 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 	private int efConstruction = 128;
 	private int m = 24;
 	
-	protected String customTemplateQuery = null;
-	protected String customResultsPath = null;
-	protected List<String> highlightFieldKeys = null;
-
+	private boolean externallyManagedIndex = false;
+	private int queryLimit = 9999;
+	private int batchLimit = 9999;
+	
+	private String listDocumentsQuery = null;
+	private String listDocumentsResultsPath = null;
+	private String listAllRecordsQuery= null;
+	private String listAllRecordsResultsPath = null;
+	private String nearestNeighborQuery= null;
+	private String nearestNeighborResultsPath = null;
+	
 	private Map<String, String> otherPropsToType = new HashMap<>();
 
 	@Override
@@ -139,25 +229,71 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 				classLogger.error(Constants.STACKTRACE, e);
 			}
 		}
-
-		String additionalMappingsStr = this.smssProp.getProperty(ADDITIONAL_MAPPINGS);
-		if(additionalMappingsStr != null && !(additionalMappingsStr=additionalMappingsStr.trim()).isEmpty()) {
-			this.otherPropsToType = new Gson().fromJson(additionalMappingsStr, new TypeToken<Map<String, String>>() {}.getType());
+		
+		externallyManagedIndex = Boolean.parseBoolean(StringUtils.trimToNull(this.smssProp.getProperty(EXTERNALLY_MANAGED_INDEX)));
+		
+		String queryLimitInput = this.smssProp.getProperty(QUERY_LIMIT);
+		if(queryLimitInput != null && !(queryLimitInput=queryLimitInput.trim()).isEmpty()) {
+			try {
+				this.queryLimit = ((Number) Double.parseDouble(queryLimitInput)).intValue();
+			} catch(NumberFormatException e) {
+				classLogger.warn("Invalid string value for query_limit value '"+queryLimitInput+"'. Must be an integer value");
+				classLogger.error(Constants.STACKTRACE, e);
+			}
+		}
+		String batchLimitInput = this.smssProp.getProperty(BATCH_LIMIT);
+		if(batchLimitInput != null && !(batchLimitInput=batchLimitInput.trim()).isEmpty()) {
+			try {
+				this.batchLimit = ((Number) Double.parseDouble(batchLimitInput)).intValue();
+			} catch(NumberFormatException e) {
+				classLogger.warn("Invalid string value for batch_limit value '"+queryLimitInput+"'. Must be an integer value");
+				classLogger.error(Constants.STACKTRACE, e);
+			}
+		}
+		
+		if(!externallyManagedIndex) {
+			String additionalMappingsStr = this.smssProp.getProperty(ADDITIONAL_MAPPINGS);
+			if(additionalMappingsStr != null && !(additionalMappingsStr=additionalMappingsStr.trim()).isEmpty()) {
+				this.otherPropsToType = new Gson().fromJson(additionalMappingsStr, new TypeToken<Map<String, String>>() {}.getType());
+			}
+			// we need to store our stuff
+			this.otherPropsToType.put(VectorDatabaseCSVTable.SOURCE, KEYWORD_DATATYPE);
+			this.otherPropsToType.put(VectorDatabaseCSVTable.MODALITY, KEYWORD_DATATYPE);
+			this.otherPropsToType.put(VectorDatabaseCSVTable.DIVIDER, TEXT_DATATYPE);
+			this.otherPropsToType.put(VectorDatabaseCSVTable.PART, TEXT_DATATYPE);
+			this.otherPropsToType.put(VectorDatabaseCSVTable.TOKENS, INT_DATATYPE);
+			this.otherPropsToType.put(VectorDatabaseCSVTable.CONTENT, TEXT_DATATYPE);
+	
+			getIndex(this.indexName, this.embeddings, this.dimension, this.methodName, this.distanceMethod, this.indexEngine, this.efConstruction, this.m);
+			updateIndexMapping(this.indexName, this.otherPropsToType);	
+		} else if(!doesIndexExist(this.indexName)) {
+			throw new IllegalArgumentException("Externally managed index does not exist");
 		}
 
-		// we need to store our stuff
-		this.otherPropsToType.put(VectorDatabaseCSVTable.SOURCE, KEYWORD_DATATYPE);
-		this.otherPropsToType.put(VectorDatabaseCSVTable.MODALITY, KEYWORD_DATATYPE);
-		this.otherPropsToType.put(VectorDatabaseCSVTable.DIVIDER, TEXT_DATATYPE);
-		this.otherPropsToType.put(VectorDatabaseCSVTable.PART, TEXT_DATATYPE);
-		this.otherPropsToType.put(VectorDatabaseCSVTable.TOKENS, INT_DATATYPE);
-		this.otherPropsToType.put(VectorDatabaseCSVTable.CONTENT, TEXT_DATATYPE);
-
-		getIndex(this.indexName, this.embeddings, this.dimension, this.methodName, this.distanceMethod, this.indexEngine, this.efConstruction, this.m);
-		updateIndexMapping(this.indexName, this.otherPropsToType);	
-		
-		this.customTemplateQuery = this.smssProp.getProperty(Constants.CUSTOM_TEMPLATE_QUERY);
-		this.customResultsPath = this.smssProp.getProperty(Constants.CUSTOM_RESULTS_PATH);
+		listDocumentsQuery = (String) ObjectUtils.firstNonNull(
+				StringUtils.trimToNull(this.smssProp.getProperty(LIST_DOCUMENTS_QUERY)),
+				DEFAULT_LIST_DOCUMENTS_QUERY
+		);
+		listDocumentsResultsPath = (String) ObjectUtils.firstNonNull(
+				StringUtils.trimToNull(this.smssProp.getProperty(LIST_DOCUMENTS_RESULTS_PATH)),
+				DEFAULT_LIST_DOCUMENTS_RESULTS_PATH
+		);
+		listAllRecordsQuery= (String) ObjectUtils.firstNonNull(
+				StringUtils.trimToNull(this.smssProp.getProperty(LIST_ALL_RECORDS_QUERY)),
+				DEFAULT_LIST_ALL_RECORDS_QUERY
+		);
+		listAllRecordsResultsPath = (String) ObjectUtils.firstNonNull(
+				StringUtils.trimToNull(this.smssProp.getProperty(LIST_ALL_RECORDS_RESULTS_PATH)),
+				DEFAULT_LIST_ALL_RECORDS_RESULTS_PATH
+		);
+		nearestNeighborQuery= (String) ObjectUtils.firstNonNull(
+				StringUtils.trimToNull(this.smssProp.getProperty(NEAREST_NEIGHBOR_QUERY)),
+				DEFAULT_NEAREST_NEIGHBOR_QUERY
+		);
+		nearestNeighborResultsPath = (String) ObjectUtils.firstNonNull(
+				StringUtils.trimToNull(this.smssProp.getProperty(NEAREST_NEIGHBOR_RESULTS_PATH)),
+				DEFAULT_NEAREST_NEIGHBOR_RESULTS_PATH
+		);
 	}
 	
 	@Override
@@ -168,6 +304,10 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 	@SuppressWarnings("unchecked")
 	@Override
 	public List<FileEmbeddingStatus> addEmbeddings(VectorDatabaseCSVTable vectorCsvTable, Insight insight, Map<String, Object> parameters) throws Exception {
+		if(externallyManagedIndex) {
+			throw new NotImplementedException("Embeddings are disabled for this instance");
+		}
+		
 		if (!modelPropsLoaded) {
 			verifyModelProps();
 		}
@@ -282,6 +422,10 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 
 	@Override
 	public void removeDocument(List<String> fileNames, Map<String, Object> parameters) throws IOException {
+		if(externallyManagedIndex) {
+			throw new NotImplementedException("Document management features are disabled for this instance");
+		}
+		
 		String indexClass = this.defaultIndexClass;
 		if (parameters.containsKey("indexClass")) {
 			indexClass = (String) parameters.get("indexClass");
@@ -353,340 +497,461 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 		}
 	}
 	
-	public List<Map<String, Object>> customNearestNeighborSearch(Insight insight, String searchStatement, Number limit, Map<String, Object> parameters, boolean meta) {
+	@SuppressWarnings("unchecked")
+	@Override
+	public List<Map<String, Object>> nearestNeighborCall(Insight insight, String searchStatement, Number limit, Map<String, Object> parameters) {
+		Gson gson = new Gson();
 		
-		/**
-		 * Flow:
-		 * 1. From SMSS, check custom json template or not
-		 * 1a. If not, pass this on to the original nearest neighbor call function.
-		 * 1b. If so, use the custom template and string substitute the search phrase into the json template
-		 * 2. Call <index>/_search
-		 * 3. From SMSS, check to see if there's a custom results path or not
-		 * 3a. If not, get via parent hits.hits
-		 * 3b. If so, get via the custom results path
-		 * 4. Are we asking for metadata through the meta param?
-		 * 4a. If not, done
-		 * 4b. If so, iterate over hits.hits._source and create map for each doc, then done
-		 */
-		
-		/**
-		 * 1
-		 */
-		JsonObject search = null;
-		if (this.customTemplateQuery != null) {
-			classLogger.info("Found a custom template query for this engine");
-			// Use Gson to properly escape the search statement for JSON
-			String escapedSearchStatement = new Gson().toJson(searchStatement);
-			String query = String.valueOf(this.customTemplateQuery)
-				.replace("\"%QUERY_PLACEHOLDER%\"", escapedSearchStatement)
-				.replace("%%LIMIT%%", limit.toString());
-			classLogger.info(query);
-			try {
-				search = JsonParser.parseString(query).getAsJsonObject();
-				// From the custom query template, get the metadata field keys under highlight > fields
-				if (highlightFieldKeys == null) {
-					highlightFieldKeys = new ArrayList<>();
-					JsonObject highlightFields = search.getAsJsonObject("highlight").getAsJsonObject("fields");
-					for (Map.Entry<String, JsonElement> entry : highlightFields.entrySet()) {
-						String fieldName = entry.getKey();
-						highlightFieldKeys.add(fieldName);
-					}
-				}
-				classLogger.info(highlightFieldKeys);
-			} catch (Exception e) {
-				classLogger.error(e);
-				throw e;
-			}
-		} else {
-			classLogger.info("No template query found, using default search");
-			
+		String vectorString = "";
+		if(nearestNeighborQuery.contains("${VECTOR}")) {
 			if (!this.modelPropsLoaded) {
 				verifyModelProps();
 			}
-			
-			search = getNearestNeighborSearchJson(insight, searchStatement, limit, parameters);
+			if (insight == null) {
+				throw new IllegalArgumentException("Insight must be provided to run Model Engine Encoder");
+			}
+			IModelEngine engine = Utility.getModel(this.embedderEngineId);
+			EmbeddingsModelEngineResponse embeddingsResponse = engine.embeddings(Arrays.asList(new String[] {searchStatement}), insight, null);
+			vectorString = gson.toJson(convertListNumToJsonArray(embeddingsResponse.getResponse().get(0)));
 		}
 		
-		classLogger.info(search);
+		int size;
+		int limitParam = (limit == null) ? queryLimit : limit.intValue();
+		int sizeParam = queryLimit;
+		if(parameters.containsKey("size")) {
+			try {
+				sizeParam = Integer.parseInt(parameters.get("size")+"");
+			} catch(NumberFormatException e) {
+				classLogger.warn("Given illegal size parameter: ", e.getMessage());
+			}
+		}
+		size = Math.min(limitParam, sizeParam);
 		
-		/**
-		 * 2
-		 */
-		String url = this.clusterUrl + "/" + this.indexName + SEARCH_ENDPOINT;
-		Map<String, String> headersMap = new HashMap<>();
-		headersMap.put(HttpHeaders.AUTHORIZATION, "Basic " + getCredsBase64Encoded());
-		headersMap.put(HttpHeaders.CONTENT_TYPE, "application/json");
-
-		String response = HttpHelperUtility.postRequestStringBody(url, headersMap, search.toString(), ContentType.APPLICATION_JSON, null, null, null);
+		int k;
+		int kParam = queryLimit;
+		if(parameters.containsKey("k")) {
+			try {
+				kParam = Integer.parseInt(parameters.get("k")+"");
+			} catch(NumberFormatException e) {
+				classLogger.warn("Given illegal size parameter: ", e.getMessage());
+			}
+		}
+		k = Math.min(kParam, 9999);
+		
+		int baseFrom;
+		int fromParam = 0;
+		if(parameters.containsKey("from")) {
+			try {
+				fromParam = Integer.parseInt(parameters.get("from")+"");
+			} catch(NumberFormatException e) {
+				classLogger.warn("Given illegal from parameter: ", e.getMessage());
+			}
+		}
+		baseFrom = Math.max(fromParam, 0);
+		
+		Object metaParameter = parameters.get("meta");
+		boolean meta = metaParameter != null && Boolean.parseBoolean(metaParameter.toString());
+		
+		List<IQueryFilter> filters = (List<IQueryFilter>) parameters.remove("filters");
+		if(filters == null) {
+			filters = new ArrayList<>();
+		}
+		List<IQueryFilter> pageFilters = new ArrayList<>(filters);
+		JsonObject filterObject = getFilterObject(pageFilters);
+		String filter = new Gson().toJson(filterObject);
+		
 		Configuration configuration = Configuration.builder()
-				.jsonProvider(new GsonJsonProvider())
-				.build();
-		DocumentContext jsonContext = JsonPath.using(configuration).parse(response);
+			.jsonProvider(new GsonJsonProvider())
+			.build();
 		
 		List<Map<String, Object>> vectorSearchResults = new ArrayList<>();
+		Map<String, Object> metaData = new HashMap<>();
 		
-		/**
-		 * 3
-		 */
-		String resultsPath = this.customResultsPath == null ? "$.hits.hits[*]" : this.customResultsPath;
-		JsonArray hits;
-		try {
-			hits = jsonContext.read(resultsPath);
-		} catch (Exception e1) {
-			throw new RuntimeException("Failed to parse results using path: " + resultsPath, e1);
-		}
-		
-		classLogger.info(hits);
-		for(JsonElement e : hits) {
-			JsonObject hitJson = e.getAsJsonObject();
-			Map<String, Object> thisMatch = new HashMap<>();
-			vectorSearchResults.add(thisMatch);
+		int remainingToFetch = size;
+		Map<String, String> replacements = new HashMap<>();
+		do {
+			int batchSize;
+			if(remainingToFetch > batchLimit) {
+				batchSize = batchLimit;
+			} else {
+				batchSize = remainingToFetch;
+			}
 			
-			Double score = (Double) hitJson.get("_score").getAsDouble();
+			replacements.clear();
+			replacements.put("FROM", Integer.toString(size-remainingToFetch + baseFrom));
+			replacements.put("SIZE", Integer.toString(batchSize));
+			replacements.put("FILTER", filter);
+			replacements.put("QUERY", StringEscapeUtils.escapeJava(searchStatement));
+			replacements.put("EMBEDDINGS", this.embeddings);
+			replacements.put("VECTOR", vectorString);
+			replacements.put("K", Integer.toString(k));
 			
-			// Add base information
-			thisMatch.put("Score", score);
+			StringSubstitutor substitutor = new StringSubstitutor(replacements);
+			substitutor.setEnableSubstitutionInVariables(true);
+			String searchString = substitutor.replace(nearestNeighborQuery);
 			
-			JsonObject sourceDetails = hitJson.get("_source").getAsJsonObject();
-			thisMatch.put(VectorDatabaseCSVTable.CONTENT, sourceDetails.get(VectorDatabaseCSVTable.CONTENT).getAsString());
-			thisMatch.put(VectorDatabaseCSVTable.SOURCE, sourceDetails.get(VectorDatabaseCSVTable.SOURCE).getAsString());
-			thisMatch.put(VectorDatabaseCSVTable.MODALITY, sourceDetails.get(VectorDatabaseCSVTable.MODALITY).getAsString());
-			thisMatch.put(VectorDatabaseCSVTable.DIVIDER, sourceDetails.get(VectorDatabaseCSVTable.DIVIDER).getAsString());
-			thisMatch.put(VectorDatabaseCSVTable.PART, sourceDetails.get(VectorDatabaseCSVTable.PART).getAsString());
-			thisMatch.put(VectorDatabaseCSVTable.TOKENS, sourceDetails.get(VectorDatabaseCSVTable.TOKENS).getAsLong());
-		}
+			String searchResponse = getSearchResponse(searchString);
+			DocumentContext jsonContext = JsonPath.using(configuration).parse(searchResponse);
 			
-		/**
-		 * 4
-		 */
-		if(meta) {
-			JsonArray metaHits = jsonContext.read("$.hits.hits[*]");
+			Set<String> hitKeys = new HashSet<>();
 			
-			Map<String, Object> metaMatch = new HashMap<>();
-			vectorSearchResults.add(metaMatch);
-			
-			for(JsonElement e : metaHits) {
+			JsonArray hits = jsonContext.read(nearestNeighborResultsPath);
+			for(JsonElement e : hits) {
 				JsonObject hitJson = e.getAsJsonObject();
 				Map<String, Object> thisMatch = new HashMap<>();
+				vectorSearchResults.add(thisMatch);
+				remainingToFetch--;
 				
 				Double score = (Double) hitJson.get("_score").getAsDouble();
+				
+				// Add base information
 				thisMatch.put("Score", score);
 				
 				JsonObject sourceDetails = hitJson.get("_source").getAsJsonObject();
-				if(!sourceDetails.has(VectorDatabaseCSVTable.SOURCE)) {
-					continue;
-				}
 				String source = sourceDetails.get(VectorDatabaseCSVTable.SOURCE).getAsString();
-				thisMatch.putAll(sourceDetails.asMap());
+				hitKeys.add(source);
 				
-				metaMatch.put(source, thisMatch);
+				thisMatch.put(VectorDatabaseCSVTable.CONTENT, sourceDetails.get(VectorDatabaseCSVTable.CONTENT).getAsString());
+				thisMatch.put(VectorDatabaseCSVTable.SOURCE, source);
+				thisMatch.put(VectorDatabaseCSVTable.MODALITY, sourceDetails.get(VectorDatabaseCSVTable.MODALITY).getAsString());
+				thisMatch.put(VectorDatabaseCSVTable.DIVIDER, sourceDetails.get(VectorDatabaseCSVTable.DIVIDER).getAsString());
+				thisMatch.put(VectorDatabaseCSVTable.PART, sourceDetails.get(VectorDatabaseCSVTable.PART).getAsString());
+				thisMatch.put(VectorDatabaseCSVTable.TOKENS, sourceDetails.get(VectorDatabaseCSVTable.TOKENS).getAsLong());
 			}
-		}
-		
-		return vectorSearchResults;
-	}
-	
-	private void addMetadataToMatch(Map<String, Object> thisMatch, JsonObject hitJson) {
-		if (highlightFieldKeys != null && !highlightFieldKeys.isEmpty()) {
-			JsonObject sourceDetails = hitJson.get("_source").getAsJsonObject();
-			Map<String, Object> meta = new HashMap<>();
-			thisMatch.put("meta", meta);
-			for (String fieldKey : highlightFieldKeys) {
-				try {
-					JsonElement fieldElement = sourceDetails.get(fieldKey);
-					if (fieldElement != null && !fieldElement.isJsonNull()) {
-						if (fieldElement.isJsonArray()) {
-							meta.put(fieldKey, fieldElement.getAsJsonArray().toString());
-						} else if (fieldElement.isJsonPrimitive()) {
-							meta.put(fieldKey, fieldElement.getAsString());
-						} else if (fieldElement.isJsonObject()) {
-							meta.put(fieldKey, fieldElement.getAsJsonObject().toString());
-						} else {
-							meta.put(fieldKey, fieldElement.toString());
-						}
-					} else {
-						meta.put(fieldKey, null);
-					}
-				} catch (Exception e) {
-					classLogger.warn("Failed to extract metadata field '{}' from hit: {}", fieldKey, e.getMessage());
-					thisMatch.put(fieldKey, null);
-				}
-			}
-		}
-	}
-	
-	@Override
-	public List<Map<String, Object>> nearestNeighborCall(Insight insight, String searchStatement, Number limit, Map<String, Object> parameters) {
-		if (insight == null) {
-			throw new IllegalArgumentException("Insight must be provided to run Model Engine Encoder");
-		}
-
-		if (!this.modelPropsLoaded) {
-			verifyModelProps();
-		}
-		
-		JsonObject search = getNearestNeighborSearchJson(insight, searchStatement, limit, parameters);
-		
-		classLogger.debug("OPENSEARCH FINAL SEARCH QUERY : " + search.toString());
-
-		String url = this.clusterUrl + "/" + this.indexName + SEARCH_ENDPOINT;
-		Map<String, String> headersMap = new HashMap<>();
-		headersMap.put(HttpHeaders.AUTHORIZATION, "Basic " + getCredsBase64Encoded());
-		headersMap.put(HttpHeaders.CONTENT_TYPE, "application/json");
-
-		String response = HttpHelperUtility.postRequestStringBody(url, headersMap, search.toString(), ContentType.APPLICATION_JSON, null, null, null);
-		JsonObject responseJson = JsonParser.parseString(response).getAsJsonObject();
-		
-		JsonArray hits = getHitsFromSearch(responseJson);
-		
-		List<Map<String, Object>> vectorSearchResults = new ArrayList<>();
-		for(JsonElement e : hits) {
-			Map<String, Object> thisMatch = new HashMap<>();
-			vectorSearchResults.add(thisMatch);
-
-			JsonObject hitJson = e.getAsJsonObject();
-			Double score = (Double) hitJson.get("_score").getAsDouble();
-			thisMatch.put("Score", score);
 			
-			JsonObject sourceDetails = hitJson.get("_source").getAsJsonObject();
-			thisMatch.put(VectorDatabaseCSVTable.SOURCE, sourceDetails.get(VectorDatabaseCSVTable.SOURCE).getAsString());
-			thisMatch.put(VectorDatabaseCSVTable.MODALITY, sourceDetails.get(VectorDatabaseCSVTable.MODALITY).getAsString());
-			thisMatch.put(VectorDatabaseCSVTable.DIVIDER, sourceDetails.get(VectorDatabaseCSVTable.DIVIDER).getAsString());
-			thisMatch.put(VectorDatabaseCSVTable.PART, sourceDetails.get(VectorDatabaseCSVTable.PART).getAsString());
-			thisMatch.put(VectorDatabaseCSVTable.TOKENS, sourceDetails.get(VectorDatabaseCSVTable.TOKENS).getAsLong());
-			thisMatch.put(VectorDatabaseCSVTable.CONTENT, sourceDetails.get(VectorDatabaseCSVTable.CONTENT).getAsString());
+			if(meta) {
+				JsonArray metaHits = jsonContext.read("$.hits.hits[*]");
+				for(JsonElement e : metaHits) {
+					JsonObject hitJson = e.getAsJsonObject();
+					Map<String, Object> thisMatch = new HashMap<>();
+					
+					Double score = (Double) hitJson.get("_score").getAsDouble();
+					thisMatch.put("Score", score);
+					
+					JsonObject sourceDetails = hitJson.get("_source").getAsJsonObject();
+					if(!sourceDetails.has(VectorDatabaseCSVTable.SOURCE)) {
+						continue;
+					}
+					String source = sourceDetails.get(VectorDatabaseCSVTable.SOURCE).getAsString();
+					thisMatch.putAll(sourceDetails.asMap());
+					
+					if(!metaData.containsKey(source)) {
+						hitKeys.add(source);
+						metaData.put(source, thisMatch);
+						remainingToFetch--;
+					}
+				}
+			}
+			
+			if(hitKeys.isEmpty()) {
+				break;
+			}
+		} while(remainingToFetch > 0);
+		
+		if(meta) {
+			vectorSearchResults.add(metaData);
 		}
+		
 		return vectorSearchResults;
 	}
-
 	
-	protected JsonObject getNearestNeighborSearchJson(Insight insight, String searchStatement, Number limit,
-			Map<String, Object> parameters) {
-		IModelEngine engine = Utility.getModel(this.embedderEngineId);
-		EmbeddingsModelEngineResponse embeddingsResponse = engine.embeddings(Arrays.asList(new String[] {searchStatement}), insight, null);
-		List<Double> searchStatementEmbedding = embeddingsResponse.getResponse().get(0);
-		
-		JsonObject search = new JsonObject();
-		search.addProperty("size", limit);
-		{
-			JsonObject query = new JsonObject();
-			{
-				JsonObject knn = new JsonObject();
-				{
-					JsonObject embedding = new JsonObject();
-					embedding.add("vector", convertListNumToJsonArray(searchStatementEmbedding));
-					embedding.addProperty("k", limit);
-					
-					if (parameters.containsKey("filters")) {
-						JsonObject filter = getFilterAggregation(parameters);
-						embedding.add("filter", filter);
-					}
-					knn.add(this.embeddings, embedding);
-				}
-				query.add("knn", knn);
-			}
-			search.add("query", query);
-		}
-		return search;
-	}
-
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
 	public List<Map<String, Object>> listDocuments(Map<String, Object> parameters) {
+		int size;
+		Integer sizeParam = null;
+		if(parameters.containsKey("size")) {
+			try {
+				sizeParam = Integer.valueOf(parameters.get("size")+"");
+			} catch(NumberFormatException e) {
+				classLogger.warn("Given illegal size parameter: ", e.getMessage());
+			}
+		}
+		if(sizeParam != null && sizeParam > 0) {
+			size = sizeParam;
+		} else {
+			size = queryLimit;
+		}
 		
-		JsonObject search = getListDocumentSearchJson(parameters);
-
-		String url = this.clusterUrl + "/" + this.indexName + SEARCH_ENDPOINT;// + "?search_type=count";
-		Map<String, String> headersMap = new HashMap<>();
-		headersMap.put(HttpHeaders.AUTHORIZATION, "Basic " + getCredsBase64Encoded());
-		headersMap.put(HttpHeaders.CONTENT_TYPE, "application/json");
-
-		String response = HttpHelperUtility.postRequestStringBody(url, headersMap, search.toString(), ContentType.APPLICATION_JSON, null, null, null);
-		JsonObject responseJson = JsonParser.parseString(response).getAsJsonObject();
-		JsonArray bucketsArr = responseJson.getAsJsonObject("aggregations").getAsJsonObject(UNIQUE_SOURCES).getAsJsonObject(FILTERED_SOURCES).getAsJsonArray("buckets");
+		String searchAfter;
+		Object searchAfterObj = parameters.get("search_after");
+		if(searchAfterObj != null) {
+			searchAfter = StringUtils.trimToNull(searchAfterObj.toString());
+		} else {
+			searchAfter = null;
+		}
 		
 		String indexClass = this.defaultIndexClass;
 		if (parameters.containsKey("indexClass")) {
 			indexClass = (String) parameters.get("indexClass");
 		}
-
+		
+		List<IQueryFilter> filters = (List<IQueryFilter>) parameters.remove("filters");
+		if(filters == null) {
+			filters = new ArrayList<>();
+		}
+		
+		LinkedHashSet<String> sources = new LinkedHashSet<>();
+		List<Map<String, Object>> metaData = new LinkedList<>();
+		int remainingToFetch = size;
+		Map<String, String> replacements = new HashMap<>();
+		do {
+			int batchSize;
+			if(remainingToFetch > queryLimit) {
+				batchSize = queryLimit;
+			} else {
+				batchSize = remainingToFetch;
+			}
+			
+			List<IQueryFilter> pageFilters = new ArrayList<>(filters);
+			if(searchAfter != null) {
+				IQueryFilter sourceFilter = SimpleQueryFilter.makeColToValFilter(VectorDatabaseCSVTable.SOURCE, ">", "${SOURCE_OFFSET}");
+				pageFilters.add(sourceFilter);
+				if(pageFilters.size() > 1) {
+					pageFilters = Lists.newArrayList(new AndQueryFilter(pageFilters));
+				}
+			}
+			JsonObject filterObject = getFilterObject(pageFilters);
+			String filter = new Gson().toJson(filterObject);
+			
+			replacements.clear();
+			replacements.put("SOURCE_OFFSET", StringEscapeUtils.escapeJava(searchAfter));
+			replacements.put("SIZE", Integer.toString(batchSize));
+			replacements.put("FILTER", filter);
+			
+			StringSubstitutor substitutor = new StringSubstitutor(replacements);
+			substitutor.setEnableSubstitutionInVariables(true);
+			String searchString = substitutor.replace(listDocumentsQuery);
+			
+			String searchResponse = getSearchResponse(searchString);
+			List<Object> pageResult = JsonPath.read(searchResponse, listDocumentsResultsPath);
+			
+			for(Object o : pageResult) {
+				Map<String, Object> resMap;
+				if(o instanceof Map) {
+					resMap = (Map<String, Object>) o;
+				} else {
+					resMap = new HashMap<>();
+					resMap.put(VectorDatabaseCSVTable.SOURCE, o);
+				}
+				
+				Map<String, Object> data = new HashMap<>();
+				for(String key : resMap.keySet()) {
+					Object valObj = resMap.get(key);
+					List valList;
+					if(valObj == null || !(valObj instanceof List)) {
+						valList = Lists.newArrayList(valObj);
+					} else {
+						valList = (List) valObj;
+					}
+					
+					if(!valList.isEmpty()) {
+						data.put(key, valList.get(0));
+						if(VectorDatabaseCSVTable.SOURCE.equalsIgnoreCase(key)) {
+							sources.add(valList.get(0)+"");
+						}
+					}
+				}
+				metaData.add(data);
+			}
+			searchAfter = sources.getLast();
+			
+			remainingToFetch -= batchSize;
+		} while(remainingToFetch > 0);
+		
 		File documentsDir = new File(this.schemaFolder.getAbsolutePath() + FILE_SEPARATOR + indexClass + FILE_SEPARATOR + DOCUMENTS_FOLDER_NAME);
-
 		List<Map<String, Object>> returnSources = new ArrayList<>();
-		for (JsonElement bucket : bucketsArr) {
-			JsonObject bucketDetails = bucket.getAsJsonObject();
+		for (String source : sources) {
 			Map<String, Object> fileInfo = new HashMap<>();
-			String fileName = bucketDetails.get("key").getAsString();
-			fileInfo.put("fileName", fileName);
-
-			File thisF = new File(documentsDir, fileName);
+			fileInfo.put("fileName", source);
+			File thisF = new File(documentsDir, source);
 			if(thisF.exists() && thisF.isFile()) {
 				long fileSizeInBytes = thisF.length();
 				double fileSizeInMB = (double) fileSizeInBytes / (1024);
 				SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 				String lastModified = dateFormat.format(new Date(thisF.lastModified()));
-
 				// add file size and last modified into the map
 				fileInfo.put("fileSize", fileSizeInMB);
 				fileInfo.put("lastModified", lastModified);
 			}
-
 			returnSources.add(fileInfo);
 		}
-
+		
+		Object metaParameter = parameters.get("meta");
+		if(metaParameter != null && Boolean.parseBoolean(metaParameter.toString())) {
+			Map<String, Object> metaMatch = new HashMap<>();
+			for(Map<String, Object> m : metaData) {
+				String source = m.get(VectorDatabaseCSVTable.SOURCE)+"";
+				metaMatch.put(source, m);
+			}
+			returnSources.add(metaMatch);
+		}
 		return returnSources;
 	}
+  
+	public List<Map<String, Object>> listAllRecords() {
+		return listAllRecords(new HashMap<>());
+	}
 
-	protected JsonObject getListDocumentSearchJson(Map<String, Object> parameters) {
-		JsonObject filter = null;
-		if (parameters.containsKey("filters")) {
-			filter = getFilterAggregation(parameters);
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	public List<Map<String, Object>> listAllRecords(Map<String, Object> parameters) {
+		int size;
+		Integer sizeParam = null;
+		if(parameters.containsKey("size")) {
+			try {
+				sizeParam = Integer.valueOf(parameters.get("size")+"");
+			} catch(NumberFormatException e) {
+				classLogger.warn("Given illegal size parameter: ", e.getMessage());
+			}
+		}
+		if(sizeParam != null && sizeParam > 0) {
+			size = sizeParam;
 		} else {
-			filter = new JsonObject();
-			{
-				JsonObject matchAll = new JsonObject();
-				filter.add("match_all", matchAll);
+			size = queryLimit;
+		}
+		
+		String searchAfter;
+		Object searchAfterObj = parameters.get("search_after");
+		if(searchAfterObj != null) {
+			searchAfter = StringUtils.trimToNull(searchAfterObj.toString());
+		} else {
+			searchAfter = null;
+		}
+		
+		boolean canSearchAfter = listAllRecordsQuery.contains("${SEARCH_AFTER}");
+		
+		String sourceAfter = searchAfter;
+		int indexAfter = -1;
+		if(searchAfter != null) {
+			int underscoreLocation = searchAfter.lastIndexOf('_');
+			if(underscoreLocation > 0) {
+				sourceAfter = searchAfter.substring(0, underscoreLocation);
+				try {
+					indexAfter = Integer.parseInt(searchAfter.substring(underscoreLocation+1));
+				} catch(NumberFormatException e) {
+					//ignore
+				}
 			}
 		}
 		
-		JsonObject search = new JsonObject();
-		search.addProperty("size", 0);
-		{
-			if (filter != null) {
-				search.add("query", filter);
-			}
-			
-			JsonObject aggs = new JsonObject();
-			{
-				JsonObject uniqueSources = new JsonObject();
-				{
-					uniqueSources.add("filter", filter);
-					
-					JsonObject nestedAggs = new JsonObject();
-					{
-						JsonObject filteredSources = new JsonObject();
-						{	
-							JsonObject terms = new JsonObject();
-							terms.addProperty("field", VectorDatabaseCSVTable.SOURCE);
-							terms.addProperty("min_doc_count", 1);
-							// Pull up to 9999 unique terms for the aggregation
-							terms.addProperty("size", 9999);
-							filteredSources.add("terms", terms);
-						}
-						nestedAggs.add(FILTERED_SOURCES, filteredSources);
-					}
-					uniqueSources.add("aggs", nestedAggs);
-				}
-				aggs.add(UNIQUE_SOURCES, uniqueSources);
-			}
-			search.add("aggs", aggs);
+		List<IQueryFilter> filters = (List<IQueryFilter>) parameters.remove("filters");
+		if(filters == null) {
+			filters = new ArrayList<>();
 		}
-		return search;
+		
+		LinkedList<Map<String, Object>> rows = new LinkedList<>();
+		
+		int remainingToFetch = size;
+		Map<String, String> replacements = new HashMap<>();
+		
+		pageProcessing: {
+			do {
+				int batchSize;
+				if(remainingToFetch > queryLimit) {
+					batchSize = queryLimit;
+				} else {
+					batchSize = remainingToFetch;
+				}
+				
+				List<IQueryFilter> pageFilters = new ArrayList<>(filters);
+				String searchAfterClause = "";
+				if(sourceAfter != null) {
+					IQueryFilter sourceFilter = SimpleQueryFilter.makeColToValFilter(VectorDatabaseCSVTable.SOURCE, ">=", "${SOURCE_OFFSET}");
+					pageFilters.add(sourceFilter);
+					if(pageFilters.size() > 1) {
+						pageFilters = Lists.newArrayList(new AndQueryFilter(pageFilters));
+					}
+					searchAfterClause = ", \"search_after\": [\"${SOURCE_OFFSET}\", ${CHUNK_OFFSET}]";
+				}
+				JsonObject filterObject = getFilterObject(pageFilters);
+				String filter = new Gson().toJson(filterObject);
+				
+				replacements.clear();
+				replacements.put("SOURCE_OFFSET", StringEscapeUtils.escapeJava(sourceAfter));
+				replacements.put("CHUNK_OFFSET", Integer.toString(indexAfter));
+				replacements.put("SIZE", Integer.toString(batchSize));
+				replacements.put("FILTER", filter);
+				replacements.put("SEARCH_AFTER", searchAfterClause);
+				
+				StringSubstitutor substitutor = new StringSubstitutor(replacements);
+				substitutor.setEnableSubstitutionInVariables(true);
+				String searchString = substitutor.replace(listAllRecordsQuery);
+				
+				String searchResponse = getSearchResponse(searchString);
+				
+				Integer totalHits = JsonPath.read(searchResponse, "$.hits.total.value");
+				if(totalHits == 0) {
+					break;
+				}
+				
+				List<Object> pageResult = JsonPath.read(searchResponse, listAllRecordsResultsPath);
+				if(pageResult == null || pageResult.isEmpty()) {
+					break;
+				}
+				for(Object o : pageResult) {
+					Map<String, Object> resMap = (Map<String, Object>) o;
+					List<Map<String, Object>> chunksForEntry = new ArrayList<>();
+					for(String key : resMap.keySet()) {
+						Object valObj = resMap.get(key);
+						
+						List valList;
+						if(valObj == null || !(valObj instanceof List)) {
+							valList = Lists.newArrayList(valObj);
+						} else {
+							valList = (List) valObj;
+						}
+						
+						for(int i=0; i<valList.size(); i++) {
+							if(chunksForEntry.size() <= i) {
+								chunksForEntry.add(new HashMap<>());
+							}
+							chunksForEntry.get(i).put(key, valList.get(i));
+						}
+					}
+					if(chunksForEntry.isEmpty()) {
+						continue;
+					}
+					String sourceForEntry = (String) chunksForEntry.get(0).get(VectorDatabaseCSVTable.SOURCE);
+					if(!sourceForEntry.equals(sourceAfter)) {
+						sourceAfter = sourceForEntry;
+						indexAfter = -1;
+					}
+					
+					// if we can form a chunk_offset-specific search_after then we want to add all results
+					// otherwise we may need to start in the middle of a document's chunk array
+					int startingIndex = 0;
+					if(!canSearchAfter) {
+						startingIndex = indexAfter + 1;
+					}
+					for(int i=startingIndex; i<chunksForEntry.size(); i++) {
+						rows.add(chunksForEntry.get(i));
+						indexAfter++;
+						remainingToFetch--;
+						if(remainingToFetch <= 0) {
+							break pageProcessing;
+						}
+					}
+				}
+				if(totalHits <= batchSize) {
+					break;
+				}
+			} while(remainingToFetch > 0);
+		}
+		return rows;
 	}
-
-	@SuppressWarnings("unchecked")
-	protected JsonObject getFilterAggregation(Map<String, Object> parameters) {
+	
+	/**
+	 * 
+	 * @param filters
+	 * @return
+	 */
+	protected JsonObject getFilterObject(List<IQueryFilter> filters) {
 		JsonObject filterParent = new JsonObject();
-		{
+		if(filters.isEmpty()) {
+			JsonObject matchAll = new JsonObject();
+			filterParent.add("match_all", matchAll);
+		} else {
 			JsonObject filterBool = new JsonObject();
 			{
 				//Filtration logic starts here
@@ -699,7 +964,6 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 				//must not contains not equals to filters
 				JsonArray must_not = new JsonArray();
 
-				List<IQueryFilter> filters = (List<IQueryFilter>) parameters.remove("filters");
 				for(IQueryFilter queryFilter : filters) {
 					RestVectorQueryFilterTranslationHelper.processFilter(queryFilter, filter, should, must_not);
 				}
@@ -717,62 +981,18 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 		}
 		return filterParent;
 	}
-  
-	public List<Map<String, Object>> listAllRecords() {
-		return listAllRecords(new HashMap<>());
-	}
-
-	@Override
-	public List<Map<String, Object>> listAllRecords(Map<String, Object> parameters) {
-		JsonObject search = getListAllRecordsSearchJson(parameters);
-
-		String url = this.clusterUrl + "/" + this.indexName + SEARCH_ENDPOINT + "?size=10000";
+	
+	/**
+	 * 
+	 * @param searchBody
+	 * @return
+	 */
+	protected String getSearchResponse(String searchBody) {
+		String url = this.clusterUrl + "/" + this.indexName + SEARCH_ENDPOINT;
 		Map<String, String> headersMap = new HashMap<>();
-		headersMap.put(HttpHeaders.AUTHORIZATION, getCredsBase64Encoded());
+		headersMap.put(HttpHeaders.AUTHORIZATION, "Basic " + getCredsBase64Encoded());
 		headersMap.put(HttpHeaders.CONTENT_TYPE, "application/json");
-
-		String response = HttpHelperUtility.postRequestStringBody(url, headersMap, search.toString(), ContentType.APPLICATION_JSON, null, null, null);
-		JsonObject responseJson = JsonParser.parseString(response).getAsJsonObject();
-		JsonArray hits = getHitsFromSearch(responseJson);
-		
-		List<Map<String, Object>> allDocuments = new ArrayList<>();
-		for(JsonElement e : hits) {
-			Map<String, Object> thisDocument = new HashMap<>();
-			allDocuments.add(thisDocument);
-
-			JsonObject fields = e.getAsJsonObject().get("fields").getAsJsonObject();
-			thisDocument.put(VectorDatabaseCSVTable.SOURCE, fields.get(VectorDatabaseCSVTable.SOURCE).getAsString());
-			thisDocument.put(VectorDatabaseCSVTable.MODALITY, fields.get(VectorDatabaseCSVTable.MODALITY).getAsString());
-			thisDocument.put(VectorDatabaseCSVTable.DIVIDER, fields.get(VectorDatabaseCSVTable.DIVIDER).getAsString());
-			thisDocument.put(VectorDatabaseCSVTable.PART, fields.get(VectorDatabaseCSVTable.PART).getAsString());
-			thisDocument.put(VectorDatabaseCSVTable.TOKENS, fields.get(VectorDatabaseCSVTable.TOKENS).getAsLong());
-			thisDocument.put(VectorDatabaseCSVTable.CONTENT, fields.get(VectorDatabaseCSVTable.CONTENT).getAsString());
-		}
-		
-		return allDocuments;
-	}
-
-	protected JsonObject getListAllRecordsSearchJson(Map<String, Object> parameters) {
-		JsonObject search = new JsonObject();
-		{
-			if (parameters.containsKey("filters")) {
-				JsonObject filter = getFilterAggregation(parameters);
-				search.add("query", filter);
-			}
-			
-			JsonArray fields = new JsonArray();
-			{	
-				fields.add(VectorDatabaseCSVTable.SOURCE);
-				fields.add(VectorDatabaseCSVTable.MODALITY);
-				fields.add(VectorDatabaseCSVTable.DIVIDER);
-				fields.add(VectorDatabaseCSVTable.PART);
-				fields.add(VectorDatabaseCSVTable.TOKENS);
-				fields.add(VectorDatabaseCSVTable.CONTENT);
-			}
-			search.add("fields", fields);
-			search.addProperty("_source", false);
-		}
-		return search;
+		return HttpHelperUtility.postRequestStringBody(url, headersMap, searchBody, ContentType.APPLICATION_JSON, null, null, null);
 	}
 	
 	/**
@@ -794,7 +1014,7 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 	public JsonArray getSearchResultsWithFilters(JsonObject searchObject) {
 		String url = this.clusterUrl + "/" + this.indexName + SEARCH_ENDPOINT;
 		Map<String, String> headersMap = new HashMap<>();
-		headersMap.put(HttpHeaders.AUTHORIZATION, getCredsBase64Encoded());
+		headersMap.put(HttpHeaders.AUTHORIZATION, "Basic " + getCredsBase64Encoded());
 		headersMap.put(HttpHeaders.CONTENT_TYPE, "application/json");
 
 		String response = HttpHelperUtility.postRequestStringBody(url, headersMap, searchObject.toString(), ContentType.APPLICATION_JSON, null, null, null);
@@ -816,8 +1036,8 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 	 * @param m
 	 */
 	private void getIndex(String specificIndexName, String embeddings, int dimension, String methodName, String spaceType, String engine, int efConstruction, int m) {
-		Boolean exisits = doesIndexExist(specificIndexName);
-		if(!exisits) {
+		Boolean exists = doesIndexExist(specificIndexName);
+		if(!exists) {
 			createIndex(specificIndexName, embeddings, dimension, methodName, spaceType, engine, efConstruction, m);
 		}
 	}

--- a/src/prerna/engine/impl/vector/OpenSearchRestVectorDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/OpenSearchRestVectorDatabaseEngine.java
@@ -754,7 +754,12 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 				}
 				metaData.add(data);
 			}
-			searchAfter = sources.getLast();
+			
+			if(sources.isEmpty() || pageResult.isEmpty()) {
+				break;
+			} else {
+				searchAfter = sources.getLast();
+			}
 			
 			remainingToFetch -= batchSize;
 		} while(remainingToFetch > 0);

--- a/src/prerna/engine/impl/vector/OpenSearchRestVectorDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/OpenSearchRestVectorDatabaseEngine.java
@@ -581,7 +581,7 @@ public class OpenSearchRestVectorDatabaseEngine extends AbstractVectorDatabaseEn
 			replacements.put("FROM", Integer.toString(size-remainingToFetch + baseFrom));
 			replacements.put("SIZE", Integer.toString(batchSize));
 			replacements.put("FILTER", filter);
-			replacements.put("QUERY", StringEscapeUtils.escapeJava(searchStatement));
+			replacements.put("QUERY", gson.toJson(searchStatement));
 			replacements.put("EMBEDDINGS", this.embeddings);
 			replacements.put("VECTOR", vectorString);
 			replacements.put("K", Integer.toString(k));

--- a/src/prerna/engine/impl/vector/RestVectorQueryFilterTranslationHelper.java
+++ b/src/prerna/engine/impl/vector/RestVectorQueryFilterTranslationHelper.java
@@ -248,18 +248,35 @@ public final class RestVectorQueryFilterTranslationHelper {
 				{
 					JsonObject column = new JsonObject();
 					{
-						if (thisComparator.equals("<")) {							
-							column.addProperty("lt", new BigDecimal(rightComp.getValue().toString()));
+						String rightStringValue = rightComp.getValue().toString();
+						try {
+							BigDecimal rightNumberValue = new BigDecimal(rightStringValue);
+							if (thisComparator.equals("<")) {
+								column.addProperty("lt", rightNumberValue);
+							}
+							if (thisComparator.equals(">")) {
+								column.addProperty("gt", rightNumberValue);
+							}
+							if (thisComparator.equals(">=")) {
+								column.addProperty("gte", rightNumberValue);
+							}
+							if (thisComparator.equals("<=")) {
+								column.addProperty("lte", rightNumberValue);
+							}
+						} catch(Exception e) {
+							if (thisComparator.equals("<")) {
+								column.addProperty("lt", rightStringValue);
+							}
+							if (thisComparator.equals(">")) {
+								column.addProperty("gt", rightStringValue);
+							}
+							if (thisComparator.equals(">=")) {
+								column.addProperty("gte", rightStringValue);
+							}
+							if (thisComparator.equals("<=")) {
+								column.addProperty("lte", rightStringValue);
+							}
 						}
-						if (thisComparator.equals(">")) {							
-							column.addProperty("gt", new BigDecimal(rightComp.getValue().toString()));
-						}
-						if (thisComparator.equals(">=")) {							
-							column.addProperty("gte", new BigDecimal(rightComp.getValue().toString()));
-						}
-						if (thisComparator.equals("<=")) {							
-							column.addProperty("lte", new BigDecimal(rightComp.getValue().toString()));
-						}			
 					}
 					range.add(leftComp.getValue().toString(), column);
 				}

--- a/src/prerna/util/Constants.java
+++ b/src/prerna/util/Constants.java
@@ -1029,9 +1029,5 @@ public class Constants {
     public static final String ADMIN_ONLY_VIEW_MENU_BAR = "ADMIN_ONLY_VIEW_MENU_BAR";
     // default AdminOnlyNonApproveProdCatalogItem
     public static final String ADMIN_ONLY_NON_APPROVED_PROD_ITEM = "ADMIN_ONLY_NON_APPROVED_PROD_ITEM";
-    
-//  OpenSearchRestVectorDatabaseEngine params
-    public static final String CUSTOM_TEMPLATE_QUERY = "CUSTOM_TEMPLATE_QUERY";
-    public static final String CUSTOM_RESULTS_PATH = "CUSTOM_RESULTS_PATH";    
 
 }


### PR DESCRIPTION
## Description
Add custom query string configuration settings to opensearch engine. Support query batching and pagination.

## Changes Made
Add more supported properties to open search smss.
Adapt each standard search method to use a query string and json path handling strategy.

## How to Test
`ListDocumentsInVectorDatabase ( engine = "1a82b146-8bc9-43eb-802c-2a18f83ba178" , paramValues = [ { "size" : 2 , "search_after" : "1984.txt" } ] ) ;`
`ListAllRecordsInVectorDatabase ( engine = "1a82b146-8bc9-43eb-802c-2a18f83ba178" , paramValues = [ { "size" : 20 } ] ) ;`
`VectorDatabaseQuery(engine="1a82b146-8bc9-43eb-802c-2a18f83ba178", command="baseball", limit=10, paramValues=[{"k": 200}]);`

## Notes
<!-- Any further notes regarding changes -->