### PR TITLE
[1235] - feat - added structured json support for openai chat-completion and responses

### DIFF
--- a/py/genai_client/message_builders/openai/openai_message_builder.py
+++ b/py/genai_client/message_builders/openai/openai_message_builder.py
@@ -1,4 +1,6 @@
 from typing import List, Dict, Any, Tuple, Union
+import json
+from pydantic import BaseModel
 from ...utils import get_image_extension
 from .openai_models import (
     OpenAIRoles,
@@ -96,6 +98,15 @@ class OpenAIMessageBuilder:
             if is_last:
                 param_map.update(message.param_map)
                 if self.chat_type == "responses":
+                    # Process structured json input
+                    has_schema = param_map.get("schema", False)
+                    if has_schema:
+                        # converting string to boolean for "additionalProperties" key
+                        param_map["schema"] = self.replace_string_false(
+                            param_map["schema"]
+                        )
+                        param_map = self._get_structured_parameters_format(**param_map)
+
                     # convert tools into openai responses format if present
                     if param_map.get("tools"):
                         param_map["tools"] = self.convert_mcp_to_openai_responses_tools(
@@ -106,6 +117,11 @@ class OpenAIMessageBuilder:
                         openai_messages, param_map
                     )
                 elif self.chat_type == "chat-completion":
+                    # Process structured json input
+                    has_schema = param_map.get("schema", False)
+                    if has_schema:
+                        param_map = self._get_structured_parameters_format(**param_map)
+
                     # convert tools into openai chat-completion format if present
                     if param_map.get("tools"):
                         param_map["tools"] = (
@@ -125,6 +141,100 @@ class OpenAIMessageBuilder:
                     raise ValueError(f"Invalid chat type: {self.chat_type}")
 
         return openai_messages, param_map
+
+    def replace_string_false(self, obj):
+        """
+        Recursively traverse a dict and replace
+        string 'False' with boolean False.
+        """
+        if isinstance(obj, dict):
+            return {k: self.replace_string_false(v) for k, v in obj.items()}
+        elif obj == "False" or obj == "false":  # exact string match
+            return False
+        else:
+            return obj
+
+    def _get_structured_parameters_format(self, **param_map) -> Tuple[str, int, str]:
+        """
+        1. Validate the schema and identify the schema type
+        2. Create the structured response format with the correct parameter name
+        3. Make the structured output call to the correct endpoint based on model type
+        4. Extract the structured output from the response
+        """
+        schema = param_map.pop("schema")
+        # Validating the schema and identifying the type
+        schema_type, schema = self._validate_structured_input(schema)
+        # Creating the structured response format with the correct parameter name
+        structured_param_name, structured_param_value = self._create_structured_format(
+            schema_type, schema
+        )
+        # Making new params so I can use dynamic keys
+        params = {structured_param_name: structured_param_value, **param_map}
+
+        return params
+
+    def _validate_structured_input(self, schema) -> Tuple[str, Any]:
+        """
+        Validate the input schema for structured output.
+        Returns a tuple with the schema type as string and the schema instance.
+        Convert to Dict if JSON..
+        """
+        if isinstance(schema, str):
+            # Attempting to parse as JSON
+            try:
+                return "dict", json.loads(schema)
+            except json.JSONDecodeError:
+                raise ValueError("Invalid JSON string provided for schema.")
+        elif isinstance(schema, dict):
+            # Validating that dict can be serialized to JSON
+            try:
+                json.dumps(schema, ensure_ascii=False)
+                return ("dict", schema)
+            except TypeError:
+                raise ValueError("Schema dict contains non-serializable values.")
+        elif isinstance(schema, BaseModel) or (
+            isinstance(schema, type) and issubclass(schema, BaseModel)
+        ):
+            # checking if Pydantic model
+            return ("pydantic", schema)
+        else:
+            raise ValueError("Schema must be a JSON string, dict, or Pydantic model.")
+
+    def _create_structured_format(self, schema_type, schema) -> Tuple[str, Any]:
+        """
+        Create the structure request format for structured output.
+        Returns a tuple with the parameter name as string and the parameter value.
+        These cases are different based on whether we are hitting OpenAI versus vLLM
+        and whether the schema is a dict or Pydantic model.
+        """
+        if self.chat_type == "chat-completion":
+            return (
+                (
+                    "response_format",
+                    {
+                        "type": "json_schema",
+                        "json_schema": {"name": "custom_schema", "schema": schema},
+                    },
+                )
+                if schema_type == "dict"
+                else ("response_format", schema)  # Pydantic model
+            )
+        elif self.chat_type == "responses":
+            return (
+                (
+                    "text",
+                    {
+                        "format": {
+                            "type": "json_schema",
+                            "name": "schema_name",
+                            "schema": schema,
+                            "strict": True,
+                        }
+                    },
+                )
+                if schema_type == "dict"
+                else ("text", schema)  # Pydantic model
+            )
 
     def convert_mcp_to_openai_chat_completions_tools(
         self, mcp_tools: List[Dict]

--- a/py/genai_client/message_builders/openai/openai_message_builder.py
+++ b/py/genai_client/message_builders/openai/openai_message_builder.py
@@ -223,21 +223,55 @@ class OpenAIMessageBuilder:
                 else ("response_format", schema)  # Pydantic model
             )
         elif self.chat_type == "responses":
-            return (
-                (
+            if schema_type == "dict":
+                # Ensure the schema has additionalProperties set to False for responses API
+                processed_schema = self._ensure_additional_properties_false(schema)
+                return (
                     "text",
                     {
                         "format": {
                             "type": "json_schema",
                             "name": "schema_name",
-                            "schema": schema,
+                            "schema": processed_schema,
                             "strict": True,
                         }
                     },
                 )
-                if schema_type == "dict"
-                else ("text", schema)  # Pydantic model
-            )
+            else:
+                return ("text", schema)  # Pydantic model
+
+    def _ensure_additional_properties_false(self, schema: dict) -> dict:
+        """
+        Recursively ensure that all objects in the schema have additionalProperties set to False.
+        This is required for OpenAI's responses API strict mode.
+        """
+        if not isinstance(schema, dict):
+            return schema
+
+        # Make a deep copy to avoid modifying the original
+        import copy
+
+        processed_schema = copy.deepcopy(schema)
+
+        def process_object(obj):
+            if isinstance(obj, dict):
+                # If this is a JSON schema object definition
+                if obj.get("type") == "object" or "properties" in obj:
+                    # Set additionalProperties to False if not already specified
+                    if "additionalProperties" not in obj:
+                        obj["additionalProperties"] = False
+
+                # Recursively process all nested objects
+                for key, value in obj.items():
+                    if isinstance(value, dict):
+                        process_object(value)
+                    elif isinstance(value, list):
+                        for item in value:
+                            if isinstance(item, dict):
+                                process_object(item)
+
+        process_object(processed_schema)
+        return processed_schema
 
     def convert_mcp_to_openai_chat_completions_tools(
         self, mcp_tools: List[Dict]

--- a/py/genai_client/message_builders/openai/openai_message_builder.py
+++ b/py/genai_client/message_builders/openai/openai_message_builder.py
@@ -144,15 +144,18 @@ class OpenAIMessageBuilder:
 
     def replace_string_false(self, obj):
         """
-        Recursively traverse a dict and replace
-        string 'False' with boolean False.
+        Recursively traverse a structure and replace string booleans with actual booleans.
         """
         if isinstance(obj, dict):
             return {k: self.replace_string_false(v) for k, v in obj.items()}
-        elif obj == "False" or obj == "false":  # exact string match
-            return False
-        else:
-            return obj
+        if isinstance(obj, list):
+            return [self.replace_string_false(v) for v in obj]
+        if isinstance(obj, str):
+            if obj.lower() == "false":
+                return False
+            if obj.lower() == "true":
+                return True
+        return obj
 
     def _get_structured_parameters_format(self, **param_map) -> Tuple[str, int, str]:
         """


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Add structured JSON support for new Python Clients - OpenAI chat-completion and responses

## Changes Made
<!-- List the key changes made in this PR -->
I have made changes on below files,
- `Semoss\py\genai_client\message_builders\openai\openai_message_builder.py`

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Test the chat-completion and responses chat types by modifying CHAT_TYPE in GPT-4o smss model file and using the below mentioned scripts.
```
from pprint import pprint
import json
from ai_server import ServerClient


secret_key = "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
access_key = "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
url = "http://localhost:9090/Monolith/api"

google_engine = "5bc04806-946a-47fc-a9ca-554b601ea7d9"
bedrock_engine = "b6fd16f0-18ba-4f24-baca-8e31a8189c55"
anthropic_engine = "64dd630e-0433-4a06-a81f-0c87bd1ae66f"
openai_engine = "4acbe913-df40-4ac0-b28a-daa5ad91b172"

engine_id = openai_engine


def run_response_schema():
    server_client = ServerClient(secret_key=secret_key, access_key=access_key, base=url)

    room_id = server_client.run_pixel("CreateRoom();").get("roomId", None)

    if not room_id:
        raise ValueError("Failed to create room")

    openai_chat_completion_json_schema = {
        "type": "object",
        "properties": {
            "players": {
                "type": "array",
                "items": {
                    "type": "object",
                    "properties": {
                        "name": {"type": "string"},
                        "position": {"type": "string"},
                        "country": {"type": "string"},
                        "skill": {"type": "integer"},
                    },
                    "required": ["name", "position", "country", "skill"],
                },
            }
        },
        "required": ["players"],
    }

    openai_responses_json_schema = {
        "type": "object",
        "properties": {
            "players": {
                "type": "array",
                "items": {
                    "type": "object",
                    "properties": {
                        "name": {"type": "string"},
                        "position": {"type": "string"},
                        "country": {"type": "string"},
                        "skill": {"type": "integer"},
                    },
                    "required": ["name", "position", "country", "skill"],
                    "additionalProperties": False,
                },
            }
        },
        "required": ["players"],
        "additionalProperties": False,
    }

    params = {"schema": openai_chat_completion_json_schema}
    # params = {"schema": openai_responses_json_schema}  # enable this for responses client

    ask_playground_pixel = f'AskPlayground(roomId=["{room_id}"], engine=["{engine_id}"], command=["Name a few Manchester United players you know with their positions, countries, and skill ratings."], paramValues=[{params}]);'

    try:
        ask_playground_response = server_client.run_pixel(ask_playground_pixel)
        content = ask_playground_response.get("responseMessage", {}).get("content", "")
        content_json = json.loads(content) if content else {}
        pprint(content_json)
    except Exception as e:
        raise RuntimeError(f"Failed to run AskPlayground pixel: {e}")


if __name__ == "__main__":
    try:
        run_response_schema()
    except Exception as e:
        print(f"An error occurred: {e}")

```

## Notes
<!-- Any further notes regarding changes -->