### PR TITLE
fix: only add license to src, test_legacy and test folders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -268,7 +268,9 @@
 						<owner>Defense Health Agency (DHA)</owner>
 					</properties>
 					<includes>
-						<include>**/*.java</include>
+						<include>src/**/*.java</include>
+						<include>test/**/*.java</include>
+						<include>test_legacy/**/*.java</include>
 					</includes>
 					<headerDefinitions>
 						<headerDefinition>src/license/header-style.xml</headerDefinition>


### PR DESCRIPTION
Only add license to source files, avoiding project files