### PR TITLE
Setting Temperature to 1 when using Extended Thinking with Claude

### DIFF
--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -434,6 +434,11 @@ class AnthropicMessageBuilder:
             param_map=kwargs,
         )
 
+        temperature = kwargs.pop("temperature", None)
+        # Temperature must be set to 1 when using extended thinking..
+        if thinking_map:
+            temperature = 1
+
         return AnthropicRequestConfig(
             model=self.model_name,
             system=system_prompt,
@@ -442,7 +447,7 @@ class AnthropicMessageBuilder:
             tools=tools,
             tool_choice=kwargs.pop("tool_choice", None),
             max_tokens=max_tokens,
-            temperature=kwargs.pop("temperature", None),
+            temperature=temperature,
             top_k=kwargs.pop("top_k", None),
             top_p=kwargs.pop("top_p", None),
             container=kwargs.pop("container", None),


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Anthropic Claude models have a hard requirement of using temperature set to 1 when using extended thinking. If extended thinking is used in the Anthropic class I will always set to 1. 

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->