### PR TITLE
feat: adding follow up questions reactor

### DIFF
--- a/src/prerna/engine/impl/model/Room.java
+++ b/src/prerna/engine/impl/model/Room.java
@@ -153,6 +153,11 @@ public class Room {
 		return ask(msg, modelEngine, null);
 	}
 
+	public ResponseMessage ask(InputMessage msg, IModelEngine modelEngine, String parentMessageId) {
+		Boolean appendToHistory = true;
+		return ask(msg, modelEngine, parentMessageId, appendToHistory);
+	}
+
 	/**
 	 * 
 	 * @param msg
@@ -161,7 +166,7 @@ public class Room {
 	 * @param parentMessageId
 	 * @return
 	 */
-	public ResponseMessage ask(InputMessage msg, IModelEngine modelEngine, String parentMessageId) {
+	public ResponseMessage ask(InputMessage msg, IModelEngine modelEngine, String parentMessageId, Boolean appendToHistory) {
 
 		Map<String, Object> kwArgMap = new HashMap<>(msg.getParamMap());
 
@@ -287,15 +292,20 @@ public class Room {
 		}
 
 		// Persist message history - room name was just updated
-		if ((prevRoomName == null || prevRoomName.trim().isEmpty()) && this.roomName != null
-				&& !this.roomName.trim().isEmpty()) {
-			// Only update with room name if we just set it now!
-			ModelInferenceLogsUtils.llm2_updateRoomMessages(room_id, insight.getUser().getPrimaryLoginToken().getId(),
-					getMessagesAsString(), this.roomName, modelEngine.getEngineId());
+		if (appendToHistory) {
+			if ((prevRoomName == null || prevRoomName.trim().isEmpty()) && this.roomName != null
+					&& !this.roomName.trim().isEmpty()) {
+				// Only update with room name if we just set it now!
+				ModelInferenceLogsUtils.llm2_updateRoomMessages(room_id, insight.getUser().getPrimaryLoginToken().getId(),
+						getMessagesAsString(), this.roomName, modelEngine.getEngineId());
+			} else {
+				// Otherwise, regular update
+				ModelInferenceLogsUtils.llm2_updateRoomMessages(room_id, insight.getUser().getPrimaryLoginToken().getId(),
+						getMessagesAsString());
+			}
 		} else {
-			// Otherwise, regular update
-			ModelInferenceLogsUtils.llm2_updateRoomMessages(room_id, insight.getUser().getPrimaryLoginToken().getId(),
-					getMessagesAsString());
+			messages.removeLast();
+			messages.removeLast();
 		}
 
 		return response;

--- a/src/prerna/playground/PlaygroundUtils.java
+++ b/src/prerna/playground/PlaygroundUtils.java
@@ -28,7 +28,6 @@
 package prerna.playground;
 
 public class PlaygroundUtils {
-
 	public static final String PLAYGROUND_PROJECT_ID = "SYSTEM__PLAYGROUND";
 	public static final String PLAYGROUND_MESSAGE_TYPE = "PLAYGROUND_MESSAGE_TYPE";
 	public static final String ENRICH_PROMPT = """
@@ -564,6 +563,31 @@ public class PlaygroundUtils {
 
 			Confirmed Chain-of-Thought Plan (in JSON):
 			%s
+			""";
+
+	public static final String FOLLOW_UP_SUGGESTIONS_PROMPT = """
+			You generate follow-up suggestions only.
+			Based on the most recent conversation, propose short, user-style follow-up questions that advance the same topic.
+			Do not answer the user. Do not include preamble or numbering.
+			Each suggestion must be a single sentence (<= 12 words).
+			Avoid repeating the last user message verbatim.
+			""";
+
+	public static final String FOLLOW_UP_SUGGESTIONS_SCHEMA = """
+			{
+			  "title": "FollowUpSuggestions",
+			  "type": "object",
+			  "additionalProperties": false,
+			  "required": ["suggestions"],
+			  "properties": {
+			    "suggestions": {
+			      "type": "array",
+			      "minItems": %s,
+			      "maxItems": %s,
+			      "items": { "type": "string" }
+			    }
+			  }
+			}
 			""";
 
 }

--- a/src/prerna/reactor/model/GenerateFollowUpQuestionsReactor.java
+++ b/src/prerna/reactor/model/GenerateFollowUpQuestionsReactor.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.model;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.SecurityEngineUtils;
+import prerna.engine.api.IModelEngine;
+import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.RoomUtils;
+import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
+import prerna.engine.impl.model.message.AbstractMessage;
+import prerna.engine.impl.model.message.InputMessage;
+import prerna.engine.impl.model.message.MessageType;
+import prerna.engine.impl.model.message.ResponseMessage;
+import prerna.playground.PlaygroundUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.GenRowStruct;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.util.Utility;
+
+public class GenerateFollowUpQuestionsReactor extends AbstractReactor {
+
+	public GenerateFollowUpQuestionsReactor() {
+		this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey(), ReactorKeysEnum.ROOM_ID.getKey(), "number",
+				ReactorKeysEnum.PARAM_VALUES_MAP.getKey() };
+		this.keyRequired = new int[] { 1, 1, 0, 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		String modelId = this.keyValue.get(this.keysToGet[0]);
+		String roomId = this.keyValue.get(this.keysToGet[1]);
+
+		User user = this.insight.getUser();
+		if (!SecurityEngineUtils.userCanViewEngine(user, modelId)) {
+			throw new IllegalArgumentException(
+					"Model " + modelId + " does not exist or user does not have access to this model");
+		}
+
+		IModelEngine modelEngine = Utility.getModel(modelId);
+		String userId = user.getPrimaryLoginToken().getId();
+		ModelInferenceLogsUtils.validUserRoom(roomId, userId);
+
+		Room room = RoomUtils.getOrLoadRoom(roomId, insight);
+		if (!hasUserMessage(room.getMessages())) {
+			throw new IllegalStateException("Room message history does not contain any user input messages.");
+		}
+
+		Map<String, Object> paramMap = getParamMap();
+		if (paramMap == null) {
+			paramMap = new HashMap<>();
+		}
+
+		int numResponses = parsePositiveInt(this.keyValue.get(this.keysToGet[2]), 3);
+		String jsonSchemaString = String.format(PlaygroundUtils.FOLLOW_UP_SUGGESTIONS_SCHEMA, numResponses,
+				numResponses);
+		Map<String, Object> jsonSchemaMap = jsonToMap(jsonSchemaString);
+		paramMap.put("schema", jsonSchemaMap);
+
+		InputMessage inputMsg = InputMessage.builder(room)
+				.withInputUIPrompt(PlaygroundUtils.FOLLOW_UP_SUGGESTIONS_PROMPT)
+				.withInputPrompt(PlaygroundUtils.FOLLOW_UP_SUGGESTIONS_PROMPT).withModelType(modelEngine.getModelType())
+				.withParamMap(paramMap).build();
+
+		ResponseMessage response = room.ask(inputMsg, modelEngine, null, false);
+		String jsonResponse = response.getContent();
+		if (jsonResponse == null || jsonResponse.trim().isEmpty()) {
+			throw new IllegalStateException("Model did not return structured follow up suggestions.");
+		}
+		Map<String, Object> pixelResponse = jsonToMap(jsonResponse);
+		return new NounMetadata(pixelResponse, PixelDataType.MAP);
+	}
+
+	private static boolean hasUserMessage(List<AbstractMessage> messages) {
+		for (int i = messages.size() - 1; i >= 0; i--) {
+			AbstractMessage message = messages.get(i);
+			if (message instanceof InputMessage inputMessage) {
+				MessageType type = inputMessage.getMessageType();
+				if (type != MessageType.INPUT_TOOL_EXEC) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static int parsePositiveInt(String value, int defaultValue) {
+		if (value == null || value.trim().isEmpty()) {
+			return defaultValue;
+		}
+		try {
+			int parsed = Integer.parseInt(value.trim());
+			return parsed > 0 ? parsed : defaultValue;
+		} catch (NumberFormatException e) {
+			return defaultValue;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> getParamMap() {
+		GenRowStruct mapGrs = this.store.getGenRowStruct(ReactorKeysEnum.PARAM_VALUES_MAP.getKey());
+		if (mapGrs != null && !mapGrs.isEmpty()) {
+			List<NounMetadata> mapInputs = mapGrs.getNounsOfType(PixelDataType.MAP);
+			if (mapInputs != null && !mapInputs.isEmpty()) {
+				return (Map<String, Object>) mapInputs.get(0).getValue();
+			}
+		}
+		List<NounMetadata> mapInputs = this.curRow.getNounsOfType(PixelDataType.MAP);
+		if (mapInputs != null && !mapInputs.isEmpty()) {
+			return (Map<String, Object>) mapInputs.get(0).getValue();
+		}
+		return null;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Generates suggested follow-up questions based on the most recent room conversation.";
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (key.equals(ReactorKeysEnum.ENGINE.getKey())) {
+			return "The model engine that generates follow up suggestions.";
+		} else if (key.equals(ReactorKeysEnum.ROOM_ID.getKey())) {
+			return "The room id used to locate the latest conversation messages.";
+		} else if (key.equals("number")) {
+			return "Optional number of follow up suggestions to generate (defaults to 3).";
+		}
+		return super.getDescriptionForKey(key);
+	}
+}


### PR DESCRIPTION
## Description
Adds a non-persistent follow-up question reactor that generates structured JSON suggestions based on the latest room conversation, without writing to room history.

## Changes Made
- Added `GenerateFollowUpQuestionsReactor` to generate follow-up suggestions with schema-enforced JSON output.
- Added follow-up prompt/schema constants and improved prompt wording for concise, user-style questions.
- Added a `Room.ask` overload to allow temporary messages that are not persisted.
- Documented the new reactor in `AGENTS_MD`.

## How to Test
1. Create or use a room with recent user messages.
2. Run the reactor with a model and room id:
   - Expected: JSON output with `suggestions` array of short questions.
   - Expected: No new messages appear in room history.
```
GenerateFollowUpQuestions(roomId=["381b42d8-f73a-4a18-be96-3be1656c1503"], engine=["b0d18f4b-ff2c-4563-8f9d-57efbff53d60"]);
```

output
```
{
    "insightID": "019be2af-6cd9-77ed-be11-c5f344877fac",
    "pixelReturn": [
        {
            "pixelId": "4",
            "pixelExpression": "GenerateFollowUpQuestions ( roomId = [ \"381b42d8-f73a-4a18-be96-3be1656c1503\" ] , engine = [ \"b0d18f4b-ff2c-4563-8f9d-57efbff53d60\" ] ) ;",
            "isMeta": false,
            "timeToRun": 7209,
            "output": {
                "suggestions": [
                    "What are the best Spanish cities to visit?",
                    "Tell me about Spanish festivals and traditions",
                    "What Spanish dishes should I try?"
                ]
            },
            "operationType": [
                "OPERATION"
            ]
        }
    ]
}
```

## Notes
- The reactor does not override the room system prompt; it relies on the existing room context and schema enforcement.