### PR TITLE
fix: runtime error with building messages

### DIFF
--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -445,9 +445,11 @@ class AnthropicMessageBuilder:
         top_p = kwargs.pop("top_p", None)
         # Temperature must be set to 1 and top_p must be at least 0.95 when using extended thinking..
         if thinking_map:
-            temperature = 1
-            if top_p < 0.95 or top_p is None:
+            if top_p is None or top_p < 0.95:
                 top_p = 0.95
+            temperature = None
+        else:
+            top_p = None
 
         return AnthropicRequestConfig(
             model=self.model_name,

--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -443,13 +443,17 @@ class AnthropicMessageBuilder:
 
         temperature = kwargs.pop("temperature", None)
         top_p = kwargs.pop("top_p", None)
-        # Temperature must be set to 1 and top_p must be at least 0.95 when using extended thinking..
+
         if thinking_map:
-            if top_p is None or top_p < 0.95:
-                top_p = 0.95
-            temperature = None
-        else:
-            top_p = None
+            # top_p between 0.95 to 1 when thinking
+            if top_p is not None:
+                if top_p < 0.95:
+                    top_p = 0.95
+                elif top_p > 1:
+                    top_p = 1
+            # temperature can only be 1 when thinking
+            if temperature is not None:
+                temperature = 1
 
         return AnthropicRequestConfig(
             model=self.model_name,


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Fixed this bug when using Claude Sonnet 4 Anthropic Vertex Model in Playground

```
  File "<string>", line 1, in <module>
  File "C:\workspace\Semoss\py\genai_client\text_generation\abstract_text_generation_client.py", line 286, in ask
    return self.ask_call(*args, **kwargs).to_dict()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\workspace\Semoss\py\genai_client\text_generation\anthropic_client\anthropic_text_client.py", line 118, in ask_call
    raise RuntimeError(
RuntimeError: Failed to build messages in Anthropic format from SEMOSS format: '<' not supported between instances of 'NoneType' and 'float'
```

## Changes Made
<!-- List the key changes made in this PR -->
- Switched order to check if `top_p` is None first
- Changes top p if thinking is on, otherwise changes temperature
- *top p and temperature can't both be on at the same time. If thinking is on, temperature must be a constant value, so top p will be changed. Otherwise, temperature is changed due to it being directly changed through the UI*


## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
- Test anthropic model in playground on localhost
- Test with thinking on and off to see if it works
2. Expected outcomes
- Model should not return an error
## Notes
<!-- Any further notes regarding changes -->