### PR TITLE
Updating locally hosted model URLs

### DIFF
--- a/src/prerna/engine/impl/model/AbstractRemoteModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractRemoteModelEngine.java
@@ -465,6 +465,12 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 	    try {
 	        checkModelUp();
 	        String modelUrl = getModelUrl();
+	        
+	        if (modelUrl.endsWith("/infer")) {
+	            String pattern = "/v2/models/[^/]+/infer$";
+	            modelUrl = modelUrl.replaceAll(pattern, "/v1");
+	        }
+	        
 	        classLogger.info("Adding cluster address to parameters: {}", modelUrl);
 	        if (hyperParameters != null) {
 	            hyperParameters.put("base_url", modelUrl);
@@ -472,6 +478,8 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 	            hyperParameters = new HashMap<>();
 	            hyperParameters.put("base_url", modelUrl);
 	        }
+	        
+	        hyperParameters.put("stream", false);
 	        return implementingEngineClass.askCall(question, fullPrompt, context, insight, hyperParameters);
 	    } catch (Exception e) {
 	        classLogger.error("Error getting model URL or deploying model", e);
@@ -484,6 +492,10 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 	    try {
 	        checkModelUp();
 	        String modelUrl = getModelUrl();
+	        if (modelUrl.endsWith("/infer")) {
+	            String pattern = "/v2/models/[^/]+/infer$";
+	            modelUrl = modelUrl.replaceAll(pattern, "/v1");
+	        }
 	        classLogger.info("Adding cluster address to parameters: {}", modelUrl);
 	        if (parameters != null) {
 	        	parameters.put("base_url", modelUrl);
@@ -491,6 +503,7 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 	        	parameters = new HashMap<>();
 	        	parameters.put("base_url", modelUrl);
 	        }
+	        parameters.put("stream", false);
 	        return implementingEngineClass.embeddingsCall(stringsToEmbed, insight, parameters);
 	    } catch (Exception e) {
 	        classLogger.error("Error getting model URL or deploying model", e);
@@ -503,6 +516,10 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 	    try {
 	        checkModelUp();
 	        String modelUrl = getModelUrl();
+	        if (modelUrl.endsWith("/infer")) {
+	            String pattern = "/v2/models/[^/]+/infer$";
+	            modelUrl = modelUrl.replaceAll(pattern, "/v1");
+	        }
 	        classLogger.info("Adding cluster address to parameters: {}", modelUrl);
 	        if (parameters != null) {
 	        	parameters.put("base_url", modelUrl);
@@ -510,13 +527,14 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 	        	parameters = new HashMap<>();
 	        	parameters.put("base_url", modelUrl);
 	        }
+	        parameters.put("stream", false);
 	        return implementingEngineClass.imageEmbeddingsCall(imagesToEmbed, insight, parameters);
 	    } catch (Exception e) {
 	        classLogger.error("Error getting model URL or deploying model", e);
 	        return null;
 	    }
 	}
-
+	
 	@Override
 	protected InstructModelEngineResponse instructCall(String task, String context, List<Map<String, Object>> projectData, Insight insight, Map<String, Object> hyperParameters) {
 		try {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Updating locally hosted model URLs when using the OpenAI python class to properly integrate with the chat/completions endpoint. 