### PR TITLE
Use project id as context in RunMCPTool

### DIFF
--- a/src/prerna/reactor/agent/mcp/RunMCPToolReactor.java
+++ b/src/prerna/reactor/agent/mcp/RunMCPToolReactor.java
@@ -25,13 +25,22 @@ public class RunMCPToolReactor extends AbstractBaseMCPReactor {
 	public RunMCPToolReactor() {
 		this.keysToGet = new String[] { ReactorKeysEnum.PROJECT.getKey(), ReactorKeysEnum.FUNCTION.getKey(),
 				ReactorKeysEnum.PARAM_VALUES_MAP.getKey() };
-		this.keyRequired = new int[] { 1, 1, 1 };
+		this.keyRequired = new int[] { 0, 1, 1 };
 	}
 
 	@Override
 	public NounMetadata execute() {
 		organizeKeys();
 		String engineId = this.keyValue.get(this.keysToGet[0]);
+		if (engineId == null || engineId.isEmpty()) {
+			engineId = insight.getContextProjectId();
+			if (engineId == null || engineId.isEmpty()) {
+				engineId = insight.getProjectId();
+			}
+		}
+		if (engineId == null || (engineId = engineId.trim()).isEmpty()) {
+			throw new IllegalArgumentException("Must provide the project id or set the app context");
+		}
 		IEngine engine = null;
 		try {
 			engine = Utility.getEngine(engineId);


### PR DESCRIPTION
## Description
If project is not passed in RunMCPTool, use the current project as context

## Description
Basically the same as https://github.com/SEMOSS/Semoss/pull/1672
