### PR TITLE
[1546] - feat - added support for schema and tool streaming of OpenAI responses client

### DIFF
--- a/py/genai_client/message_builders/openai/openai_message_builder.py
+++ b/py/genai_client/message_builders/openai/openai_message_builder.py
@@ -246,6 +246,8 @@ class OpenAIMessageBuilder:
 
         has_schema = param_map.get("schema", False)
         if has_schema:
+            # # converting string to boolean for "additionalProperties" key
+            param_map["schema"] = self.replace_string_false(param_map["schema"])
             param_map = self._get_structured_parameters_format(**param_map)
 
         # convert tools into openai chat-completion format if present
@@ -361,21 +363,23 @@ class OpenAIMessageBuilder:
         and whether the schema is a dict or Pydantic model.
         """
         if self.chat_type == "chat-completion":
-            return (
-                (
+            if schema_type == "dict":
+                # Ensure the schema has additionalProperties set to False for chat-completions API
+                processed_schema = self._ensure_additional_properties_false(schema)
+                return (
                     "response_format",
                     {
                         "type": "json_schema",
                         "json_schema": {
                             "name": "custom_schema",
                             "strict": True,
-                            "schema": schema,
+                            "schema": processed_schema,
                         },
                     },
                 )
-                if schema_type == "dict"
-                else ("response_format", schema)  # Pydantic model
-            )
+            else:
+                return ("response_format", schema)  # Pydantic model
+
         elif self.chat_type == "responses":
             if schema_type == "dict":
                 # Ensure the schema has additionalProperties set to False for responses API

--- a/py/genai_client/message_builders/openai/openai_message_builder.py
+++ b/py/genai_client/message_builders/openai/openai_message_builder.py
@@ -364,7 +364,7 @@ class OpenAIMessageBuilder:
         """
         if self.chat_type == "chat-completion":
             if schema_type == "dict":
