### PR TITLE
fix(engine-access): delete stale access requests when engine/project …

### DIFF
--- a/src/prerna/auth/utils/SecurityEngineUtils.java
+++ b/src/prerna/auth/utils/SecurityEngineUtils.java
@@ -1205,12 +1205,8 @@ public class SecurityEngineUtils extends AbstractSecurityUtils {
 	public static void deleteEngine(String engineId) {
 		List<String> deletes = new ArrayList<>();
 		deletes.add("DELETE FROM ENGINE WHERE ENGINEID=?");
-//		deletes.add("DELETE FROM INSIGHT WHERE ENGINEID=?");
 		deletes.add("DELETE FROM ENGINEPERMISSION WHERE ENGINEID=?");
 		deletes.add("DELETE FROM ENGINEMETA WHERE ENGINEID=?");
-//		deletes.add("DELETE FROM WORKSPACEENGINE WHERE ENGINEID=?");
-//		deletes.add("DELETE FROM ASSETENGINE WHERE ENGINEID=?");
-		// delete stale access requests linked to this engine
 		deletes.add("DELETE FROM ENGINEACCESSREQUEST WHERE ENGINEID=?");
 
 		for (String deleteQuery : deletes) {
@@ -1242,7 +1238,8 @@ public class SecurityEngineUtils extends AbstractSecurityUtils {
 			throws IllegalAccessException {
 		// make sure user can edit the database
 		int userPermissionLvl = getMaxUserEnginePermission(user, engineId);
-		if (!AccessPermissionEnum.isEditor(userPermissionLvl) && !user.getPrimaryLoginToken().getId().equals(existingUserId)) {
+		if (!AccessPermissionEnum.isEditor(userPermissionLvl)
+				&& !user.getPrimaryLoginToken().getId().equals(existingUserId)) {
 			throw new IllegalAccessException("Insufficient privileges to modify this engine's permissions.");
 		}
 

--- a/src/prerna/auth/utils/SecurityEngineUtils.java
+++ b/src/prerna/auth/utils/SecurityEngineUtils.java
@@ -1210,6 +1210,8 @@ public class SecurityEngineUtils extends AbstractSecurityUtils {
 		deletes.add("DELETE FROM ENGINEMETA WHERE ENGINEID=?");
 //		deletes.add("DELETE FROM WORKSPACEENGINE WHERE ENGINEID=?");
 //		deletes.add("DELETE FROM ASSETENGINE WHERE ENGINEID=?");
+		// delete stale access requests linked to this engine
+		deletes.add("DELETE FROM ENGINEACCESSREQUEST WHERE ENGINEID=?");
 
 		for (String deleteQuery : deletes) {
 			PreparedStatement ps = null;

--- a/src/prerna/auth/utils/SecurityProjectUtils.java
+++ b/src/prerna/auth/utils/SecurityProjectUtils.java
@@ -1518,9 +1518,7 @@ public class SecurityProjectUtils extends AbstractSecurityUtils {
 		deletes.add("DELETE FROM PROJECTMETA WHERE PROJECTID=?");
 		deletes.add("DELETE FROM WORKSPACEENGINE WHERE PROJECTID=?");
 		deletes.add("DELETE FROM ASSETENGINE WHERE PROJECTID=?");
-		// delete stale access requests linked to this project
 		deletes.add("DELETE FROM PROJECTACCESSREQUEST WHERE PROJECTID=?");
-		// TODO: add the other tables...
 
 		for (String deleteQuery : deletes) {
 			PreparedStatement ps = null;

--- a/src/prerna/auth/utils/SecurityProjectUtils.java
+++ b/src/prerna/auth/utils/SecurityProjectUtils.java
@@ -1518,6 +1518,8 @@ public class SecurityProjectUtils extends AbstractSecurityUtils {
 		deletes.add("DELETE FROM PROJECTMETA WHERE PROJECTID=?");
 		deletes.add("DELETE FROM WORKSPACEENGINE WHERE PROJECTID=?");
 		deletes.add("DELETE FROM ASSETENGINE WHERE PROJECTID=?");
+		// delete stale access requests linked to this project
+		deletes.add("DELETE FROM PROJECTACCESSREQUEST WHERE PROJECTID=?");
 		// TODO: add the other tables...
 
 		for (String deleteQuery : deletes) {


### PR DESCRIPTION
## Description
Delete stale access requests when engine/project is deleted

For fix: Added logic in both **deleteEngine** and **deleteProject** reactors to clean up stale **ENGINEACCESSREQUEST**/ **PROJECTACCESSREQUEST** entries during deletion.
