### PR TITLE
Source modelId from non-null column

### DIFF
--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -1984,7 +1984,7 @@ public class ModelInferenceLogsUtils {
 						resultSet.getBoolean("IS_ACTIVE"), resultSet.getTimestamp("DATE_CREATED"),
 						resultSet.getTimestamp("UPDATED_AT"), resultSet.getString("MESSAGES"),
 						resultSet.getBoolean("PINNED"), resultSet.getString("OPTIONS"),
-						resultSet.getString("MODEL_ID"));
+						modelId);
 			} else {
 				return null;
 			}
@@ -2868,3 +2868,4 @@ public class ModelInferenceLogsUtils {
 	}
 
 }
+

--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -1975,12 +1975,15 @@ public class ModelInferenceLogsUtils {
 			stmt.setString(2, user_id);
 			resultSet = stmt.executeQuery();
 			if (resultSet.next()) {
+				String agentId = resultSet.getString("AGENT_ID");
+				String modelId = resultSet.getString("MODEL_ID");
+				modelId = modelId != null ? modelId : agentId;
 				return new Room(resultSet.getString("ROOM_ID"), resultSet.getString("USER_ID"),
 						resultSet.getString("ROOM_NAME"), resultSet.getString("ROOM_CONTEXT"), resultSet.getString("PROJECT_ID"),
 						resultSet.getString("SHARE_ID"), resultSet.getBoolean("IS_ACTIVE"),
 						resultSet.getTimestamp("DATE_CREATED"), resultSet.getTimestamp("UPDATED_AT"),
 						resultSet.getString("MESSAGES"), resultSet.getBoolean("PINNED"), resultSet.getString("OPTIONS"),
-						resultSet.getString("MODEL_ID"));
+						modelId);
 			} else {
 				return null;
 			}


### PR DESCRIPTION
To test, load an existing room through getRoomById (happens in RoomUtils.getOrLoadRoom) and inspect it to make sure it has some value for modelId. Eventually want to think about removing this column since we track this on a message level.