### PR TITLE
Remove _meta.map from tool responses

### DIFF
--- a/src/prerna/reactor/agent/mcp/MCPUtility.java
+++ b/src/prerna/reactor/agent/mcp/MCPUtility.java
@@ -445,9 +445,6 @@ public final class MCPUtility {
 					currentMeta.put(SMSS_MCP_EXECUTION, mcpExecution);
 				}
 
-				// for legacy ...
-				// it had map inside of _meta
-				currentMeta.put("map", new HashMap<>(currentMeta));
 			} else {
 				responseToolMap.put("_tool_found", false);
 			}


### PR DESCRIPTION
## Description
We now use the info in just _meta, not _meta.map
See https://github.com/SEMOSS/Semoss/pull/1881
And https://github.com/SEMOSS/semoss-ui/pull/2463

## How to Test
The data passed in _meta is used in a couple places; an easy one to test should be SMSS_MCP_EXECUTION. If Playground is able to auto_execute tools, then the changes worked.
1. (Make sure the latest FE is built)
2. In playground, create a chat with an MCP that has a tool set to auto-execute
3. Prompt the LLM to run that tool
4. Verify that the tool_response sent from the BE has _meta.SMSS_MCP_EXECUTION, but not _meta.map.SMSS_MCP_EXECUTION
5. Verify that the tool auto-executes correctly