### PR TITLE
feat: adding base64 handling for images on llm and ask playground

### DIFF
--- a/src/prerna/engine/impl/model/message/MessageUtils.java
+++ b/src/prerna/engine/impl/model/message/MessageUtils.java
@@ -36,6 +36,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -645,6 +646,13 @@ public class MessageUtils {
 			return copiedFileNames;
 		}
 		for (String relPath : relativePathToFiles) {
+			if (isBase64ImageDataUri(relPath)) {
+				String fileName = writeBase64ImageDataUriToDir(relPath, targetDir);
+				if (fileName != null) {
+					copiedFileNames.add(fileName);
+				}
+				continue;
+			}
 			File srcFile = new File(insightFolder, relPath);
 			if (!srcFile.exists() || !srcFile.isFile()) {
 				classLogger.info("Source file does not exist in insight folder: " + srcFile.getAbsolutePath());
@@ -660,6 +668,93 @@ public class MessageUtils {
 			}
 		}
 		return copiedFileNames;
+	}
+
+	private static boolean isBase64ImageDataUri(String value) {
+		if (value == null) {
+			return false;
+		}
+		// e.g. data:image/jpeg;base64,/9j/4AAQ...
+		String trimmed = value.trim();
+		return trimmed.startsWith("data:image/") && trimmed.contains(";base64,");
+	}
+
+	private static String writeBase64ImageDataUriToDir(String dataUri, Path targetDir) {
+		try {
+			String trimmed = dataUri.trim();
+			int commaIdx = trimmed.indexOf(',');
+			if (commaIdx < 0) {
+				classLogger.info("Invalid data URI (no comma separator)");
+				return null;
+			}
+
+			String meta = trimmed.substring(0, commaIdx); // data:image/jpeg;base64
+			String base64 = trimmed.substring(commaIdx + 1);
+			if (!meta.startsWith("data:") || !meta.contains(";base64")) {
+				classLogger.info("Invalid data URI meta: " + meta);
+				return null;
+			}
+
+			int colonIdx = meta.indexOf(':');
+			int semiIdx = meta.indexOf(';');
+			if (colonIdx < 0 || semiIdx < 0 || semiIdx <= colonIdx + 1) {
+				classLogger.info("Invalid data URI meta: " + meta);
+				return null;
+			}
+
+			String mimeType = meta.substring(colonIdx + 1, semiIdx).trim().toLowerCase();
+			if (!mimeType.startsWith("image/")) {
+				classLogger.info("Unsupported data URI mime type: " + mimeType);
+				return null;
+			}
+
+			String ext = extensionFromImageMimeType(mimeType);
+			String fileName = "image_" + UUID.randomUUID().toString() + "." + ext;
+			Path destination = targetDir.resolve(fileName);
+
+			byte[] decoded = Base64.getDecoder().decode(base64.replaceAll("\\s+", ""));
+			Files.write(destination, decoded);
+			return fileName;
+		} catch (IllegalArgumentException e) {
+			// base64 decoder throws IllegalArgumentException on bad input
+			classLogger.warn("Failed to decode base64 data URI image", e);
+			return null;
+		} catch (IOException e) {
+			classLogger.warn("Failed to write decoded base64 data URI image to room folder: " + targetDir, e);
+			return null;
+		}
+	}
+
+	private static String extensionFromImageMimeType(String mimeType) {
+		if (mimeType == null || !mimeType.startsWith("image/")) {
+			return "png";
+		}
+		switch (mimeType) {
+		case "image/jpg":
+		case "image/jpeg":
+			return "jpeg";
+		case "image/png":
+			return "png";
+		case "image/gif":
+			return "gif";
+		case "image/webp":
+			return "webp";
+		case "image/bmp":
+			return "bmp";
+		case "image/svg+xml":
+			return "svg";
+		case "image/x-icon":
+		case "image/vnd.microsoft.icon":
+			return "ico";
+		default:
+			String subtype = mimeType.substring("image/".length());
+			int plusIdx = subtype.indexOf('+');
+			if (plusIdx > 0) {
+				subtype = subtype.substring(0, plusIdx);
+			}
+			subtype = subtype.replaceAll("[^a-z0-9]", "");
+			return subtype.isEmpty() ? "png" : subtype;
+		}
 	}
 
 	// Method to parse markdown code blocks

--- a/src/prerna/playground/reactors/AskPlaygroundReactor.java
+++ b/src/prerna/playground/reactors/AskPlaygroundReactor.java
@@ -144,7 +144,7 @@ public class AskPlaygroundReactor extends AbstractReactor {
 		} else if (key.equals(ReactorKeysEnum.ROOM_ID.getKey())) {
 			return "This is the room ID that will be used for storing messages. If no room id is passed in, then insight id will be used for the room";
 		} else if (key.equals(ReactorKeysEnum.IMAGE.getKey())) {
-			return "This is  an array of image file names that have already been uploaded to the insight folder.";
+			return "This is an array of image file names that have already been uploaded to the insight folder, or base64 image data URIs (e.g. data:image/jpeg;base64,....).";
 		} else if (key.equals(ReactorKeysEnum.PARAM_VALUES_MAP.getKey())) {
 			return """
 					Map containing the key-value pairs for model parameters like 'temperature', 'top_p', etc.

--- a/src/prerna/reactor/model/LLMReactor.java
+++ b/src/prerna/reactor/model/LLMReactor.java
@@ -177,7 +177,7 @@ public class LLMReactor extends AbstractReactor {
 		} else if (key.equals(ReactorKeysEnum.CONTEXT.getKey())) {
 			return "The system prompt to use for the LLM call";
 		} else if (key.equals(ReactorKeysEnum.IMAGE.getKey())) {
-			return "This is an array of image file names that have already been uploaded to the insight folder.";
+			return "This is an array of image file names that have already been uploaded to the insight folder, or base64 image data URIs (e.g. data:image/jpeg;base64,....).";
 		} else if (key.equals(ReactorKeysEnum.URL.getKey())) {
 			return "This is an array of image file urls whose contents will be fetched when building the message content.";
 		} else if (key.equals(ReactorKeysEnum.PARAM_VALUES_MAP.getKey())) {


### PR DESCRIPTION
## **Description**
Enable `images` parameters in `LLMReactor` and `AskPlaygroundReactor` to accept base64-encoded image data URIs (e.g., `data:image/jpeg;base64,...`) in addition to insight-uploaded image filenames. Base64 images are decoded into files in the room folder and then processed through the existing `MessageInputMedia` / room-media flow.

## **Changes Made**
- Updated `MessageUtils.copyFilesToRoomFolder(...)` to detect `data:image/*;base64,...` entries, decode them, and write them into the room folder with a generated filename, returning that filename like the existing copy flow (`MessageUtils.java`).
- Updated `images` parameter descriptions to document support for base64 data URIs (`LLMReactor.java`, `AskPlaygroundReactor.java`).

## **How to Test**
1. Run either reactor with:
   - `image=["/myImage1.png","data:image/jpeg;base64,<valid_base64>"]` (plus your normal required params like `engine`, `command`, etc.).

2. Expected outcomes:
   - The filename entry is handled as before (copied from insight folder to room folder).
   - The base64 data URI is decoded and saved as a new image file in the room folder (e.g., `image_<uuid>.jpeg`).
   - The LLM call proceeds normally and the resulting `InputMessage` includes the images as `MessageInputMedia` entries.

## **Notes**
- Only `data:image/*;base64,...` is treated as inline base64; other strings continue to be treated as insight-relative file paths (existing behavior).
- The decoded file is written directly to the room folder to keep the rest of the message/media pipeline unchanged.