### PR TITLE
fix: Deprecate instead of removing makeConnection references in PR 1903 (closes #1921)

### DIFF
--- a/src/prerna/engine/api/IRDBMSEngine.java
+++ b/src/prerna/engine/api/IRDBMSEngine.java
@@ -59,6 +59,17 @@ public interface IRDBMSEngine extends IDatabaseEngine {
 	java.sql.Connection getConnection() throws SQLException;
 
 	/**
+	 * Deprecated - switch to {@link #getConnection()}
+	 * 
+	 * @return
+	 * @throws SQLException
+	 */
+	@IgnoreEngineLogging
+	@Deprecated
+	java.sql.Connection makeConnection() throws SQLException;
+
+
+	/**
 	 * This is intended to be executed via doAction
 	 * 
 	 * @param args Object[] where the first index is the table name and every other

--- a/src/prerna/engine/impl/rdbms/MultiRDBMSNativeEngine.java
+++ b/src/prerna/engine/impl/rdbms/MultiRDBMSNativeEngine.java
@@ -276,6 +276,18 @@ public class MultiRDBMSNativeEngine extends AbstractDatabaseEngine implements IR
 	}
 
 	@Override
+	@Deprecated
+	/**
+	 * Deprecated - switch to {@link #getConnection()}
+	 * 
+	 * @return Connection
+	 * @throws SQLException
+	 */
+	public Connection makeConnection() throws SQLException {
+		return getConnection();
+	}
+
+	@Override
 	// need to clean up the exception it will never be thrown
 	public void insertData(String query) throws SQLException {
 		getContext().insertData(query);

--- a/src/prerna/engine/impl/rdbms/RDBMSNativeEngine.java
+++ b/src/prerna/engine/impl/rdbms/RDBMSNativeEngine.java
@@ -539,6 +539,18 @@ public class RDBMSNativeEngine extends AbstractDatabaseEngine implements IRDBMSE
 	}
 
 	@Override
+	@Deprecated
+	/**
+	 * Deprecated - switch to {@link #getConnection()}
+	 * 
+	 * @return Connection
+	 * @throws SQLException
+	 */
+	public Connection makeConnection() throws SQLException {
+		return getConnection();
+	}
+
+	@Override
 	public void insertData(String query) throws SQLException {
 		Connection conn = null;
 		try {


### PR DESCRIPTION
## Description
Restore makeConnection references as deprecated and point them to the new getConnection reference

## Changes Made
IRDBMSEngine.java
MultiRDBMSEngine.java
RDBMSNativeEngine.java