### PR TITLE
Update tomcat start script

### DIFF
--- a/.github/workflows/tomcat-builder.yml
+++ b/.github/workflows/tomcat-builder.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      TOMCAT_VERSION: ${{ github.event.inputs.version || '9.0.106' }}
+      TOMCAT_VERSION: ${{ github.event.inputs.version || '9.0.112' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/tomcat-builder.yml
+++ b/.github/workflows/tomcat-builder.yml
@@ -7,7 +7,7 @@ on:
         required: true
         default: '9.0.106'
   push:
-    branches: [ "dev", "main", "update-tomcat-start-script" ]
+    branches: [ "dev", "main"]
     paths:
       - 'docker/Dockerfile.tomcat'
       - '.github/workflows/tomcat-builder.yml'

--- a/.github/workflows/tomcat-builder.yml
+++ b/.github/workflows/tomcat-builder.yml
@@ -7,7 +7,7 @@ on:
         required: true
         default: '9.0.106'
   push:
-    branches: [ "dev", "main" ]
+    branches: [ "dev", "main", "update-tomcat-start-script" ]
     paths:
       - 'docker/Dockerfile.tomcat'
       - '.github/workflows/tomcat-builder.yml'

--- a/docker/Dockerfile.tomcat
+++ b/docker/Dockerfile.tomcat
@@ -90,8 +90,7 @@ RUN apt-get -y install apt-transport-https ca-certificates git wget dirmngr gnup
 	&& rm apache-maven-3.8.5-bin.tar.gz \
 	&& apt-get -y install nano \
 	&& echo '#!/bin/sh' > $TOMCAT_HOME/bin/start.sh \
-	&& echo 'catalina.sh start' >> $TOMCAT_HOME/bin/start.sh \
-	&& echo "tail -f $TOMCAT_HOME/logs/catalina.out" >> $TOMCAT_HOME/bin/start.sh \
+	&& echo 'exec catalina.sh run' >> $TOMCAT_HOME/bin/start.sh \
 	&& echo '#!/bin/sh' > $TOMCAT_HOME/bin/stop.sh \
 	&& echo 'shutdown.sh -force' >> $TOMCAT_HOME/bin/stop.sh \
 	&& chmod 777 $TOMCAT_HOME/bin/*.sh \


### PR DESCRIPTION
## Description
Updating tomcat start script and tomcat default version

## Changes Made
- Updated tomcat start script to start tomcat/catalina as a main process instead of a child process
- Updated tomcat default version to 9.0.112

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Tomcat builds successfully
2. Able to build ubuntu and ubi8 images with latest tomcat changes
3. Run ubuntu or ubi8 image and check if tomcat is being started as a main process

## Notes
<!-- Any further notes regarding changes -->