### PR TITLE
feat: Allow for module path to be auto added into sys path as well as assign param values

### DIFF
--- a/py/smssutil.py
+++ b/py/smssutil.py
@@ -955,8 +955,18 @@ def load_module_from_file(module_name=None, file_path=None, search=None):
         del prev_module
     except Exception as e:
         pass
-    if search is not None:
+    if search is not None and search not in sys.path:
         sys.path.append(search)
+    
+    # TODO:
+    # If the module's directory is not part of sys.path adding it in 
+    # to allow relative imports within the module
+    # Now unsure if i should do this way or take in a new param from the java side so that the dev can specify it
+    # So its either this or have the PyTranslator loadPythonModuleFromFile take in a new param called module_dir_path 
+    module_dir = os.path.dirname(file_path)
+    if module_dir not in sys.path and module_dir is not None:
+        sys.path.append(module_dir)
+    
     spec = importlib.util.spec_from_file_location(
         module_name, file_path, submodule_search_locations=search
     )

--- a/src/prerna/ds/py/PyTranslator.java
+++ b/src/prerna/ds/py/PyTranslator.java
@@ -529,20 +529,42 @@ public class PyTranslator {
 			if (add_comma) {
 				args.append(", ");
 			}
-
-			args.append(PyUtils.determineStringType(argsList.get(i)));
+			
+			/**
+			 * Keeping the argsList intake as a List<Obj> for now to be backwards compat with teams that use it
+			 * But i think constructing a call similar to Sum(a=5, b=6) could be better 
+			 * So a dev could pass in a list of 5, 6 or send in one map with {"a":5, "b":5}
+			 */
+			if(argsList.get(i) instanceof Map) {
+				Map<Object, Object> currArgMap = (Map<Object, Object>) argsList.get(i); 
+				//TODO: I could just use the add_comma but wasnt sure if we want to set it to true here and then false again
+				// Or just sep it like this for now while we talk through it 
+				boolean firstParam = true;
+		        for (Map.Entry<Object, Object> entry : currArgMap.entrySet()) {
+					if (!firstParam) {
+						args.append(", ");
+					}
+					args.append(entry.getKey().toString() + "=" + PyUtils.determineStringType(entry.getValue()));
+					firstParam = false;
+		        }
+			} else {
+				args.append(PyUtils.determineStringType(argsList.get(i)));
+			}
 			add_comma = true;
 		}
 
 		Object pyResponse = null;
 		try {
 			String commands = moduleAlias + "." + functionName + "(" + args.toString() + ")\n";
-			pyResponse = runDirectPy(executionInsight, commands);
+			// TODO: REMOVE PARTH Checking that we are only running on insight id for current session insight rather then app 
+			System.out.println("Running Python Script on insight {" + executionInsight + "} with script >>> " + commands);
+			pyResponse = runDirectPy(executionInsight.getInsightId(), commands);
 		} catch (Exception e) {
 			throw new SemossPixelException("Unable to run function from module " + moduleAlias);
 		}
 
 		return pyResponse;
 	}
+	
 
 }


### PR DESCRIPTION
When in a space and loading python from file for an app- We will allow for the module path to be added to the sys path to allow for easier execution of python incase there are any related imports in the files. 

## Changes Made
Smssutil.py -> Load_module -> grabs module path dir and adds to sys path 
PyTransaltor.java -> Allowing for intake of param map to allow for better param creation on java side


## How to Test
1. Create a app, add py and java files to invoke loadPythonModuleFromFile as well as loadPythonModuleFromFile
