### PR TITLE
Feat: Support hover steps in Playwright app

### DIFF
--- a/src/prerna/reactor/playwright/PlaywrightSessionUtility.java
+++ b/src/prerna/reactor/playwright/PlaywrightSessionUtility.java
@@ -121,6 +121,7 @@ public class PlaywrightSessionUtility {
 		case TYPE -> typeStep(page, step);
 		case SCROLL -> scrollStep(page, step);
 		case WAIT -> waitStep(page, step);
+		case HOVER -> hoverStep(page, step);
 		case CONTEXT -> {
 			return;
 		}
@@ -281,6 +282,54 @@ public class PlaywrightSessionUtility {
 		} catch (Exception ignore) {
 			return false;
 		}
+	}
+
+	/**
+	 * Attempts to hover over an element.
+	 *
+	 * @param page The Playwright Page object.
+	 * @param step The PlaywrightStep containing hover information.
+	 * @return true if hovering was successful, false otherwise.
+	 */
+	private static boolean hoverWithFallback(Page page, PlaywrightStep step) {
+		boolean hovered = false;
+
+		// 1) Try selector
+		Locator loc = resolveLocator(page, step.selector());
+		if (loc != null && isActionable(loc)) {
+			try {
+				loc.hover(new Locator.HoverOptions().setTimeout(300));
+				hovered = true;
+			} catch (Exception ignore) {
+			}
+		}
+
+		// 2) Try healed selector from coords
+		if (!hovered && step.coords() != null) {
+			Locator healed = null;
+			try {
+				healed = healSelector(page, step.coords().x(), step.coords().y());
+			} catch (Exception ignore) {
+			}
+			if (healed != null && isActionable(healed)) {
+				try {
+					healed.hover(new Locator.HoverOptions().setTimeout(300));
+					hovered = true;
+				} catch (Exception ignore) {
+				}
+			}
+		}
+
+		// 3) Try raw coords
+		if (!hovered && step.coords() != null && coordHasHit(page, step.coords().x(), step.coords().y())) {
+			try {
+				page.mouse().move(step.coords().x(), step.coords().y());
+				hovered = true;
+			} catch (Exception ignore) {
+			}
+		}
+
+		return hovered;
 	}
 
 	/**
@@ -613,6 +662,34 @@ public class PlaywrightSessionUtility {
 		int deltaY = step.deltaY() != null ? step.deltaY() : 300;
 		page.mouse().wheel(0, deltaY);
 		classLogger.info("[ACTION] SCROLL took {} ms (deltaY={})", System.currentTimeMillis() - start, deltaY);
+	}
+
+	/**
+	 * Executes a hover step.
+	 *
+	 * @param page The Playwright Page object.
+	 * @param step The PlaywrightStep containing hover information.
+	 */
+	private static void hoverStep(Page page, PlaywrightStep step) {
+		long start = System.currentTimeMillis();
+		if (step.selector() != null) {
+			Locator loc = resolveLocator(page, step.selector());
+			if (loc == null) {
+				// No selector match 
+				throw new PlaywrightException("SELECTOR_NOT_FOUND: " + step.selector().value());
+			}
+		}
+		boolean ok = hoverWithFallback(page, step);
+
+		if (!ok) {
+			throw new PlaywrightException(
+					"NO_EFFECT: hover had no actionable target (selector not found & no hit at coords).");
+		}
+
+        page.waitForTimeout(100);
+
+		classLogger.info("[ACTION] HOVER took {} ms (selector={})", System.currentTimeMillis() - start,
+				step.selector() != null ? step.selector().value() : "coords");
 	}
 
 	/**

--- a/src/prerna/reactor/playwright/PlaywrightStepType.java
+++ b/src/prerna/reactor/playwright/PlaywrightStepType.java
@@ -1,5 +1,5 @@
 package prerna.reactor.playwright;
 
 public enum PlaywrightStepType {
-	NAVIGATE, CLICK, TYPE, SCROLL, WAIT, CONTEXT
+	NAVIGATE, CLICK, TYPE, SCROLL, WAIT, CONTEXT, HOVER
 }

--- a/src/prerna/reactor/playwright/ReplaySingleStepReactor.java
+++ b/src/prerna/reactor/playwright/ReplaySingleStepReactor.java
@@ -278,6 +278,16 @@ public class ReplaySingleStepReactor extends AbstractReactor {
 			// Context steps don't need validation
 			break;
 
+		case HOVER:
+			// Validate hover has coordinates
+			if (step.coords() == null) {
+				return "Missing coordinates for hover";
+			}
+			if (!canFindElement(playwrightSession, step, tabId)) {
+				return "Element not found or not ready at coordinates: " + step.coords();
+			}
+			break;
+
 		default:
 			return "Unknown step type: " + step.type();
 		}

--- a/src/prerna/reactor/playwright/ReplayStepReactor.java
+++ b/src/prerna/reactor/playwright/ReplayStepReactor.java
@@ -500,6 +500,9 @@ public class ReplayStepReactor extends AbstractReactor {
 			case CONTEXT:
 				action.put("CONTEXT", Map.of("multiCoords", current.multiCoords(), "prompt", current.prompt()));
 				break;
+			case HOVER:
+				action.put("HOVER", current.coords());
+				break;
 			default:
 				break;
 			}

--- a/src/prerna/reactor/playwright/SkipStepReactor.java
+++ b/src/prerna/reactor/playwright/SkipStepReactor.java
@@ -183,6 +183,9 @@ public class SkipStepReactor extends AbstractReactor {
 			case CONTEXT:
 				action.put("CONTEXT", Map.of(current.multiCoords(), current.prompt()));
 				break;
+			case HOVER:
+				action.put("HOVER", current.coords());
+				break;
 			default:
 				break;
 			}


### PR DESCRIPTION
## Description
Added HOVER step type for Playwright automation to trigger hover effects like tooltips and dropdowns.

## Changes Made
Added HOVER enum to PlaywrightStepType
Implemented hover execution with fallback in PlaywrightSessionUtility
Added HOVER validation and serialization to reactors

## How to Test
1. Navigate to page with hover tooltips
2. Send HOVER step with coordinates
3. Verify tooltips/dropdowns appear
