### PR TITLE
[1266] - feat - Support beta headers for the Python Anthropic Client

### DIFF
--- a/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
+++ b/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
@@ -53,6 +53,7 @@ class StreamingResponse(BaseModel):
 class AnthropicRequestConfig(BaseModel):
     model: str
     messages: List[Dict[str, Any]]
+    betas: Optional[List[str]] = None
     system: Optional[str] = None
     tools: Optional[List[Dict]] = None
     max_tokens: Optional[int] = None
@@ -67,6 +68,7 @@ class AnthropicTextClient(AbstractTextGenerationClient):
     def __init__(
         self,
         provider: str,
+        use_beta_header: str,
         **kwargs,
     ):
         super().__init__(
@@ -76,6 +78,8 @@ class AnthropicTextClient(AbstractTextGenerationClient):
         )
 
         self.provider = provider.lower()
+        self.use_beta_header = use_beta_header.lower() in ["true", "1", "yes", "on"]
+        self.beta_feature_name = kwargs.pop("beta_feature_name", None)
         self.client = self._get_client(**kwargs)
 
     def _get_client(self, **kwargs):
@@ -168,24 +172,30 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             response_text = response.text
             usage = response.usage
         else:
-            response = self.client.messages.create(
-                **self.request_config.model_dump(exclude_none=True),
-            )
+            if self.use_beta_header:
+                response = self.client.beta.messages.create(
+                    **self.request_config.model_dump(exclude_none=True),
+                )
+            else:
+                response = self.client.messages.create(
+                    **self.request_config.model_dump(exclude_none=True),
+                )
+
             if response.stop_reason == "tool_use":
                 return self._parse_tools_call_response(
                     response,
                     prompt_tokens=response.usage.input_tokens,
                     response_tokens=response.usage.output_tokens,
                 )
-            
-            if 'schema' in param_map:
+
+            if "schema" in param_map:
                 return self._parse_structured_json_response(
                     response,
                     prompt_tokens=response.usage.input_tokens,
                     response_tokens=response.usage.output_tokens,
                 )
-            
-            response_text = response.content[0].text        
+
+            response_text = response.content[0].text
             usage = Usage(
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
@@ -245,7 +255,7 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             prompt_tokens=prompt_tokens,
             messageType="CHAT",
         )
-    
+
     def _parse_tools_call_response(
         self, response, prompt_tokens: int = None, response_tokens: int = None
     ) -> AskModelEngineResponse:
@@ -319,6 +329,7 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             model=self.model_name,
             system=system_prompt,
             messages=[message.model_dump(mode="json") for message in history],
+            betas=[self.beta_feature_name] if self.use_beta_header else None,
             tools=tools,
             max_tokens=max_tokens,
             temperature=kwargs.pop("temperature", None),

--- a/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
+++ b/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
@@ -134,9 +134,14 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             response_text = response.text
             usage = response.usage
         else:
-            response = self.client.messages.create(
-                **self.request_config.model_dump(exclude_none=True),
-            )
+            if self.use_beta_header:
+                response = self.client.beta.messages.create(
+                    **self.request_config.model_dump(exclude_none=True),
+                )
+            else:
+                response = self.client.messages.create(
+                    **self.request_config.model_dump(exclude_none=True),
+                )
             if response.stop_reason == "tool_use":
                 return self._parse_tools_call_response(
                     response,
@@ -289,15 +294,26 @@ class AnthropicTextClient(AbstractTextGenerationClient):
 
         final_response = ""
 
-        with self.client.messages.stream(
-            **self.request_config.model_dump(exclude_none=True),
-        ) as stream:
-            for text in stream.text_stream:
-                final_response += text
-                print(
-                    prefix + text,
-                    end="",
-                )
+        if self.use_beta_header:
+            with self.client.beta.messages.stream(
+                **self.request_config.model_dump(exclude_none=True),
+            ) as stream:
+                for text in stream.text_stream:
+                    final_response += text
+                    print(
+                        prefix + text,
+                        end="",
+                    )
+        else:
+            with self.client.messages.stream(
+                **self.request_config.model_dump(exclude_none=True),
+            ) as stream:
+                for text in stream.text_stream:
+                    final_response += text
+                    print(
+                        prefix + text,
+                        end="",
+                    )
 
         input_tokens = self._count_tokens(msg_history=msg_history)
         output_tokens = self._count_tokens(response_string=final_response)

--- a/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
+++ b/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
@@ -78,8 +78,14 @@ class AnthropicTextClient(AbstractTextGenerationClient):
         )
 
         self.provider = provider.lower()
