### PR TITLE
feat: expose room id through the server proxy if it's set

### DIFF
--- a/py/gaas_server_proxy.py
+++ b/py/gaas_server_proxy.py
@@ -202,6 +202,21 @@ class ServerProxy:
                 return None
         except AttributeError:
             return None
+        
+    def get_thread_room_id(self):
+        """Helper function to get room_id from the current thread's payload. Only set when Playground sets the room id on the insight."""
+        try:
+            # get the original payload from the current thread so that we can get the room id
+            orig_payload = getattr(self.server.thread_local, "payload", None)
+
+            if orig_payload:
+                return orig_payload.get("roomId") or orig_payload.get(
+                    "roomId"
+                )
+            else:
+                return None
+        except AttributeError:
+            return None
 
 
 if __name__ == "__main__":

--- a/py/semoss.py
+++ b/py/semoss.py
@@ -7,11 +7,15 @@ class Insight(ServerProxy):
     def __init__(
         self,
         insight_id: Optional[str] = None,
+        room_id: Optional[str] = None
     ):
         super().__init__()
         if insight_id is None:
             insight_id = super().get_thread_insight_id()
+        if room_id is None:
+            room_id = super().get_thread_room_id()
         self.insight_id = insight_id
+        self.room_id = room_id
 
     def run_pixel(self, pixel: str = None, insight_id: Optional[str] = None):
         """

--- a/src/prerna/ds/py/PyTranslator.java
+++ b/src/prerna/ds/py/PyTranslator.java
@@ -398,6 +398,7 @@ public class PyTranslator {
 		ps.longRunning = true;
 		// we always need an insight
 		ps.insightId = this.globalStoreInsight.getInsightId();
+		ps.roomId = this.globalStoreInsight.getRoomId();
 		// so we have a context project id that we need to set?
 		if (this.globalStoreInsight.getContextProjectId() != null) {
 			String assetsDir = EngineUtility.getSpecificEngineAssetsFolder(IEngine.CATALOG_TYPE.PROJECT,

--- a/src/prerna/tcp/PayloadStruct.java
+++ b/src/prerna/tcp/PayloadStruct.java
@@ -85,6 +85,8 @@ public class PayloadStruct implements Serializable {
 	// set the insight id
 	public String insightId = null;
 
+	public String roomId = null;
+
 	// set the job id
 	public String jobId = null;
 


### PR DESCRIPTION
Expose room id as part of the insight. Easiest way to test is, in a python MCP on the platform, load the Insight and get insight.room_id and return that as a tool. Then in playground, load your MCP and ask it to call that tool. You can also manually `SetRoomForInsight(%room_id%)` and just run this python.