### PR TITLE
fix: switch from athena simba jar to aws jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2408,10 +2408,11 @@
 			<artifactId>sql-jdbc</artifactId>
 			<version>1.1.0.1</version>
 		</dependency>
+		<!-- https://mvnrepository.com/artifact/com.amazonaws/athena-jdbc -->
 		<dependency>
-			<groupId>com.simba</groupId>
-			<artifactId>AthenaJDBC</artifactId>
-			<version>42</version>
+		    <groupId>com.amazonaws</groupId>
+		    <artifactId>athena-jdbc</artifactId>
+		    <version>2025.34.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.xeustechnologies</groupId>
@@ -2707,3 +2708,4 @@
 		<!--  please add jars above and not within the testing block -->
 	</dependencies>
 </project>
+


### PR DESCRIPTION
Simba jar has a sharded log4j jar that results in a startup issue with latest log4j2.xml 