### PR TITLE
Support Interleaved Text and Image Responses for Google GenAI

### DIFF
--- a/py/genai_client/constants.py
+++ b/py/genai_client/constants.py
@@ -1,4 +1,4 @@
-from typing import List, Any
+from typing import List, Any, Optional
 import dataclasses
 
 MODEL_NAME = "model_name"
@@ -52,6 +52,7 @@ class AskModelEngineResponse(AbstractModelEngineResponse):
 
     Attributes:
         response: response from api.
+        response_media: any type of media response from the api including base64 images, audio bytes, etc.
         responseTokens: response token count.
         promptTokens: prompt token count.
         messageType: response message type
@@ -62,13 +63,14 @@ class AskModelEngineResponse(AbstractModelEngineResponse):
     """
 
     response: Any = ""
+    response_media: Optional[List[Any]] = None
     response_tokens: int = 0
     prompt_tokens: int = 0
     messageType: str = "CHAT"
-    thinking: List[str] = None
-    warning: str = None
-    tokens: List[str] = None
-    logprobs: List[float] = None
+    thinking: Optional[List[str]] = None
+    warning: Optional[str] = None
+    tokens: Optional[List[str]] = None
+    logprobs: Optional[List[float]] = None
 
 
 class EmbeddingsModelEngineResponse(AbstractModelEngineResponse):

--- a/py/genai_client/message_builders/google_genai/google_genai_builder.py
+++ b/py/genai_client/message_builders/google_genai/google_genai_builder.py
@@ -209,17 +209,33 @@ class GoogleGenAIMessageBuilder:
 
         stream = kwargs.pop("streaming", None)
         if stream is None:
-            stream = kwargs.pop("stream", None)
-        if stream is None:
-            stream = True
+            stream = kwargs.pop("stream", True)
 
-        if stream is not None and isinstance(stream, str):
+        if isinstance(stream, str):
             try:
                 stream = string_to_bool(stream)
             except ValueError:
-                stream = False
+                stream = True
 
         thinking_config = self._resolve_thinking_config(kwargs)
+
+        response_modalities = (
+            [m.upper() for m in self.model_settings.modalities]
+            if self.model_settings.modalities
+            else ["TEXT"]
+        )
+
+        if "IMAGE" in response_modalities:
+            image_config = types.ImageConfig(
+                aspect_ratio=kwargs.pop("image_aspect_ratio", None),
+                image_size=kwargs.pop("image_size", None),
+                output_mime_type=kwargs.pop("output_mime_type", None),
+                output_compression_quality=kwargs.pop(
+                    "output_compression_quality", None
+                ),
+            )
+        else:
+            image_config = None
 
         config = types.GenerateContentConfig(
             http_options=kwargs.pop("http_options", None),
@@ -231,13 +247,14 @@ class GoogleGenAIMessageBuilder:
             stop_sequences=kwargs.pop("stop_sequences", None),
             presence_penalty=kwargs.pop("presence_penalty", None),
             frequency_penalty=kwargs.pop("frequency_penalty", None),
-            # TODO: Pass this from the init.. this lives in smss
-            safety_settings=None,
+            safety_settings=None,  # TODO: Pass this from the init.. this lives in smss
             response_schema=structured_response_schema,
             response_mime_type=response_mime_type,
             tools=tools,
             tool_config=tool_config,
             thinking_config=thinking_config,
+            response_modalities=response_modalities,
+            image_config=image_config,
         )
 
         return config, stream

--- a/py/genai_client/message_builders/semoss_base/semoss_models.py
+++ b/py/genai_client/message_builders/semoss_base/semoss_models.py
@@ -66,25 +66,6 @@ class SEMOSSMessage(BaseModel):
         use_enum_values = True
 
 
-class AskSettings(BaseModel):
-    """
-    Represents all of the conditional settings that affect the model call but are not passed
-    as parameters to the model call itself.
-
-    *NOTE: The only purpose for this right now is for the new clients until we fully go to semoss messages.
-    """
-
-    full_prompt: Optional[List[Dict]] = None
-    streaming: bool = False
-    use_history: bool = True
-    history: Optional[List[Dict]] = None
-    image_url: Optional[List[str]] = None
-    image_encoded: Optional[List[str]] = None
-    semoss_messages: Optional[List[SEMOSSMessage]] = None
-    system_prompt: Optional[str] = None
-    extra_params: Optional[Dict[str, Any]] = None
-
-
 class ModelSettings(BaseModel):
     """These are attributes I want set in the SMSS file for each model"""
 
@@ -100,3 +81,4 @@ class ModelSettings(BaseModel):
     tokens_param_name: Optional[str] = None
     thinking: Optional[bool] = False
     thinking_budget: Optional[int] = None
+    modalities: Optional[List[str]] = None

--- a/py/genai_client/text_generation/abstract_text_generation_client.py
+++ b/py/genai_client/text_generation/abstract_text_generation_client.py
@@ -7,12 +7,10 @@ from pydantic import BaseModel
 from ..constants import (
     AskModelEngineResponse,
     EmbeddingsModelEngineResponse,
-    FULL_PROMPT,
 )
 from ..message_builders.semoss_base.semoss_message_builder import SEMOSSMessageBuilder
 from ..message_builders.semoss_base.semoss_models import (
     ModelSettings,
-    AskSettings,
     SEMOSSMessage,
 )
 from ..utils import string_to_bool
@@ -29,8 +27,8 @@ class AbstractTextGenerationClient(ABC):
     # fills the templates and gives information back
     def __init__(
         self,
-        template: Union[Dict, str] = None,
-        template_name: str = None,
+        template: Optional[Union[Dict, str]] = None,
+        template_name: Optional[str] = None,
         **kwargs: Any,
     ):
         self.model_name = kwargs.pop("model_name", None)
@@ -79,6 +77,7 @@ class AbstractTextGenerationClient(ABC):
             tokens_param_name=tokens_param_name,
             thinking=thinking,
             thinking_budget=thinking_budget,
+            modalities=kwargs.pop("modalities", None),
         )
 
     def _handle_template_args(self, template):
@@ -149,93 +148,14 @@ class AbstractTextGenerationClient(ABC):
 
                 message_json = json.loads(decoded_string)
                 semoss_messages = SEMOSSMessageBuilder().build_messages(
-                    input_messages=message_json, param_map=param_map
+                    input_messages=message_json,
+                    param_map=param_map,
+                    model_settings=model_settings,
                 )
             except Exception as e:
                 raise ValueError(f"Invalid JSON format in message_json.: {e}")
 
         return semoss_messages
-
-    def get_ask_settings(
-        self,
-        model_settings: ModelSettings,
-        **kwargs,
-    ) -> AskSettings:
-        """Get the ask settings from the provided keyword arguments."""
-        full_prompt = kwargs.pop(FULL_PROMPT, None)
-        if (
-            full_prompt
-            and isinstance(full_prompt, List)
-            and isinstance(full_prompt[0], str)
-        ):
-            full_prompt = [json.loads(i) for i in full_prompt]
-
-        streaming = kwargs.pop("stream", False)
-        if not streaming:
-            streaming = kwargs.pop("streaming", False)
-
-        streaming = string_to_bool(streaming)
-
-        message_json = kwargs.pop("message_json", None)
-
-        if message_json:
-            json_messages_param_map = {
-                "stream": streaming,
-                **kwargs,
-            }
-            try:
-                message_json = json.loads(message_json)
-                semoss_messages = SEMOSSMessageBuilder().build_messages(
-                    input_messages=message_json,
-                    param_map=json_messages_param_map,
-                    model_settings=model_settings,
-                )
-            except json.JSONDecodeError:
-                try:
-                    decoded_string = message_json.replace('\\n",', '",')
-                    decoded_string = decoded_string.encode().decode("unicode_escape")
-
-                    message_json = json.loads(decoded_string)
-                    semoss_messages = SEMOSSMessageBuilder().build_messages(
-                        input_messages=message_json, param_map=json_messages_param_map
-                    )
-                except Exception as e:
-                    raise ValueError(f"Invalid JSON format in message_json.: {e}")
-
-            if len(semoss_messages):
-                json_messages_param_map = semoss_messages[-1].param_map
-
-                if json_messages_param_map.get("stream"):
-                    streaming = json_messages_param_map["stream"]
-        else:
-            semoss_messages = None
-
-        image_url = kwargs.pop("image_url", None)
-        if isinstance(image_url, str):
-            image_url = [image_url]
-
-        image_encoded = kwargs.pop("image_encoded", None)
-        if isinstance(image_encoded, str):
-            image_encoded = [image_encoded]
-
-        use_history = kwargs.pop("use_history", True)
-        if not use_history:
-            history = None
-        else:
-            history = kwargs.pop("history", None)
-
-        context = kwargs.pop("context", None)
-
-        return AskSettings(
-            full_prompt=full_prompt,
-            streaming=streaming or False,
-            history=history,
-            image_url=image_url,
-            image_encoded=image_encoded,
-            semoss_messages=semoss_messages,
-            system_prompt=context,
-            extra_params=kwargs,
-        )
 
     def get_template(self, template_name=None, **kwargs):
         if template_name in self.templates.keys():

--- a/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
+++ b/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
@@ -187,6 +187,7 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
         smss_stream = get_smss_stream()
         final_response = ""
         thinking_response = ""
+        image_data = []
         input_tokens = 0
         output_tokens = 0
 
@@ -213,6 +214,13 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
                                 and hasattr(part, "text")
                             ):
                                 thinking_response += part.text
+                            if part.inline_data:
+                                image_data.append(
+                                    self._create_image_url(
+                                        mime_type=part.inline_data.mime_type,
+                                        image_bytes=part.inline_data.data,
+                                    )
+                                )
 
                 if event.text:
                     this_content_block["final_response"] = ""
@@ -324,6 +332,7 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
                             response=json_str,
                             response_tokens=output_tokens,
                             prompt_tokens=input_tokens,
+                            response_media=image_data,
                             messageType="CHAT",
                             thinking=thinking_response if thinking_response else None,
                         )
@@ -332,6 +341,7 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
                         response=tool_result,
                         response_tokens=output_tokens,
                         prompt_tokens=input_tokens,
+                        response_media=image_data,
                         messageType="TOOL",
                     )
             else:
@@ -340,6 +350,7 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
                     thinking=thinking_response if thinking_response else None,
                     response_tokens=output_tokens,
                     prompt_tokens=input_tokens,
+                    response_media=image_data,
                     messageType="CHAT",
                 )
         except Exception as e:

--- a/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
+++ b/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
@@ -1,3 +1,4 @@
+import json, base64
 from typing import List, Optional, Dict
 from pydantic import BaseModel
 from google.genai import types
@@ -14,7 +15,6 @@ from ...message_builders.google_genai.google_genai_builder import (
 from ...retry_handler import RetryHandler
 from smss_thread_local import get_smss_stream
 from ...message_builders.semoss_base.semoss_streaming_util import StreamUtil
-import json
 
 
 class UsageMetadata(BaseModel):
@@ -33,12 +33,12 @@ class StreamingResponse(BaseModel):
 class GoogleGenAiTextClient(AbstractTextGenerationClient):
     def __init__(
         self,
-        service_account_credentials: Dict = None,
-        service_account_key_file: str = None,
-        region: str = None,
-        project: str = None,
-        api_key: str = None,
-        safety_settings: dict = None,
+        service_account_credentials: Optional[Dict] = None,
+        service_account_key_file: Optional[str] = None,
+        region: Optional[str] = None,
+        project: Optional[str] = None,
+        api_key: Optional[str] = None,
+        safety_settings: Optional[dict] = None,
         **kwargs,
     ):
         super().__init__(
@@ -113,6 +113,7 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
             )
 
         thinking_text = ""
+        image_data = []
 
         if hasattr(model_response, "candidates") and len(model_response.candidates) > 0:
             first = model_response.candidates[0]
@@ -120,17 +121,24 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
                 first.content, "parts", None
             ):
                 for part in first.content.parts:
-                    part_text = getattr(part, "text", None)
-                    if not part_text:
-                        continue
-                    if getattr(part, "thought", False):
-                        thinking_text += part_text
+                    if getattr(part, "text", False) and getattr(part, "thought", False):
+                        thinking_text += getattr(part, "text", "")
+                    if part.inline_data:
+                        image_data.append(
+                            self._create_image_url(
+                                mime_type=part.inline_data.mime_type,
+                                image_bytes=part.inline_data.data,
+                            )
+                        )
 
         if thinking_text == "":
             thinking_text = None
 
+        text_response = model_response.text if model_response.text else ""
+
         return AskModelEngineResponse(
-            response=model_response.text,
+            response=text_response,
+            response_media=image_data,
             prompt_tokens=prompt_tokens,
             response_tokens=response_tokens,
             messageType="CHAT",
@@ -394,3 +402,9 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
             json_str = str(final_py)
 
         return True, json_str
+
+    def _create_image_url(self, mime_type: str, image_bytes: str):
+        """Creating base64 string URL for generated image from bytes."""
+        return (
+            f"data:{mime_type};base64,{base64.b64encode(image_bytes).decode('utf-8')}"
+        )

--- a/py/install_config/pyproject.toml
+++ b/py/install_config/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "gliner>=0.2.22",
     "google-auth>=2.38.0",
     "google-cloud-aiplatform==1.112.0",
-    "google-genai==1.36.0",
+    "google-genai==1.52.0",
     "guidance>=0.2.0",
     "gunicorn>=23.0.0",
     "huggingface-hub>=0.29.3",


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Support interleaved text and image responses for Google models such as Gemini 3 Pro Image. This PR is for the Python implementation only. Now returns a `response_media` field in the Python response. 

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->

```python
from ai_server import ServerClient

secret_key = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
access_key = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
url = "http://localhost:9090/Monolith/api"

engine_id = "ff9a50fa-fc84-4eb8-b76a-16bec2cc0bee"


def test_interleaved():
    server_client = ServerClient(secret_key=secret_key, access_key=access_key, base=url)
    room_id = server_client.run_pixel("CreateRoom();").get("roomId", None)

    param_values = {"stream": True}

    command = "Generate an illustrated recipe for a paella. Create images alongside the text as you generate the recipe."

    llm_pixel = f'LLM(roomId=["{room_id}"], engine=["{engine_id}"], command=["{command}"], paramValues=[{param_values}]);'

    print(f"Running Pixel: {llm_pixel}")

    try:
        llm_response = server_client.run_pixel(llm_pixel)
        print(llm_response)
    except Exception as e:
        raise RuntimeError(f"PHASE 1: Failed to run LLM pixel: {e}")


if __name__ == "__main__":
    test_interleaved()
```

## Notes
<!-- Any further notes regarding changes -->