### PR TITLE
fix: remove js evaluate delay and return tag from probe

### DIFF
--- a/src/prerna/reactor/playwright/GetAllStepsReactor.java
+++ b/src/prerna/reactor/playwright/GetAllStepsReactor.java
@@ -57,6 +57,10 @@ public class GetAllStepsReactor extends AbstractReactor {
 						stepMap.put("shouldRun", step.shouldRun());
 					}
 
+					if (step.tag() != null) {
+						stepMap.put("tag", step.tag());
+					}
+
 					if (step.required() != null) {
 						stepMap.put("required", step.required());
 					}

--- a/src/prerna/reactor/playwright/PlaywrightSessionUtility.java
+++ b/src/prerna/reactor/playwright/PlaywrightSessionUtility.java
@@ -310,15 +310,8 @@ public class PlaywrightSessionUtility {
 		boolean hovered = false;
 
 		// Check if target is a canvas element, if yes use coords only
-		boolean isCanvas = false;
+		boolean isCanvas = step.tag() != null && "canvas".equals(step.tag().toLowerCase());
 		Locator loc = resolveLocator(page, step.selector());
-		if (loc != null) {
-			try {
-				String tagName = loc.evaluate("el => el.tagName.toLowerCase()").toString();
-				isCanvas = "canvas".equals(tagName);
-			} catch (Exception ignore) {
-			}
-		}
 
 		// 1) Try selector
 		if (loc != null && !(isCanvas && step.coords() != null)) {
@@ -401,15 +394,8 @@ public class PlaywrightSessionUtility {
 	 */
 	private static boolean tryClick(Page page, PlaywrightStep step) {
 		// Check if target is a canvas element
-		boolean isCanvas = false;
+        boolean isCanvas = step.tag() != null && "canvas".equals(step.tag().toLowerCase());
 		Locator loc = resolveLocator(page, step.selector());
-		if (loc != null) {
-			try {
-				String tagName = loc.evaluate("el => el.tagName.toLowerCase()").toString();
-				isCanvas = "canvas".equals(tagName);
-			} catch (Exception ignore) {
-			}
-		}
 
 		// 1) Try selector
 		if (loc != null && !(isCanvas && step.coords() != null)) {

--- a/src/prerna/reactor/playwright/PlaywrightSessionUtility.java
+++ b/src/prerna/reactor/playwright/PlaywrightSessionUtility.java
@@ -394,7 +394,7 @@ public class PlaywrightSessionUtility {
 	 */
 	private static boolean tryClick(Page page, PlaywrightStep step) {
 		// Check if target is a canvas element
-        boolean isCanvas = step.tag() != null && "canvas".equals(step.tag().toLowerCase());
+		boolean isCanvas = step.tag() != null && "canvas".equals(step.tag().toLowerCase());
 		Locator loc = resolveLocator(page, step.selector());
 
 		// 1) Try selector

--- a/src/prerna/reactor/playwright/PlaywrightStep.java
+++ b/src/prerna/reactor/playwright/PlaywrightStep.java
@@ -42,11 +42,13 @@ import java.util.List;
  * @param shouldRun       A boolean indicating if this step should be executed
  *                        during replay.
  * @param required        A boolean indicating if this step is mandatory.
+ * 
+ * @param tag             An optional tag associated with the step, the element tag from ProbeElement response.
  */
 public record PlaywrightStep(int id, PlaywrightStepType type, String url, Coords coords, List<Coords> multiCoords,
 		String prompt, String text, Boolean pressEnter, Integer deltaY, String waitUntil, Integer waitAfterMs,
 		Viewport viewport, Long timestamp, String label, String description, boolean isPassword, boolean storeValue,
-		Selector selector, TriggerNewTab isTriggerNewTab, Boolean shouldRun, Boolean required) {
+		Selector selector, TriggerNewTab isTriggerNewTab, Boolean shouldRun, Boolean required, String tag) {
 
 	/**
 	 * Convenience constructor to create a new PlaywrightStep by copying an existing
@@ -58,7 +60,7 @@ public record PlaywrightStep(int id, PlaywrightStepType type, String url, Coords
 	PlaywrightStep(PlaywrightStep s, String text) {
 		this(s.id, s.type, s.url, s.coords, s.multiCoords, s.prompt, text, s.pressEnter, s.deltaY, s.waitUntil,
 				s.waitAfterMs, s.viewport, s.timestamp, s.label, s.description, s.isPassword, s.storeValue, s.selector,
-				s.isTriggerNewTab, s.shouldRun, s.required);
+				s.isTriggerNewTab, s.shouldRun, s.required, s.tag);
 	}
 
 	/**
@@ -71,7 +73,7 @@ public record PlaywrightStep(int id, PlaywrightStepType type, String url, Coords
 	PlaywrightStep(PlaywrightStep s, int id) {
 		this(id, s.type, s.url, s.coords, s.multiCoords, s.prompt, s.text, s.pressEnter, s.deltaY, s.waitUntil,
 				s.waitAfterMs, s.viewport, s.timestamp, s.label, s.description, s.isPassword, s.storeValue, s.selector,
-				s.isTriggerNewTab, s.shouldRun, s.required);
+				s.isTriggerNewTab, s.shouldRun, s.required, s.tag);
 	}
 
 	/**
@@ -91,6 +93,6 @@ public record PlaywrightStep(int id, PlaywrightStepType type, String url, Coords
 			boolean shouldRun, boolean required) {
 		this(s.id, s.type, s.url, s.coords, s.multiCoords, s.prompt, text, s.pressEnter, s.deltaY, s.waitUntil,
 				s.waitAfterMs, s.viewport, s.timestamp, label, description, s.isPassword, storeValue, s.selector,
-				s.isTriggerNewTab, shouldRun, required);
+				s.isTriggerNewTab, shouldRun, required, s.tag);
 	}
 }

--- a/src/prerna/reactor/playwright/PlaywrightStep.java
+++ b/src/prerna/reactor/playwright/PlaywrightStep.java
@@ -43,7 +43,8 @@ import java.util.List;
  *                        during replay.
  * @param required        A boolean indicating if this step is mandatory.
  * 
- * @param tag             An optional tag associated with the step, the element tag from ProbeElement response.
+ * @param tag             An optional tag associated with the step, the element
+ *                        tag from ProbeElement response.
  */
 public record PlaywrightStep(int id, PlaywrightStepType type, String url, Coords coords, List<Coords> multiCoords,
 		String prompt, String text, Boolean pressEnter, Integer deltaY, String waitUntil, Integer waitAfterMs,

--- a/src/prerna/reactor/playwright/StepReactor.java
+++ b/src/prerna/reactor/playwright/StepReactor.java
@@ -147,7 +147,8 @@ public class StepReactor extends AbstractReactor {
 			newStep = new PlaywrightStep(stepId, step.type(), step.url(), step.coords(), step.multiCoords(),
 					step.prompt(), "", step.pressEnter(), step.deltaY(), step.waitUntil(), step.waitAfterMs(),
 					step.viewport(), step.timestamp(), step.label(), step.description(), step.isPassword(),
-					step.storeValue(), step.selector(), step.isTriggerNewTab(), step.shouldRun(), step.required(), step.tag());
+					step.storeValue(), step.selector(), step.isTriggerNewTab(), step.shouldRun(), step.required(),
+					step.tag());
 		}
 
 		if (isNewTab && newTabId != null) {

--- a/src/prerna/reactor/playwright/StepReactor.java
+++ b/src/prerna/reactor/playwright/StepReactor.java
@@ -147,7 +147,7 @@ public class StepReactor extends AbstractReactor {
 			newStep = new PlaywrightStep(stepId, step.type(), step.url(), step.coords(), step.multiCoords(),
 					step.prompt(), "", step.pressEnter(), step.deltaY(), step.waitUntil(), step.waitAfterMs(),
 					step.viewport(), step.timestamp(), step.label(), step.description(), step.isPassword(),
-					step.storeValue(), step.selector(), step.isTriggerNewTab(), step.shouldRun(), step.required());
+					step.storeValue(), step.selector(), step.isTriggerNewTab(), step.shouldRun(), step.required(), step.tag());
 		}
 
 		if (isNewTab && newTabId != null) {
@@ -156,7 +156,7 @@ public class StepReactor extends AbstractReactor {
 					step.prompt(), newStep.text(), newStep.pressEnter(), newStep.deltaY(), newStep.waitUntil(),
 					newStep.waitAfterMs(), newStep.viewport(), newStep.timestamp(), newStep.label(),
 					newStep.description(), newStep.isPassword(), newStep.storeValue(), newStep.selector(),
-					triggerNewTab, newStep.shouldRun(), newStep.required());
+					triggerNewTab, newStep.shouldRun(), newStep.required(), step.tag());
 			playwrightSession.addChildTabRelationship(tabId, newTabId);
 		}
 


### PR DESCRIPTION
## Description
Removed the JS evaluate function and return tag from the probe element response to check on the Canvas tag and handle accordingly. This is to fix the delay time of the click steps.
