### PR TITLE
fix: npe by initializing smss properties in createFunctionEngineReactor

### DIFF
--- a/src/prerna/reactor/function/upload/CreatePythonFunctionEngineReactor.java
+++ b/src/prerna/reactor/function/upload/CreatePythonFunctionEngineReactor.java
@@ -125,7 +125,7 @@ public class CreatePythonFunctionEngineReactor extends AbstractEngineFileReactor
 			// store in DIHelper so that when we move temp smss to smss it doesn't try to
 			// reload again
 			DIHelper.getInstance().setEngineProperty(functionId + "_" + Constants.STORE, tempSmss.getAbsolutePath());
-
+			function.open(tempSmss.getAbsolutePath());
 			smssFile = new File(tempSmss.getAbsolutePath().replace(".temp", ".smss"));
 			FileUtils.copyFile(tempSmss, smssFile);
 			tempSmss.delete();


### PR DESCRIPTION
**Error Message :**
`Cannot invoke "java.util.Properties.containsKey(Object)"  because the return value of  "prerna.engine.api.IFunctionEngine.getSmssProp()" is null`

**Fix:**
Addded line **function.open(tempSmss.getAbsolutePath())**  for the fix of smss file initialization