### PR TITLE
feat: add return to playground tag to context step

### DIFF
--- a/src/prerna/reactor/playwright/GetAllStepsReactor.java
+++ b/src/prerna/reactor/playwright/GetAllStepsReactor.java
@@ -106,7 +106,7 @@ public class GetAllStepsReactor extends AbstractReactor {
 						if (step.prompt() != null) {
 							stepMap.put("prompt", step.prompt());
 						}
-						if(step.sendToPlayground() != null) {
+						if (step.sendToPlayground() != null) {
 							stepMap.put("sendToPlayground", step.sendToPlayground());
 						}
 					}

--- a/src/prerna/reactor/playwright/GetAllStepsReactor.java
+++ b/src/prerna/reactor/playwright/GetAllStepsReactor.java
@@ -106,6 +106,9 @@ public class GetAllStepsReactor extends AbstractReactor {
 						if (step.prompt() != null) {
 							stepMap.put("prompt", step.prompt());
 						}
+						if(step.sendToPlayground() != null) {
+							stepMap.put("sendToPlayground", step.sendToPlayground());
+						}
 					}
 					if (step.waitAfterMs() != null) {
 						stepMap.put("waitAfterMs", step.waitAfterMs());

--- a/src/prerna/reactor/playwright/PlaywrightStep.java
+++ b/src/prerna/reactor/playwright/PlaywrightStep.java
@@ -7,52 +7,53 @@ import java.util.List;
  * sequence. This record is an immutable data carrier designed to hold all
  * necessary information to execute a specific step.
  *
- * @param id              A unique identifier for the step.
- * @param type            The type of action (e.g., NAVIGATE, CLICK, TYPE,
- *                        SCROLL, WAIT, CONTEXT), defined by
- *                        {@link PlaywrightStepType}.
- * @param url             The URL to navigate to (for NAVIGATE steps).
- * @param coords          Coordinates (x, y) for actions like CLICK, TYPE,
- *                        SCROLL.
- * @param multiCoords     A list of coordinates for CONTEXT steps, possibly for
- *                        defining an area.
- * @param prompt          A prompt string for CONTEXT steps.
- * @param text            The text to type (for TYPE steps).
- * @param pressEnter      A boolean indicating whether to press Enter after
- *                        typing (for TYPE steps).
- * @param deltaY          The vertical scroll amount (for SCROLL steps).
- * @param waitUntil       A condition to wait for after navigation (for NAVIGATE
- *                        steps).
- * @param waitAfterMs     A generic wait duration in milliseconds after an
- *                        action.
- * @param viewport        The viewport dimensions when the coordinates were
- *                        computed against.
- * @param timestamp       The time when the step was recorded or created (epoch
- *                        milliseconds).
- * @param label           A human-readable label for the step.
- * @param description     A more detailed description of the step.
- * @param isPassword      A boolean indicating if the typed text is a password
- *                        (for TYPE steps).
- * @param storeValue      A boolean indicating if the value typed should be
- *                        stored as a variable.
- * @param selector        A {@link Selector} object to identify the target
- *                        element.
- * @param isTriggerNewTab A {@link TriggerNewTab} object indicating if the
- *                        action is expected to open a new tab.
- * @param shouldRun       A boolean indicating if this step should be executed
- *                        during replay.
- * @param required        A boolean indicating if this step is mandatory.
+ * @param id               A unique identifier for the step.
+ * @param type             The type of action (e.g., NAVIGATE, CLICK, TYPE,
+ *                         SCROLL, WAIT, CONTEXT), defined by
+ *                         {@link PlaywrightStepType}.
+ * @param url              The URL to navigate to (for NAVIGATE steps).
+ * @param coords           Coordinates (x, y) for actions like CLICK, TYPE,
+ *                         SCROLL.
+ * @param multiCoords      A list of coordinates for CONTEXT steps, possibly for
+ *                         defining an area.
+ * @param prompt           A prompt string for CONTEXT steps.
+ * @param text             The text to type (for TYPE steps).
+ * @param pressEnter       A boolean indicating whether to press Enter after
+ *                         typing (for TYPE steps).
+ * @param deltaY           The vertical scroll amount (for SCROLL steps).
+ * @param waitUntil        A condition to wait for after navigation (for
+ *                         NAVIGATE steps).
+ * @param waitAfterMs      A generic wait duration in milliseconds after an
+ *                         action.
+ * @param viewport         The viewport dimensions when the coordinates were
+ *                         computed against.
+ * @param timestamp        The time when the step was recorded or created (epoch
+ *                         milliseconds).
+ * @param label            A human-readable label for the step.
+ * @param description      A more detailed description of the step.
+ * @param isPassword       A boolean indicating if the typed text is a password
+ *                         (for TYPE steps).
+ * @param storeValue       A boolean indicating if the value typed should be
+ *                         stored as a variable.
+ * @param selector         A {@link Selector} object to identify the target
+ *                         element.
+ * @param isTriggerNewTab  A {@link TriggerNewTab} object indicating if the
+ *                         action is expected to open a new tab.
+ * @param shouldRun        A boolean indicating if this step should be executed
+ *                         during replay.
+ * @param required         A boolean indicating if this step is mandatory.
  * 
- * @param sendToPlayground A boolean indicating if the context should be automatically
- *                        sent to the playground (for CONTEXT steps). 
- * @param tag             An optional tag associated with the step, the element
- *                        tag from ProbeElement response.
+ * @param sendToPlayground A boolean indicating if the context should be
+ *                         automatically sent to the playground (for CONTEXT
+ *                         steps).
+ * @param tag              An optional tag associated with the step, the element
+ *                         tag from ProbeElement response.
  */
 public record PlaywrightStep(int id, PlaywrightStepType type, String url, Coords coords, List<Coords> multiCoords,
-        String prompt, String text, Boolean pressEnter, Integer deltaY, String waitUntil, Integer waitAfterMs,
-        Viewport viewport, Long timestamp, String label, String description, boolean isPassword, boolean storeValue,
-        Selector selector, TriggerNewTab isTriggerNewTab, Boolean shouldRun, Boolean required, Boolean sendToPlayground,
-                             String tag) {
+		String prompt, String text, Boolean pressEnter, Integer deltaY, String waitUntil, Integer waitAfterMs,
+		Viewport viewport, Long timestamp, String label, String description, boolean isPassword, boolean storeValue,
+		Selector selector, TriggerNewTab isTriggerNewTab, Boolean shouldRun, Boolean required, Boolean sendToPlayground,
+		String tag) {
 
 	/**
 	 * Convenience constructor to create a new PlaywrightStep by copying an existing
@@ -100,4 +101,3 @@ public record PlaywrightStep(int id, PlaywrightStepType type, String url, Coords
 				s.isTriggerNewTab, shouldRun, required, s.sendToPlayground, s.tag);
 	}
 }
-

--- a/src/prerna/reactor/playwright/PlaywrightStep.java
+++ b/src/prerna/reactor/playwright/PlaywrightStep.java
@@ -43,13 +43,16 @@ import java.util.List;
  *                        during replay.
  * @param required        A boolean indicating if this step is mandatory.
  * 
+ * @param sendToPlayground A boolean indicating if the context should be automatically
+ *                        sent to the playground (for CONTEXT steps). 
  * @param tag             An optional tag associated with the step, the element
  *                        tag from ProbeElement response.
  */
 public record PlaywrightStep(int id, PlaywrightStepType type, String url, Coords coords, List<Coords> multiCoords,
-		String prompt, String text, Boolean pressEnter, Integer deltaY, String waitUntil, Integer waitAfterMs,
-		Viewport viewport, Long timestamp, String label, String description, boolean isPassword, boolean storeValue,
-		Selector selector, TriggerNewTab isTriggerNewTab, Boolean shouldRun, Boolean required, String tag) {
+        String prompt, String text, Boolean pressEnter, Integer deltaY, String waitUntil, Integer waitAfterMs,
+        Viewport viewport, Long timestamp, String label, String description, boolean isPassword, boolean storeValue,
+        Selector selector, TriggerNewTab isTriggerNewTab, Boolean shouldRun, Boolean required, Boolean sendToPlayground,
+                             String tag) {
 
 	/**
 	 * Convenience constructor to create a new PlaywrightStep by copying an existing
@@ -61,7 +64,7 @@ public record PlaywrightStep(int id, PlaywrightStepType type, String url, Coords
 	PlaywrightStep(PlaywrightStep s, String text) {
 		this(s.id, s.type, s.url, s.coords, s.multiCoords, s.prompt, text, s.pressEnter, s.deltaY, s.waitUntil,
 				s.waitAfterMs, s.viewport, s.timestamp, s.label, s.description, s.isPassword, s.storeValue, s.selector,
-				s.isTriggerNewTab, s.shouldRun, s.required, s.tag);
+				s.isTriggerNewTab, s.shouldRun, s.required, s.sendToPlayground, s.tag);
 	}
 
 	/**
@@ -74,7 +77,7 @@ public record PlaywrightStep(int id, PlaywrightStepType type, String url, Coords
 	PlaywrightStep(PlaywrightStep s, int id) {
 		this(id, s.type, s.url, s.coords, s.multiCoords, s.prompt, s.text, s.pressEnter, s.deltaY, s.waitUntil,
 				s.waitAfterMs, s.viewport, s.timestamp, s.label, s.description, s.isPassword, s.storeValue, s.selector,
-				s.isTriggerNewTab, s.shouldRun, s.required, s.tag);
+				s.isTriggerNewTab, s.shouldRun, s.required, s.sendToPlayground, s.tag);
 	}
 
 	/**
@@ -82,7 +85,7 @@ public record PlaywrightStep(int id, PlaywrightStepType type, String url, Coords
 	 * one and updating its label, text, storeValue, description, shouldRun, and
 	 * required flags.
 	 * 
-	 * @param s           The existing PlaywrightStep to copy from.
+	 * @param s           The existing PlaywrightStep to copy from.§
 	 * @param label       The new label for the step.
 	 * @param text        The new text content for the step.
 	 * @param storeValue  The new storeValue flag for the step.
@@ -94,6 +97,7 @@ public record PlaywrightStep(int id, PlaywrightStepType type, String url, Coords
 			boolean shouldRun, boolean required) {
 		this(s.id, s.type, s.url, s.coords, s.multiCoords, s.prompt, text, s.pressEnter, s.deltaY, s.waitUntil,
 				s.waitAfterMs, s.viewport, s.timestamp, label, description, s.isPassword, storeValue, s.selector,
-				s.isTriggerNewTab, shouldRun, required, s.tag);
+				s.isTriggerNewTab, shouldRun, required, s.sendToPlayground, s.tag);
 	}
 }
+

--- a/src/prerna/reactor/playwright/StepReactor.java
+++ b/src/prerna/reactor/playwright/StepReactor.java
@@ -147,8 +147,7 @@ public class StepReactor extends AbstractReactor {
 			newStep = new PlaywrightStep(stepId, step.type(), step.url(), step.coords(), step.multiCoords(),
 					step.prompt(), "", step.pressEnter(), step.deltaY(), step.waitUntil(), step.waitAfterMs(),
 					step.viewport(), step.timestamp(), step.label(), step.description(), step.isPassword(),
-					step.storeValue(), step.selector(), step.isTriggerNewTab(), step.shouldRun(), step.required(),
-					step.tag());
+					step.storeValue(), step.selector(), step.isTriggerNewTab(), step.shouldRun(), step.required(), step.sendToPlayground(), step.tag());
 		}
 
 		if (isNewTab && newTabId != null) {
@@ -157,7 +156,7 @@ public class StepReactor extends AbstractReactor {
 					step.prompt(), newStep.text(), newStep.pressEnter(), newStep.deltaY(), newStep.waitUntil(),
 					newStep.waitAfterMs(), newStep.viewport(), newStep.timestamp(), newStep.label(),
 					newStep.description(), newStep.isPassword(), newStep.storeValue(), newStep.selector(),
-					triggerNewTab, newStep.shouldRun(), newStep.required(), step.tag());
+					triggerNewTab, newStep.shouldRun(), newStep.required(), step.sendToPlayground(),step.tag());
 			playwrightSession.addChildTabRelationship(tabId, newTabId);
 		}
 

--- a/src/prerna/reactor/playwright/StepReactor.java
+++ b/src/prerna/reactor/playwright/StepReactor.java
@@ -147,7 +147,8 @@ public class StepReactor extends AbstractReactor {
 			newStep = new PlaywrightStep(stepId, step.type(), step.url(), step.coords(), step.multiCoords(),
 					step.prompt(), "", step.pressEnter(), step.deltaY(), step.waitUntil(), step.waitAfterMs(),
 					step.viewport(), step.timestamp(), step.label(), step.description(), step.isPassword(),
-					step.storeValue(), step.selector(), step.isTriggerNewTab(), step.shouldRun(), step.required(), step.sendToPlayground(), step.tag());
+					step.storeValue(), step.selector(), step.isTriggerNewTab(), step.shouldRun(), step.required(),
+					step.sendToPlayground(), step.tag());
 		}
 
 		if (isNewTab && newTabId != null) {
@@ -156,7 +157,7 @@ public class StepReactor extends AbstractReactor {
 					step.prompt(), newStep.text(), newStep.pressEnter(), newStep.deltaY(), newStep.waitUntil(),
 					newStep.waitAfterMs(), newStep.viewport(), newStep.timestamp(), newStep.label(),
 					newStep.description(), newStep.isPassword(), newStep.storeValue(), newStep.selector(),
-					triggerNewTab, newStep.shouldRun(), newStep.required(), step.sendToPlayground(),step.tag());
+					triggerNewTab, newStep.shouldRun(), newStep.required(), step.sendToPlayground(), step.tag());
 			playwrightSession.addChildTabRelationship(tabId, newTabId);
 		}
 


### PR DESCRIPTION
## Description
Added "Send to playground" tag to the context step to be used in the player to automatically send contexts back to the playground without user intervention.