### PR TITLE
Add USE_PYTHON Check When Reloading Insight/Dashboard

### DIFF
--- a/src/prerna/util/insight/InsightUtility.java
+++ b/src/prerna/util/insight/InsightUtility.java
@@ -28,6 +28,7 @@ import prerna.algorithm.api.DataFrameTypeEnum;
 import prerna.algorithm.api.ITableDataFrame;
 import prerna.date.SemossDate;
 import prerna.ds.nativeframe.NativeFrame;
+import prerna.ds.py.PyUtils;
 import prerna.om.Insight;
 import prerna.om.InsightFile;
 import prerna.om.InsightPanel;
@@ -385,7 +386,7 @@ public class InsightUtility {
 			}
 			// if Python is instantiated
 			// clear all vars that are not modules from the globals() dict for the insight
-			if(insight.isDeletePythonGlobalsOnDropInsight()) {
+			if(PyUtils.pyEnabled() && insight.isDeletePythonGlobalsOnDropInsight()) {
 				insight.getPyTranslator().clearInsightGlobals();
 			}
 			
@@ -459,7 +460,7 @@ public class InsightUtility {
 			}
 			// if Python is instantiated
 			// remove the globals() dict for the insight
-			if(insight.isDeletePythonGlobalsOnDropInsight()) {
+			if(PyUtils.pyEnabled() && insight.isDeletePythonGlobalsOnDropInsight()) {
 				insight.getPyTranslator().removeInsightGlobals();
 			}
 			


### PR DESCRIPTION
Adding _PyUtils.pyEnabled()_ check to **InsightUtility** prior to attempting _insight.getPyTranslator().clearInsightGlobals()_