### PR TITLE
1598 add total record count in audit log

### DIFF
--- a/src/prerna/engine/logging/AuditLogsDbUtils.java
+++ b/src/prerna/engine/logging/AuditLogsDbUtils.java
@@ -268,5 +268,50 @@ public class AuditLogsDbUtils {
 	private static int getIntValue(Object obj) {
 		return (obj instanceof Integer) ? (Integer) obj : 0;
 	}
+	
+    /**
+     * get audit log total record count
+     * 
+     * @param userId
+     * @param projectId
+     * @param engineId
+     * @param dateTime
+     * @param roomId
+     * @param sessionId
+     * @return
+     */
+	public static long getAuditLogsCount(String userId, String projectId, String engineId, String dateTime, String roomId, String sessionId) {
+	    SelectQueryStruct qs = new SelectQueryStruct();
+
+	    // COUNT(*) selector
+	    QueryFunctionSelector fSelector = new QueryFunctionSelector();
+	    fSelector.setAlias("total_count");
+	    fSelector.setFunction(QueryFunctionHelper.COUNT);
+	    fSelector.addInnerSelector(new QueryColumnSelector("AUDIT_LOGS__LOG_ID"));
+	    qs.addSelector(fSelector);
+
+	    // Apply filters dynamically
+	    if (userId != null && !userId.isEmpty()) {
+	        qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("AUDIT_LOGS__USER_ID", "==", userId));
+	    }
+	    if (projectId != null && !projectId.isEmpty()) {
+	        qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("AUDIT_LOGS__PROJECT_ID", "==", projectId));
+	    }
+	    if (engineId != null && !engineId.isEmpty()) {
+	        qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("AUDIT_LOGS__ENGINE_ID", "==", engineId));
+	    }
+	    if (roomId != null && !roomId.isEmpty()) {
+	        qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("AUDIT_LOGS__ROOM_ID", "==", roomId));
+	    }
+	    if (sessionId != null && !sessionId.isEmpty()) {
+	        qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("AUDIT_LOGS__SESSION_ID", "==", sessionId));
+	    }
+	    if (dateTime != null && !dateTime.isEmpty()) {
+	        qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("AUDIT_LOGS__LOG_TIMESTAMP", "<=", dateTime));
+	    }
+
+	    // Execute query and return count
+	    return QueryExecutionUtility.flushToLong(auditLogsDb, qs);
+	}
 
 }

