### PR TITLE
feat: use project id to create python MCP if available and no project id was passed in

### DIFF
--- a/src/prerna/reactor/agent/mcp/MakePythonMCPReactor.java
+++ b/src/prerna/reactor/agent/mcp/MakePythonMCPReactor.java
@@ -62,7 +62,6 @@ public class MakePythonMCPReactor extends AbstractReactor {
 	@Override
 	public NounMetadata execute() {
 		organizeKeys();
-		// get the canonical key
 		String engineId = this.keyValue.get(this.keysToGet[0].split(",")[0]);
 		if (engineId == null || engineId.isEmpty()) {
 			engineId = insight.getContextProjectId();

--- a/src/prerna/reactor/agent/mcp/MakePythonMCPReactor.java
+++ b/src/prerna/reactor/agent/mcp/MakePythonMCPReactor.java
@@ -56,7 +56,7 @@ public class MakePythonMCPReactor extends AbstractReactor {
 	public MakePythonMCPReactor() {
 		this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey() + "," + ReactorKeysEnum.PROJECT.getKey(),
 				ReactorKeysEnum.MODEL.getKey(), ReactorKeysEnum.COMMENT_KEY.getKey() };
-		this.keyRequired = new int[] { 1, 0, 0 };
+		this.keyRequired = new int[] { 0, 0, 0 };
 	}
 
 	@Override
@@ -64,6 +64,15 @@ public class MakePythonMCPReactor extends AbstractReactor {
 		organizeKeys();
 		// get the canonical key
 		String engineId = this.keyValue.get(this.keysToGet[0].split(",")[0]);
+		if (engineId == null || engineId.isEmpty()) {
+			engineId = insight.getContextProjectId();
+			if (engineId == null || engineId.isEmpty()) {
+				engineId = insight.getProjectId();
+			}
+		}
+		if (engineId == null || (engineId = engineId.trim()).isEmpty()) {
+			throw new IllegalArgumentException("Must provide the engine/project id or set the app context");
+		}
 
 		// get engine
 		IEngine engine = null;


### PR DESCRIPTION
use context project id to create the MCP if available and no project id was passed in