-                # Ensure the schema has additionalProperties set to False for chat-completions API
+                # Ensure the schema has additionalProperties set to False for chat completions API
                 processed_schema = self._ensure_additional_properties_false(schema)
                 return (
                     "response_format",

--- a/py/genai_client/text_generation/openai_clients/openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_client.py
@@ -116,6 +116,10 @@ class OpenAiClient(AbstractTextGenerationClient):
                 kwargs.update(
                     {"stream": True, "stream_options": {"include_usage": True}}
                 )
+        elif self.chat_type == "responses":
+            streaming = kwargs.pop("stream", True)
+            if streaming:
+                kwargs.update({"stream": True})
 
         semoss_messages = self.build_semoss_messages(
             model_settings=self.model_settings, **kwargs
@@ -173,26 +177,119 @@ class OpenAiClient(AbstractTextGenerationClient):
         request: Dict[str, Any],
         prefix: str = "",
     ) -> AskModelEngineResponse:
+        smss_stream = get_smss_stream()
+
         response = self.client.responses.create(
             model=self.model_settings.model_name, **request
         )
+
         if request.get("stream", False):
-            final_query = ""
-            for chunk in response:
-                if "delta" in chunk.type:
-                    content = chunk.delta
-                    if content != None:
-                        final_query += content
-                        print(prefix + content, end="")
             response_tokens = 0
             input_tokens = 0
+
+            streamed_tools = {}
+            finish_reason = None
+            aggregated_content = ""
+            for chunk in response:
+                # Usage info typically comes in the final chunk
+                if "response.completed" in chunk.type:
+                    response_tokens = chunk.response.usage.output_tokens
+                    input_tokens = chunk.response.usage.input_tokens
+                    finish_reason = chunk.response.status
+
+                # streaming text and schema
+                if "response.output_text.delta" in chunk.type:
+                    content = chunk.delta
+                    if content is not None:
+                        aggregated_content += content
+                        data = StreamUtil.create_content_chunk(content)
+                        smss_stream(data, stream_type="content")
+                        print(prefix + content, end="")
+
+                # streaming tool calls
+                if "response.function_call_arguments.done" in chunk.type:
+                    idx = chunk.output_index
+                    if idx not in streamed_tools:
+                        streamed_tools[idx] = {
+                            "id": None,
+                            "type": None,
+                            "name": None,
+                            "arguments": "",
+                        }
+
+                    if hasattr(chunk, "item_id") and chunk.item_id is not None:
+                        streamed_tools[idx]["id"] = chunk.item_id
+                        data = StreamUtil.create_tool_id_chunk(idx, chunk.item_id)
+                        smss_stream(data, stream_type="tool")
+                        print(prefix + str(data), end="")
+
+                    if hasattr(chunk, "type") and chunk.type is not None:
+                        streamed_tools[idx]["type"] = chunk.type
+                        data = StreamUtil.create_tool_type_chunk(idx, chunk.type)
+                        smss_stream(data, stream_type="tool")
+                        print(prefix + str(data), end="")
+
+                    # since name key is mandatory, so added item_id as name for now
+                    if hasattr(chunk, "item_id") and chunk.item_id is not None:
+                        streamed_tools[idx]["name"] = chunk.item_id
+                        data = StreamUtil.create_function_name_chunk(idx, chunk.item_id)
+                        smss_stream(data, stream_type="tool")
+                        print(prefix + str(data), end="")
+
+                    if hasattr(chunk, "arguments") and chunk.arguments is not None:
+                        streamed_tools[idx]["arguments"] += chunk.arguments
+                        data = StreamUtil.create_function_arguments_chunk(
+                            idx, chunk.arguments
+                        )
+                        smss_stream(data, stream_type="tool")
+                        print(prefix + str(data), end="")
+
+            if streamed_tools:
+                data = StreamUtil.create_finish_reason_chunk(finish_reason)
+                smss_stream(data, stream_type="tool", interim=False)
+                final_tool_calls = [
+                    streamed_tools[idx] for idx in sorted(streamed_tools.keys())
+                ]
+                # we flatten out the tool calls
+                tool_result = []
+                for tool_call in final_tool_calls:
+                    # tool_call is a normal dict, need to use [] to pull keys
+                    try:
+                        arguments = json.loads(tool_call["arguments"])
+                    except json.decoder.JSONDecodeError:
+                        arguments = tool_call["arguments"]
+
+                    tool_result.append(
+                        {
+                            "id": tool_call["id"],
+                            "type": tool_call["type"],
+                            "name": tool_call["name"],
+                            "arguments": arguments,
+                        }
+                    )
+
+                return AskModelEngineResponse(
+                    response=tool_result,
+                    prompt_tokens=input_tokens,
+                    response_tokens=response_tokens,
+                    messageType="TOOL",
+                )
+            else:
+                data = StreamUtil.create_finish_reason_chunk(finish_reason)
+                smss_stream(data, stream_type="content", interim=False)
+
+                return AskModelEngineResponse(
+                    response=aggregated_content,
+                    response_tokens=response_tokens,
+                    prompt_tokens=input_tokens,
+                )
         else:
-            final_query = response.output_text
             response_tokens = response.usage.output_tokens
             input_tokens = response.usage.input_tokens
 
-        # Returning a diff type of AskModelEngineResponse if there are tool calls
-        if not request.get("stream", False):
+            final_content = response.output_text
+
+            # non-stream tool calls
             for output in response.output:
                 if output.type == "function_call":
                     return self._parse_tools_call_response(
@@ -200,14 +297,12 @@ class OpenAiClient(AbstractTextGenerationClient):
                         response_tokens=response_tokens,
                         prompt_tokens=input_tokens,
                     )
-
-        model_engine_response = AskModelEngineResponse(
-            response=final_query,
-            response_tokens=response_tokens,
-            prompt_tokens=input_tokens,
-        )
-
-        return model_engine_response
+            else:
+                return AskModelEngineResponse(
+                    response=final_content,
+                    response_tokens=response_tokens,
+                    prompt_tokens=input_tokens,
+                )
 
     def handle_chat_completion_response(
         self,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Add the support for Tool and Schema streaming in OpenAI responses client from the issue - #1546 

## Changes Made
<!-- List the key changes made in this PR -->
I have made changes in the below files, 
- `Semoss\py\genai_client\message_builders\openai\openai_message_builder.py`
- `Semoss\py\genai_client\text_generation\openai_clients\openai_client.py`

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Modify the CHAT_TYPE as `responses` in the model SMSS
2. Use the below code to test the schema streaming of OpenAI responses client.
```
from pprint import pprint
import json
from ai_server import ServerClient


secret_key = "xxxxxxxxxxxxx"
access_key = "xxxxxxxxxxxxx"
url = "http://localhost:9090/Monolith/api"

google_engine = "692215ed-b693-45df-a464-56a99d397d27"
bedrock_engine = "b6fd16f0-18ba-4f24-baca-8e31a8189c55"
anthropic_engine = "b0d18f4b-ff2c-4563-8f9d-57efbff53d60"
openai_chat_engine = "4acbe913-df40-4ac0-b28a-daa5ad91b172"
openai_responses_engine = "714e633c-ae67-49c8-98ff-b631222b8bca"
openai_azure = "c5b85067-01b0-4134-917f-2a46290832fb"

engine_id = openai_responses_engine 


def run_response_schema():
    server_client = ServerClient(secret_key=secret_key, access_key=access_key, base=url)

    room_id = server_client.run_pixel("CreateRoom();").get("roomId", None)

    if not room_id:
        raise ValueError("Failed to create room")

    json_schema = {
        "type": "object",
        "properties": {
            "players": {
                "type": "array",
                "items": {
                    "type": "object",
                    "properties": {
                        "name": {"type": "string"},
                        "position": {"type": "string"},
                        "country": {"type": "string"},
                        "skill": {"type": "integer"},
                    },
                    "required": ["name", "position", "country", "skill"],
                },
            }
        },
        "required": ["players"],
    }

    params = {"schema": json_schema}

    ask_playground_pixel = f'AskPlayground(roomId=["{room_id}"], engine=["{engine_id}"], command=["Name a few Manchester United players you know with their positions, countries, and skill ratings."], paramValues=[{params}]);'

    try:
        ask_playground_response = server_client.run_pixel(ask_playground_pixel)
        content = ask_playground_response.get("responseMessage", {}).get("content", "")
        content_json = json.loads(content) if content else {}
        pprint(content_json)
    except Exception as e:
        raise RuntimeError(f"Failed to run AskPlayground pixel: {e}")

if __name__ == "__main__":
    try:
        run_response_schema()
    except Exception as e:
        print(f"An error occurred: {e}")
```
3. Use the below code to test the tools streaming of OpenAI responses client.
```
from typing import List
from ai_server import ServerClient


secret_key = "xxxxxxxxxxx"
access_key = "xxxxxxxxxxxx"
url = "http://localhost:9090/Monolith/api"

google_engine = "692215ed-b693-45df-a464-56a99d397d27"
bedrock_engine = "b6fd16f0-18ba-4f24-baca-8e31a8189c55"
anthropic_engine = "b0d18f4b-ff2c-4563-8f9d-57efbff53d60"
openai_chat_engine = "4acbe913-df40-4ac0-b28a-daa5ad91b172"
openai_responses_engine = "714e633c-ae67-49c8-98ff-b631222b8bca"
openai_azure = "c5b85067-01b0-4134-917f-2a46290832fb"

engine_id = openai_responses_engine


def run_multi_tool():
    server_client = ServerClient(secret_key=secret_key, access_key=access_key, base=url)

    room_id = server_client.run_pixel("CreateRoom();").get("roomId", None)

    if not room_id:
        raise ValueError("Failed to create room")

    instructions = {
        "instructions": "",
        "mcp": [
            {
                "id": "29e9e371-9243-4293-ad3b-4be08ef95ab5",
                "type": "PROJECT",
                "name": "MCP",
            }
        ],
        "temperature": 0.3,
    }

    update_room_pixel = (
        f'UpdateRoomOptions(roomId="{room_id}", roomOptions=[{instructions}]);'
    )

    try:
        update_room_response = server_client.run_pixel(update_room_pixel)
        print(update_room_response)
        if not update_room_response:
            raise ValueError("Failed to update room options")
    except Exception as e:
        raise RuntimeError(f"Failed to update room options: {e}")

    # PHASE 1: Single tool call
    # STEP 1: AskPlayground with mcpToolID to get tool call details
    ask_playground_pixel = f'AskPlayground(roomId=["{room_id}"], engine=["{engine_id}"], command=["What is stock price of META?"], paramValues=[{{"max_new_tokens":null,"temperature":0.3}}])'

    try:
        ask_playground_response = server_client.run_pixel(ask_playground_pixel)
        tool_response = ask_playground_response.get("responseMessage", None).get(
            "tool_responses", None
        )[0]
    except Exception as e:
        raise RuntimeError(f"PHASE 1: Failed to run AskPlayground pixel: {e}")

    param_values = tool_response.get("arguments", {})
    tool_call_id = tool_response.get("id", None)

    # STEP 2: RunMCPTool with extracted parameters
    run_mcp_tool_pixel = f'RunMCPTool(project=["29e9e371-9243-4293-ad3b-4be08ef95ab5"], function=["get_stock_price"], paramValues=[{param_values}])'

    try:
        run_mcp_tool_response = server_client.run_pixel(run_mcp_tool_pixel)
        if not run_mcp_tool_response:
            raise ValueError("PHASE 1: Run MCP Tool response is empty")
    except Exception as e:
        raise RuntimeError(f"PHASE 1: Failed to run MCP Tool pixel: {e}")

    add_tool_execution_pixel = f'AddToolExecution(engine=["{engine_id}"], roomId=["{room_id}"], toolId=["{tool_call_id}"], toolName=["get_stock_price"], tool_execution_response=[{run_mcp_tool_response}])'

    try:
        add_tool_execution_response = server_client.run_pixel(add_tool_execution_pixel)
        if not add_tool_execution_response:
            raise ValueError("PHASE 1: Add Tool Execution response is empty")

        print("Tool execution added successfully:", add_tool_execution_response)
    except Exception as e:
        raise RuntimeError(f"PHASE 1: Failed to run Add Tool Execution pixel: {e}")

    # PHASE 2: Multiple tool calls
    ask_playground_pixel2 = f'AskPlayground(roomId=["{room_id}"], engine=["{engine_id}"], mcpToolID=["29e9e371-9243-4293-ad3b-4be08ef95ab5"], command=["What about TSLA and MSFT?"])'

    try:
        ask_playground_response = server_client.run_pixel(ask_playground_pixel2)
        tool_responses = ask_playground_response.get("responseMessage", None).get(
            "tool_responses", None
        )
    except Exception as e:
        raise RuntimeError(f"PHASE 2: Failed to run AskPlayground pixel: {e}")

    if not isinstance(tool_responses, List):
        raise ValueError(
            "PHASE 2: Tool response is not a list, expected multiple tool calls"
        )

    if len(tool_responses) < 2:
        raise ValueError(f"PHASE 2: Expected 2 tool calls, got {len(tool_responses)}")

    tool_execution_results = []

    for i, tool_response in enumerate(tool_responses):
        tool_call_id = tool_response.get("id", None)
        param_values = tool_response.get("arguments", {})

        print(f"Processing tool call {i+1}: ID={tool_call_id}, Params={param_values}")

        run_mcp_tool_pixel = f'RunMCPTool(project=["29e9e371-9243-4293-ad3b-4be08ef95ab5"], function=["get_stock_price"], paramValues=[{param_values}])'

        try:
            run_mcp_tool_response = server_client.run_pixel(run_mcp_tool_pixel)
            if not run_mcp_tool_response:
                raise ValueError(f"PHASE 2 TOOL {i+1}: Run MCP Tool response is empty")
        except Exception as e:
            raise RuntimeError(f"PHASE 2 TOOL {i+1}: Failed to run MCP Tool pixel: {e}")

        tool_execution_results.append(
            {"tool_call_id": tool_call_id, "tool_response": run_mcp_tool_response}
        )

    for i, execution_result in enumerate(tool_execution_results):
        add_tool_execution_pixel = f'AddToolExecution(engine=["{engine_id}"], roomId=["{room_id}"], toolId=["{execution_result["tool_call_id"]}"], toolName=["get_stock_price"], tool_execution_response=[{execution_result["tool_response"]}])'

        try:
            add_tool_execution_response = server_client.run_pixel(
                add_tool_execution_pixel
            )
            if not add_tool_execution_response:
                raise ValueError(
                    f"PHASE 2 TOOL {i+1}: Add Tool Execution response is empty"
                )

            print(
                f"Tool execution {i+1} added successfully:", add_tool_execution_response
            )
        except Exception as e:
            raise RuntimeError(
                f"PHASE 2 TOOL {i+1}: Failed to run Add Tool Execution pixel: {e}"
            )

    print("All tool executions completed successfully!")

    # Phase 3: Summmary
    ask_playground_pixel = f'AskPlayground(roomId=["{room_id}"], engine=["{engine_id}"], command=["Can you create a summary of the stock prices we discussed?"])'
    try:
        ask_playground_response = server_client.run_pixel(ask_playground_pixel)
        text_response = ask_playground_response.get("responseMessage", None)
        if not text_response:
            raise ValueError("PHASE 3: AskPlayground response is empty")
        print("Summary response:", text_response)
    except Exception as e:
        raise RuntimeError(f"PHASE 3: Failed to run AskPlayground pixel: {e}")


if __name__ == "__main__":
    try:
        run_multi_tool()
    except Exception as e:
        print(f"An error occurred: {e}")
```


## Notes
<!-- Any further notes regarding changes -->