--- a/src/prerna/engine/logging/AuditLogsDbUtils.java
+++ b/src/prerna/engine/logging/AuditLogsDbUtils.java
@@ -138,7 +138,7 @@ public class AuditLogsDbUtils {
 	 * @param userId
 	 * @param projectId
 	 * @param engineId
-	 * @param date
+	 * @param dateTime
 	 * @param roomId
 	 * @param sessionId
 	 * @param offset
@@ -147,7 +147,7 @@ public class AuditLogsDbUtils {
 	 * @throws SQLException
 	 */
 	public static List<LogActivityDto> getAuditLogsTimeLineDatas(String userId, String projectId, String engineId,
-			String date, String roomId, String sessionId, int limit, int offset) throws SQLException {
+			String dateTime, String roomId, String sessionId, int limit, int offset) throws SQLException {
 
 		SelectQueryStruct qs = new SelectQueryStruct();
 		qs.addSelector(new QueryColumnSelector("AUDIT_LOGS__REQUEST_ID"));
@@ -164,15 +164,17 @@ public class AuditLogsDbUtils {
 		qs.addSelector(new QueryColumnSelector("AUDIT_LOGS__IS_SUCCESS"));
 		qs.addSelector(new QueryColumnSelector("AUDIT_LOGS__USER_ID"));
 		qs.addSelector(new QueryColumnSelector("AUDIT_LOGS__SESSION_ID"));
+		qs.addSelector(new QueryColumnSelector("AUDIT_LOGS__SPAN_ID"));
+		qs.addSelector(new QueryColumnSelector("AUDIT_LOGS__LOG_TIMESTAMP"));
 
 		// add filters dynamically if present
-		addFilter(qs, "AUDIT_LOGS__LOG_TIMESTAMP", "<=", date);
+		addFilter(qs, "AUDIT_LOGS__LOG_TIMESTAMP", "<=", dateTime);
 		addFilter(qs, "AUDIT_LOGS__USER_ID", "==", userId);
 		addFilter(qs, "AUDIT_LOGS__PROJECT_ID", "==", projectId);
 		addFilter(qs, "AUDIT_LOGS__ENGINE_ID", "==", engineId);
 		addFilter(qs, "AUDIT_LOGS__ROOM_ID", "==", roomId);
 		addFilter(qs, "AUDIT_LOGS__SESSION_ID", "==", sessionId);
-		qs.addOrderBy("AUDIT_LOGS__END_TIME", "desc");
+		qs.addOrderBy("AUDIT_LOGS__LOG_TIMESTAMP", "desc");
 
 		// pagination
 		if (limit > 0) {
@@ -204,7 +206,7 @@ public class AuditLogsDbUtils {
 		for (Map<String, Object> map : list) {
 			Timestamp startTime = extractTimestamp(map.get("START_TIME"));
 			Timestamp endTime = extractTimestamp(map.get("END_TIME"));
-			String payload = getOrDefault(map.get("REQUEST"), "REQUEST NOT TRACKED");
+			String request = getOrDefault(map.get("REQUEST"), "REQUEST NOT TRACKED");
 			String response = getOrDefault(map.get("RESPONSE"), "RESPONSE NOT TRACKED");
 			String engineName = getOrDefault(map.get("ENGINE_NAME"), null);
 			String engineType = getOrDefault(map.get("ENGINE_TYPE"), null);
@@ -214,9 +216,11 @@ public class AuditLogsDbUtils {
 					+ getIntValue(map.get("NUMBER_OF_TOKENS_IN_RESPONSE"));
 			String userIdFromRow = getOrDefault(map.get("USER_ID"), null);
 			String sessionIdFromRow = getOrDefault(map.get("SESSION_ID"), null);
+			String spanIdFromRow = getOrDefault(map.get("SPAN_ID"), null);
+			Timestamp logTimestamp = extractTimestamp(map.get("END_TIME"));
 
-			activityList.add(new LogActivityDto(startTime, endTime, payload, response, tokens, latency, status,
-					engineName, engineType, userIdFromRow, sessionIdFromRow));
+			activityList.add(new LogActivityDto(startTime, endTime, request, response, tokens, latency, status,
+					engineName, engineType, userIdFromRow, sessionIdFromRow, spanIdFromRow, logTimestamp));
 
 		}
 		return activityList;
@@ -268,50 +272,38 @@ public class AuditLogsDbUtils {
 	private static int getIntValue(Object obj) {
 		return (obj instanceof Integer) ? (Integer) obj : 0;
 	}
-	
-    /**
-     * get audit log total record count
-     * 
-     * @param userId
-     * @param projectId
-     * @param engineId
-     * @param dateTime
-     * @param roomId
-     * @param sessionId
-     * @return
-     */
-	public static long getAuditLogsCount(String userId, String projectId, String engineId, String dateTime, String roomId, String sessionId) {
-	    SelectQueryStruct qs = new SelectQueryStruct();
 
-	    // COUNT(*) selector
-	    QueryFunctionSelector fSelector = new QueryFunctionSelector();
-	    fSelector.setAlias("total_count");
-	    fSelector.setFunction(QueryFunctionHelper.COUNT);
-	    fSelector.addInnerSelector(new QueryColumnSelector("AUDIT_LOGS__LOG_ID"));
-	    qs.addSelector(fSelector);
+	/**
+	 * Get audit log total record count
+	 * 
+	 * @param userId
+	 * @param projectId
+	 * @param engineId
+	 * @param dateTime
+	 * @param roomId
+	 * @param sessionId
+	 * @return
+	 */
+	public static long getAuditLogsCount(String userId, String projectId, String engineId, String dateTime,
+			String roomId, String sessionId) {
+		SelectQueryStruct qs = new SelectQueryStruct();
 
-	    // Apply filters dynamically
-	    if (userId != null && !userId.isEmpty()) {
-	        qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("AUDIT_LOGS__USER_ID", "==", userId));
-	    }
-	    if (projectId != null && !projectId.isEmpty()) {
-	        qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("AUDIT_LOGS__PROJECT_ID", "==", projectId));
-	    }
-	    if (engineId != null && !engineId.isEmpty()) {
-	        qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("AUDIT_LOGS__ENGINE_ID", "==", engineId));
-	    }
-	    if (roomId != null && !roomId.isEmpty()) {
-	        qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("AUDIT_LOGS__ROOM_ID", "==", roomId));
-	    }
-	    if (sessionId != null && !sessionId.isEmpty()) {
-	        qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("AUDIT_LOGS__SESSION_ID", "==", sessionId));
-	    }
-	    if (dateTime != null && !dateTime.isEmpty()) {
-	        qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("AUDIT_LOGS__LOG_TIMESTAMP", "<=", dateTime));
-	    }
+		// COUNT(AUDIT_LOGS__LOG_ID) selector
+		QueryFunctionSelector fSelector = new QueryFunctionSelector();
+		fSelector.setAlias("total_count");
+		fSelector.setFunction(QueryFunctionHelper.COUNT);
+		fSelector.addInnerSelector(new QueryColumnSelector("AUDIT_LOGS__LOG_ID"));
+		qs.addSelector(fSelector);
 
-	    // Execute query and return count
-	    return QueryExecutionUtility.flushToLong(auditLogsDb, qs);
+		// Apply filters dynamically
+		addFilter(qs, "AUDIT_LOGS__LOG_TIMESTAMP", "<=", dateTime);
+		addFilter(qs, "AUDIT_LOGS__USER_ID", "==", userId);
+		addFilter(qs, "AUDIT_LOGS__PROJECT_ID", "==", projectId);
+		addFilter(qs, "AUDIT_LOGS__ENGINE_ID", "==", engineId);
+		addFilter(qs, "AUDIT_LOGS__ROOM_ID", "==", roomId);
+		addFilter(qs, "AUDIT_LOGS__SESSION_ID", "==", sessionId);
+
+		return QueryExecutionUtility.flushToLong(auditLogsDb, qs);
 	}
 
 }

--- a/src/prerna/logging/AuditLogReportReactor.java
+++ b/src/prerna/logging/AuditLogReportReactor.java
@@ -2,6 +2,7 @@ package prerna.logging;
 
 import java.sql.SQLException;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -57,14 +58,21 @@ public class AuditLogReportReactor extends AbstractReactor {
 		int offset = parseIntWithDefault(offsetStr, 0);
 
 		List<LogActivityDto> result = Collections.emptyList();
+		long totalCount = 0;
 		try {
 			result = AuditLogsDbUtils.getAuditLogsTimeLineDatas(userId, projectId, engineId, dateTime, roomId,
 					sessionId, limit, offset);
+			// Get total record count
+	        totalCount = AuditLogsDbUtils.getAuditLogsCount(userId, projectId, engineId, dateTime, roomId, sessionId);
+
 		} catch (SQLException e) {
 			classLogger.error("Error executing audit log fetch: {}", e.getMessage(), e);
 		}
-
-		String json = GSON.toJson(result);
+		//combine logs and totalCount
+	    Map<String, Object> responseMap = new HashMap<>();
+	    responseMap.put("totalCount", totalCount);
+	    responseMap.put("logs", result);
+		String json = GSON.toJson(responseMap);
 		return new NounMetadata(json, PixelDataType.JSON_OBJECT, PixelOperationType.LOGGING_DATA);
 	}
 

--- a/src/prerna/logging/LogActivityDto.java
+++ b/src/prerna/logging/LogActivityDto.java
@@ -6,7 +6,9 @@ public class LogActivityDto {
 
 	private java.sql.Timestamp startTime;
 	private java.sql.Timestamp endTime;
-	private String payload;
+	private java.sql.Timestamp logTimestamp;
+
+	private String request;
 	private String response;
 	private int tokens;
 
@@ -16,17 +18,18 @@ public class LogActivityDto {
 	private String engineType;
 	private String userId;
 	private String sessionId;
+	private String spanId;
 
 	public LogActivityDto() {
 
 	}
 
-	public LogActivityDto(java.sql.Timestamp startTime, java.sql.Timestamp endTime, String payload, String response,
+	public LogActivityDto(java.sql.Timestamp startTime, java.sql.Timestamp endTime, String request, String response,
 			int tokens, long latency, boolean status, String engineName, String engineType, String userId,
-			String sessionId) {
+			String sessionId, String spanId, java.sql.Timestamp logTimestamp) {
 		this.startTime = startTime;
 		this.endTime = endTime;
-		this.payload = payload;
+		this.request = request;
 		this.response = response;
 		this.tokens = tokens;
 		this.latency = latency;
@@ -35,6 +38,8 @@ public class LogActivityDto {
 		this.engineType = engineType;
 		this.userId = userId;
 		this.sessionId = sessionId;
+		this.spanId = spanId;
+		this.logTimestamp = logTimestamp;
 	}
 
 	public Timestamp getStartTime() {
@@ -53,12 +58,12 @@ public class LogActivityDto {
 		this.endTime = endTime;
 	}
 
-	public String getPayload() {
-		return payload;
+	public String getRequest() {
+		return request;
 	}
 
-	public void setPayload(String payload) {
-		this.payload = payload;
+	public void setRequest(String request) {
+		this.request = request;
 	}
 
 	public String getResponse() {
@@ -123,6 +128,22 @@ public class LogActivityDto {
 
 	public void setSessionId(String sessionId) {
 		this.sessionId = sessionId;
+	}
+
+	public String getSpanId() {
+		return spanId;
+	}
+
+	public void setSpanId(String spanId) {
+		this.spanId = spanId;
+	}
+
+	public java.sql.Timestamp getLogTimestamp() {
+		return logTimestamp;
+	}
+
+	public void setLogTimestamp(java.sql.Timestamp logTimestamp) {
+		this.logTimestamp = logTimestamp;
 	}
 
 }


### PR DESCRIPTION
- Added **totalCount** key to return total record count.
- Added **logs** key to hold paginated audit log records.
- Refactored query logic to support total count retrieval.

for FE reffernce:

<img width="1069" height="545" alt="Image" src="https://github.com/user-attachments/assets/14cbeae6-2f83-47e8-8bb5-d0a45094b1c3" />
