### PR TITLE
fix: validate user login when using basic auth

### DIFF
--- a/src/prerna/auth/utils/SecurityUserAccessKeyUtils.java
+++ b/src/prerna/auth/utils/SecurityUserAccessKeyUtils.java
@@ -140,6 +140,13 @@ public class SecurityUserAccessKeyUtils extends AbstractSecurityUtils {
 		token.setName(name);
 		token.setUsername(username);
 		token.setEmail(email);
+		
+		try {
+			SecurityUpdateUtils.validateUserLogin(token);
+		} catch (Exception e) {
+			classLogger.error(e);
+		}
+
 		user.setAccessToken(token);
 
 		return user;


### PR DESCRIPTION
Fully hydrate access token of a user when authenticating through basic auth