### PR TITLE
fix: adding default vars into the mcp driver module

### DIFF
--- a/src/prerna/reactor/agent/mcp/MCPUtility.java
+++ b/src/prerna/reactor/agent/mcp/MCPUtility.java
@@ -185,6 +185,13 @@ public final class MCPUtility {
 		                           "        del sys.modules[mod]\n" +
 		                           "import " + moduleName + " as mcp_driver";
 		// @formatter:on
+		// Copy default path vars from translator globals into the loaded MCP module.
+		// These vars are injected into the translator scope, not the module scope.
+		// @formatter:off
+		String injectDefaultVars = "for _k in ['ROOT', 'APP_ROOT', 'USER_ROOT']:\n" +
+		                          "    if _k in globals():\n" +
+		                          "        setattr(mcp_driver, _k, globals()[_k])";
+		// @formatter:on
 
 		if (!namedMCP) {
 			classLogger.warn("Using legacy {} python file name - needs to be updated to {}", LEGACY_PY_FILE_NAME,
@@ -243,6 +250,8 @@ public final class MCPUtility {
 
 		// reload the module
 		pyt.runScript(insight, loadFreshSmssModule);
+		// inject default vars into module scope
+		pyt.runScript(insight, injectDefaultVars);
 		// run method
 		return pyt.runScript(insight, runMethod) + "";
 	}


### PR DESCRIPTION
## **Description**

Fix MCP Python tools not seeing `ROOT`/`APP_ROOT`/`USER_ROOT` by injecting the default path variables into the freshly loaded `mcp_driver` module after import.

## **Changes Made**

- Added a post-import injection step in `MCPUtility.java` to copy `ROOT`, `APP_ROOT`, and `USER_ROOT` from the translator globals into the MCP module’s globals.
- Preserved existing behavior for loading/reloading the MCP module and executing the tool.

## **How to Test**

1. Run an MCP tool that reads `globals().get("ROOT")` inside `mcp_driver.py` (example: `get_files_in_room`).
2. Call the tool via Pixel (e.g., `RunMCPTool(...)`).
3. Expected outcomes:
   - `ROOT`/`APP_ROOT`/`USER_ROOT` are non-null inside the MCP function.
   - The tool can use `ROOT` (e.g., `os.listdir(ROOT)`) without a `None` error.


```
from smssutil import mcp_execution
import os

@mcp_execution("ask")
def get_files_in_room(path = None) -> dict:
    files = os.listdir(ROOT)
    return files
````
## **Notes**

- This aligns module scope with the already-injected translator scope without changing the MCP tool API or behavior.