### PR TITLE
feat: enhance OpenAI message builder and client for image generation support

### DIFF
--- a/py/genai_client/message_builders/openai/openai_message_builder.py
+++ b/py/genai_client/message_builders/openai/openai_message_builder.py
@@ -150,8 +150,16 @@ class OpenAIMessageBuilder:
 
         # convert tools into openai responses format if present
         if param_map.get("tools"):
-            tools = self.convert_mcp_to_openai_responses_tools(param_map["tools"])
-            param_map["tools"] = [tool.model_dump() for tool in tools]
+            native_tools = [
+                t
+                for t in param_map["tools"]
+                if isinstance(t, dict) and t.get("type") in ["image_generation"]
+            ]
+            if native_tools:
+                param_map["tools"] = native_tools
+            else:
+                tools = self.convert_mcp_to_openai_responses_tools(param_map["tools"])
+                param_map["tools"] = [tool.model_dump() for tool in tools]
         else:
             param_map.pop("tools", None)
 
@@ -279,6 +287,9 @@ class OpenAIMessageBuilder:
         """
         tool_type = tool_choice.get("type", "auto").lower()
         tool_name = tool_choice.get("name", None)
+
+        if tool_type == "image_generation":
+            return {"type": "image_generation"}
 
         if tool_type == "auto":
             return "auto"

--- a/py/genai_client/text_generation/openai_clients/openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_client.py
@@ -289,7 +289,20 @@ class OpenAiClient(AbstractTextGenerationClient):
 
             final_content = response.output_text
 
-            # non-stream tool calls
+            image_calls = [
+                o
+                for o in response.output
+                if hasattr(o, "type") and o.type == "image_generation_call"
+            ]
+            if image_calls:
+                images = [ic.result for ic in image_calls if hasattr(ic, "result")]
+                return AskModelEngineResponse(
+                    response=images,
+                    response_tokens=response_tokens,
+                    prompt_tokens=input_tokens,
+                    messageType="IMAGE",
+                )
+
             for output in response.output:
                 if output.type == "function_call":
                     return self._parse_tools_call_response(
@@ -297,12 +310,11 @@ class OpenAiClient(AbstractTextGenerationClient):
                         response_tokens=response_tokens,
                         prompt_tokens=input_tokens,
                     )
-            else:
-                return AskModelEngineResponse(
-                    response=final_content,
-                    response_tokens=response_tokens,
-                    prompt_tokens=input_tokens,
-                )
+            return AskModelEngineResponse(
+                response=final_content,
+                response_tokens=response_tokens,
+                prompt_tokens=input_tokens,
+            )
 
     def handle_chat_completion_response(
         self,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Added support for using the OpenAI's image generation as a tool.

## Changes Made
<!-- List the key changes made in this PR -->
In building the response, if it was a OpenAI native tool, instead of converting from MCP to openai response, I just passed it through.
Also returns the image within the response if it recognizes a IMAGE call

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
On the local python side, I ran this simple test to ensure the image generation works
```
openai4o = genai_client.OpenAiClient(
    model_name="gpt-4o",
    api_key="sk-xxxx", # Add your own API key
    context_window=128000,
    max_completion_tokens=16384,
    chat_type="responses",  
)


x = openai4o.ask(
    question="""""",
    max_completion_tokens=4000,
    message_json='[{"inputUIPrompt":"can you generate a picture of a basketball that is yellow","inputPrompt":"can you generate a picture of a basketball that is yellow","type":"INPUT_TEXT","imageInfos":[],"modelId":"b0d18f4b-ff2c-4563-8f9d-57efbff53d60","modelType":"VERTEX","messageId":"0199f28c-c2d4-70dd-a29a-1e18c7ef853d","tokens":0,"visible":true,"platform_generated":false,"dateCreated":"2025-10-17 14:22:15","ornaments":{}}]',
    tools=[{"type": "image_generation"}],
    tool_choice={"type": "image_generation"},
    prefix="",
    stream=False,
)

if x.get("response"):
    image_base64 = x["response"][0]  # Get first image from response array
    with open("yellow_basketball.png", "wb") as f:
        f.write(base64.b64decode(image_base64))
    print("Image saved as yellow_basketball.png")
else:
    print("No image in response")
```

2. Expected outcomes
Should generate a picture based on the prompt
## Notes
<!-- Any further notes regarding changes -->