+        # Parse boolean-like values
         self.use_beta_header = use_beta_header.lower() in ["true", "1", "yes", "on"]
         self.beta_feature_name = kwargs.pop("beta_feature_name", None)
+        if self.use_beta_header and not self.beta_feature_name:
+            raise ValueError(
+                "beta_feature_name is required when use_beta_header is enabled."
+            )
+
         self.client = self._get_client(**kwargs)
 
     def _get_client(self, **kwargs):


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Enable the support of beta headers for the Python Anthropic Client.

## Changes Made
<!-- List the key changes made in this PR -->
I have made changes in the below files,
- `py\genai_client\text_generation\anthropic_client\anthropic_text_client.py`

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Update the model's SMSS file as below,
```
#Base Properties
ENGINE	b0d18f4b-ff2c-4563-8f9d-57efbff53d60
ENGINE_ALIAS	Claude-Sonnet-4-Anthropic-Vertex
ENGINE_TYPE	prerna.engine.impl.model.VertexEngine

KEEP_CONVERSATION_HISTORY	true
VAR_NAME	claude4
INIT_MODEL_ENGINE	import genai_client;${VAR_NAME} = genai_client.AnthropicClient(model_name = '${MODEL}', max_tokens=${MAX_TOKENS}, context_window=${CONTEXT_WINDOW}, project='${PROJECT}', region='${REGION}',  service_account_credentials = ${SERVICE_ACCOUNT_CREDENTIALS}, provider = '${PROVIDER}', use_beta_header = '${USE_BETA_HEADER}', beta_feature_name = '${BETA_FEATURE_NAME}')
MODEL	claude-sonnet-4@20250514
CHAT_TYPE	chat-completion
USE_BETA_HEADER true
BETA_FEATURE_NAME context-1m-2025-08-07
NAME	Claude-Sonnet-4-Anthropic-Vertex
KEEP_INPUT_OUTPUT	true
MODEL_TYPE	VERTEX
MAX_TOKENS 8162
CONTEXT_WINDOW 200000
PROVIDER google
REGION	<region>
PROJECT <project>
SERVICE_ACCOUNT_CREDENTIALS <service_acc_creds>
```

2. Then, use this below sample code to test the beta headers feature,
```
from ai_server import ServerClient

secret_key = "xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
access_key = "xxxxxxxxxxxxxxxxxxxxxxxxxxx"
url = "http://localhost:9090/Monolith/api"

anthropic_engine = "b0d18f4b-ff2c-4563-8f9d-57efbff53d60"
engine_id = anthropic_engine

def run_response_schema():
    server_client = ServerClient(secret_key=secret_key, access_key=access_key, base=url)

    room_id = server_client.run_pixel("CreateRoom();").get("roomId", None)

    if not room_id:
        raise ValueError("Failed to create room")
    
    command = "This is a test sentence. " * 50000
    command += "Count the repeated words in this large prompt."

    ask_playground_pixel = f'AskPlayground(roomId=["{room_id}"], engine=["{engine_id}"], command=["{command}"]);'

    try:
        ask_playground_response = server_client.run_pixel(ask_playground_pixel)
        content = ask_playground_response.get("responseMessage", {}).get("content", "")
        print("Response - ", content)
    except Exception as e:
        raise RuntimeError(f"Failed to run AskPlayground pixel: {e}")

if __name__ == "__main__":
    try:
        run_response_schema()
    except Exception as e:
        print(f"An error occurred: {e}")
```
3. In the SMSS file, you can tweak the value of `USE_BETA_HEADER` as `true` or `false` to test the above sample code to evaluate  and see the beta headers feature.

## Notes
<!-- Any further notes regarding changes -->