### PR TITLE
Disassociate tool name from function name for Internal MCPs

### DIFF
--- a/py/smssutil.py
+++ b/py/smssutil.py
@@ -9,6 +9,8 @@ from deprecated import deprecated
 
 logger = logging.getLogger("SocketServer")
 
+MCP_MAX_NAME_LENGTH = 128 # max char length for mcp tool names and titles that are taken
+
 # callback link
 executorExceptionCallback = None
 
@@ -1106,11 +1108,12 @@ def generate_mcp(
                 or function_name == "*"
                 or this_function == function_name
             ):
-                this_function = this_function[:128] # enforce 128 char limit on function names for MCP
-                function.update({"name": this_function})
+                this_function = this_function
                 if mcp_display_name:
+                    function.update({"name": format_to_snake_case(mcp_display_name)})
                     function.update({"title": format_to_title_case(mcp_display_name)})
                 else:
+                    function.update({"name": format_to_snake_case(this_function)})
                     function.update({"title": format_to_title_case(this_function)})
                 docstring = ast.get_docstring(node)
                 if docstring is not None and len(docstring) > 0:
@@ -1177,6 +1180,7 @@ def generate_mcp(
                     "generated_on": todays_date_utc.strftime(date_format),
                     "SMSS_MCP_EXECUTION": mcp_execution_mode,
                     "SMSS_MCP_UI": cleaned_mcp_ui_map,
+                    "function_name": this_function,
                 }
                 if function_name_to_cell is not None:
                     cell_id = function_name_to_cell.get(this_function)
@@ -1444,7 +1448,8 @@ def map_mcp_to_py(input):
         return "object"
 
 
-def format_to_title_case(input_str) -> str:
+
+def format_to_title_case(input_str, max_length=MCP_MAX_NAME_LENGTH) -> str:
     """
     Converts camelCase, PascalCase, or snake_case strings to title case with spaces
     Examples:
@@ -1486,7 +1491,31 @@ def format_to_title_case(input_str) -> str:
         else:
             result.append(char)
 
-    return "".join(result)
+    return "".join(result)[:max_length]
+
+
+def format_to_snake_case(input_str, max_length=MCP_MAX_NAME_LENGTH) -> str:
+    """
+    Converts camelCase, PascalCase, or title/space-delimited strings to snake_case.
+    Examples:
+        "RunNER" -> "run_ner"
+        "ToUpperCase" -> "to_upper_case"
+        "simpleWord" -> "simple_word"
+        "XMLParser" -> "xml_parser"
+        "Get Stock Price" -> "get_stock_price"
+        "get_stock_price" -> "get_stock_price"
+    """
+    if not input_str:
+        return input_str
+
+    import re
+
+    normalized = input_str.strip().replace("-", "_").replace(" ", "_")
+    # Split camel/pascal and acronym boundaries.
+    normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", normalized)
+    normalized = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", normalized)
+    normalized = re.sub(r"_+", "_", normalized)
+    return normalized.strip("_").lower()[:max_length]
 
 
 def get_function_name_from_code(code_string) -> str:

--- a/py/smssutil.py
+++ b/py/smssutil.py
@@ -1019,6 +1019,7 @@ def generate_mcp(
 
             # Check for new mcp_execution decorator and _mcp_execution attribute
             mcp_execution_mode: str = None
+            mcp_display_name: str = None
             mcp_ui_map: dict = {}
             try:
                 module = load_module_from_file("temp_module", src_file)
@@ -1028,6 +1029,8 @@ def generate_mcp(
                     mcp_execution_mode = mcp_metadata.pop("execution")
                 if mcp_metadata:
                     mcp_ui_map = mcp_metadata
+                if mcp_metadata.get("displayName", None) is not None:
+                    mcp_display_name = mcp_metadata.pop("displayName")[:128] # enforce 128 char limit on display names for MCP
 
                 # Fallback to old _mcp_execution attribute if not set via new decorator
                 if (
@@ -1057,6 +1060,8 @@ def generate_mcp(
                                     mcp_execution_mode = mcp_metadata.pop("execution")
                                 if mcp_metadata:
                                     mcp_ui_map = mcp_metadata
+                                if mcp_metadata.get("displayName", None) is not None:
+                                    mcp_display_name = mcp_metadata.pop("displayName")[:128] # enforce 128 char limit on display names for MCP
 
                             except:
                                 pass
@@ -1101,8 +1106,12 @@ def generate_mcp(
                 or function_name == "*"
                 or this_function == function_name
             ):
+                this_function = this_function[:128] # enforce 128 char limit on function names for MCP
                 function.update({"name": this_function})
-                function.update({"title": format_to_title_case(this_function)})
+                if mcp_display_name:
+                    function.update({"title": format_to_title_case(mcp_display_name)})
+                else:
+                    function.update({"title": format_to_title_case(this_function)})
                 docstring = ast.get_docstring(node)
                 if docstring is not None and len(docstring) > 0:
                     function.update({"description": docstring})
@@ -1205,7 +1214,7 @@ def mcp_execution(arg: str):
 def mcp_metadata(_mcp_metadata: dict):
     """
     Decorator factory to add metadata to MCP functions.
-    Usage: @mcp_metadata({'loadingMessage': 'Loading...', 'resourceURI': null, 'execution':'auto'|'ask_user'|'disabled', 'displayLocation': 'inline'|'sidebar'|'hidden'})
+    Usage: @mcp_metadata({'loadingMessage': 'Loading...', 'resourceURI': null, 'execution':'auto'|'ask_user'|'disabled', 'displayLocation': 'inline'|'sidebar'|'hidden', 'displayName': 'Custom Name'})
     """
 
     def _decorator(func):

--- a/py/smssutil.py
+++ b/py/smssutil.py
@@ -1436,7 +1436,6 @@ def map_mcp_to_py(input):
         return "object"
 
 
-
 def format_to_title_case(input_str) -> str:
     """
     Converts camelCase, PascalCase, or snake_case strings to title case with spaces

--- a/py/smssutil.py
+++ b/py/smssutil.py
@@ -1168,7 +1168,7 @@ def generate_mcp(
                     "generated_on": todays_date_utc.strftime(date_format),
                     "SMSS_MCP_EXECUTION": mcp_execution_mode,
                     "SMSS_MCP_UI": cleaned_mcp_ui_map,
-                    "function_name": this_function,
+                    "SMSS_FUNCTION_NAME": this_function,
                 }
                 if function_name_to_cell is not None:
                     cell_id = function_name_to_cell.get(this_function)

--- a/py/smssutil.py
+++ b/py/smssutil.py
@@ -9,8 +9,6 @@ from deprecated import deprecated
 
 logger = logging.getLogger("SocketServer")
 
-MCP_MAX_NAME_LENGTH = 128 # max char length for mcp tool names and titles that are taken
-
 # callback link
 executorExceptionCallback = None
 
@@ -1021,7 +1019,6 @@ def generate_mcp(
 
             # Check for new mcp_execution decorator and _mcp_execution attribute
             mcp_execution_mode: str = None
-            mcp_display_name: str = None
             mcp_ui_map: dict = {}
             try:
                 module = load_module_from_file("temp_module", src_file)
@@ -1031,8 +1028,6 @@ def generate_mcp(
                     mcp_execution_mode = mcp_metadata.pop("execution")
                 if mcp_metadata:
                     mcp_ui_map = mcp_metadata
-                if mcp_metadata.get("displayName", None) is not None:
-                    mcp_display_name = mcp_metadata.pop("displayName")[:128] # enforce 128 char limit on display names for MCP
 
                 # Fallback to old _mcp_execution attribute if not set via new decorator
                 if (
@@ -1062,8 +1057,6 @@ def generate_mcp(
                                     mcp_execution_mode = mcp_metadata.pop("execution")
                                 if mcp_metadata:
                                     mcp_ui_map = mcp_metadata
-                                if mcp_metadata.get("displayName", None) is not None:
-                                    mcp_display_name = mcp_metadata.pop("displayName")[:128] # enforce 128 char limit on display names for MCP
 
                             except:
                                 pass
@@ -1109,12 +1102,8 @@ def generate_mcp(
                 or this_function == function_name
             ):
                 this_function = this_function
-                if mcp_display_name:
-                    function.update({"name": format_to_snake_case(mcp_display_name)})
-                    function.update({"title": format_to_title_case(mcp_display_name)})
-                else:
-                    function.update({"name": format_to_snake_case(this_function)})
-                    function.update({"title": format_to_title_case(this_function)})
+                function.update({"name": this_function})
+                function.update({"title": format_to_title_case(this_function)})
                 docstring = ast.get_docstring(node)
                 if docstring is not None and len(docstring) > 0:
                     function.update({"description": docstring})
@@ -1218,7 +1207,7 @@ def mcp_execution(arg: str):
 def mcp_metadata(_mcp_metadata: dict):
     """
     Decorator factory to add metadata to MCP functions.
-    Usage: @mcp_metadata({'loadingMessage': 'Loading...', 'resourceURI': null, 'execution':'auto'|'ask_user'|'disabled', 'displayLocation': 'inline'|'sidebar'|'hidden', 'displayName': 'Custom Name'})
+    Usage: @mcp_metadata({'loadingMessage': 'Loading...', 'resourceURI': null, 'execution':'auto'|'ask_user'|'disabled', 'displayLocation': 'inline'|'sidebar'|'hidden', 'toolName': 'Custom Name'})
     """
 
     def _decorator(func):
@@ -1449,7 +1438,7 @@ def map_mcp_to_py(input):
 
 
 
-def format_to_title_case(input_str, max_length=MCP_MAX_NAME_LENGTH) -> str:
+def format_to_title_case(input_str) -> str:
     """
     Converts camelCase, PascalCase, or snake_case strings to title case with spaces
     Examples:
@@ -1491,31 +1480,7 @@ def format_to_title_case(input_str, max_length=MCP_MAX_NAME_LENGTH) -> str:
         else:
             result.append(char)
 
-    return "".join(result)[:max_length]
-
-
-def format_to_snake_case(input_str, max_length=MCP_MAX_NAME_LENGTH) -> str:
-    """
-    Converts camelCase, PascalCase, or title/space-delimited strings to snake_case.
-    Examples:
-        "RunNER" -> "run_ner"
-        "ToUpperCase" -> "to_upper_case"
-        "simpleWord" -> "simple_word"
-        "XMLParser" -> "xml_parser"
-        "Get Stock Price" -> "get_stock_price"
-        "get_stock_price" -> "get_stock_price"
-    """
-    if not input_str:
-        return input_str
-
-    import re
-
-    normalized = input_str.strip().replace("-", "_").replace(" ", "_")
-    # Split camel/pascal and acronym boundaries.
-    normalized = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", normalized)
-    normalized = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", normalized)
-    normalized = re.sub(r"_+", "_", normalized)
-    return normalized.strip("_").lower()[:max_length]
+    return "".join(result)
 
 
 def get_function_name_from_code(code_string) -> str:

--- a/py/smssutil.py
+++ b/py/smssutil.py
@@ -1101,7 +1101,6 @@ def generate_mcp(
                 or function_name == "*"
                 or this_function == function_name
             ):
-                this_function = this_function
                 function.update({"name": this_function})
                 function.update({"title": format_to_title_case(this_function)})
                 docstring = ast.get_docstring(node)
@@ -1207,7 +1206,7 @@ def mcp_execution(arg: str):
 def mcp_metadata(_mcp_metadata: dict):
     """
     Decorator factory to add metadata to MCP functions.
-    Usage: @mcp_metadata({'loadingMessage': 'Loading...', 'resourceURI': null, 'execution':'auto'|'ask_user'|'disabled', 'displayLocation': 'inline'|'sidebar'|'hidden', 'toolName': 'Custom Name'})
+    Usage: @mcp_metadata({'loadingMessage': 'Loading...', 'resourceURI': null, 'execution':'auto'|'ask_user'|'disabled', 'displayLocation': 'inline'|'sidebar'|'hidden'})
     """
 
     def _decorator(func):

--- a/src/prerna/engine/impl/InternalMCP.java
+++ b/src/prerna/engine/impl/InternalMCP.java
@@ -195,7 +195,7 @@ public class InternalMCP implements IMCP {
 		Object output = null;
 		if (toolProperties != null) {
 			// this is a python mcp tool
-			String functionName = (String) toolProperties.remove("function_name");
+			String functionName = (String) toolProperties.remove(MCPUtility.SMSS_FUNCTION_NAME);
 			output = MCPUtility.runPythonTool(this.engine, insight, functionName, toolProperties, params);
 			return output;
 		}
@@ -203,7 +203,7 @@ public class InternalMCP implements IMCP {
 		toolProperties = getFunction(toolName, pixelJsonFileLoc);
 		if (toolProperties != null) {
 			// this is a pixel mcp tool
-			String functionName = (String) toolProperties.remove("function_name");
+			String functionName = (String) toolProperties.remove(MCPUtility.SMSS_FUNCTION_NAME);
 			output = MCPUtility.runPixelTool(this.engine, insight, functionName, toolProperties, params);
 			return output;
 		}
@@ -234,8 +234,8 @@ public class InternalMCP implements IMCP {
 							// get everything else
 							JSONObject properties = ((JSONObject) thisTool.get("inputSchema"))
 									.getJSONObject("properties");
-							String functionName = ((JSONObject) thisTool.get("_meta")).optString("function_name");
-							properties.put("function_name", (functionName != null  && !functionName.isBlank()) ? functionName : inputName);
+							String functionName = ((JSONObject) thisTool.get("_meta")).optString(MCPUtility.SMSS_FUNCTION_NAME);
+							properties.put(MCPUtility.SMSS_FUNCTION_NAME, (functionName != null  && !functionName.isBlank()) ? functionName : inputName);
 							return properties;
 						}
 					}

--- a/src/prerna/engine/impl/InternalMCP.java
+++ b/src/prerna/engine/impl/InternalMCP.java
@@ -34,7 +34,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.hadoop.shaded.org.eclipse.jetty.util.ajax.JSON;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;

--- a/src/prerna/engine/impl/InternalMCP.java
+++ b/src/prerna/engine/impl/InternalMCP.java
@@ -191,19 +191,31 @@ public class InternalMCP implements IMCP {
 		String pythonJsonFileLoc = assetsFolder + "/mcp/py_mcp.json";
 		String pixelJsonFileLoc = assetsFolder + "/mcp/pixel_mcp.json";
 
-		JSONObject toolProperties = getFunction(toolName, pythonJsonFileLoc);
+		JSONObject toolDefinition = getFunction(toolName, pythonJsonFileLoc);
 		Object output = null;
-		if (toolProperties != null) {
-			// this is a python mcp tool
-			String functionName = (String) toolProperties.remove(MCPUtility.SMSS_FUNCTION_NAME);
+		if (toolDefinition != null) {
+			// this is a python mcp
+			JSONObject toolProperties = ((JSONObject) toolDefinition.get("inputSchema")).getJSONObject("properties");
+			// check if we have an aliased name pointing to a function
+			// this is so we can have the same tool/function exposed more than once with
+			// different parameters exposed as multiple tools
+			String functionName = ((JSONObject) toolDefinition.get("_meta")).optString(MCPUtility.SMSS_FUNCTION_NAME);
+			functionName = (functionName != null && !functionName.isBlank()) ? functionName : toolName;
+
 			output = MCPUtility.runPythonTool(this.engine, insight, functionName, toolProperties, params);
 			return output;
 		}
 
-		toolProperties = getFunction(toolName, pixelJsonFileLoc);
-		if (toolProperties != null) {
+		toolDefinition = getFunction(toolName, pixelJsonFileLoc);
+		if (toolDefinition != null) {
 			// this is a pixel mcp tool
-			String functionName = (String) toolProperties.remove(MCPUtility.SMSS_FUNCTION_NAME);
+			JSONObject toolProperties = ((JSONObject) toolDefinition.get("inputSchema")).getJSONObject("properties");
+			// check if we have an aliased name pointing to a function
+			// this is so we can have the same tool/function exposed more than once with
+			// different parameters exposed as multiple tools
+			String functionName = ((JSONObject) toolDefinition.get("_meta")).optString(MCPUtility.SMSS_FUNCTION_NAME);
+			functionName = (functionName != null && !functionName.isBlank()) ? functionName : toolName;
+
 			output = MCPUtility.runPixelTool(this.engine, insight, functionName, toolProperties, params);
 			return output;
 		}
@@ -231,12 +243,8 @@ public class InternalMCP implements IMCP {
 						JSONObject thisTool = toolObj.getJSONObject(toolIndex);
 						String toolName = thisTool.getString("name");
 						if (toolName.contains(inputName)) {
-							// get everything else
-							JSONObject properties = ((JSONObject) thisTool.get("inputSchema"))
-									.getJSONObject("properties");
-							String functionName = ((JSONObject) thisTool.get("_meta")).optString(MCPUtility.SMSS_FUNCTION_NAME);
-							properties.put(MCPUtility.SMSS_FUNCTION_NAME, (functionName != null  && !functionName.isBlank()) ? functionName : inputName);
-							return properties;
+							// return the full tool
+							return thisTool;
 						}
 					}
 				}

--- a/src/prerna/engine/impl/InternalMCP.java
+++ b/src/prerna/engine/impl/InternalMCP.java
@@ -34,6 +34,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.shaded.org.eclipse.jetty.util.ajax.JSON;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONArray;
@@ -195,14 +196,16 @@ public class InternalMCP implements IMCP {
 		Object output = null;
 		if (toolProperties != null) {
 			// this is a python mcp tool
-			output = MCPUtility.runPythonTool(this.engine, insight, toolName, toolProperties, params);
+			String functionName = (String) toolProperties.remove("function_name");
+			output = MCPUtility.runPythonTool(this.engine, insight, functionName, toolProperties, params);
 			return output;
 		}
 
 		toolProperties = getFunction(toolName, pixelJsonFileLoc);
 		if (toolProperties != null) {
 			// this is a pixel mcp tool
-			output = MCPUtility.runPixelTool(this.engine, insight, toolName, toolProperties, params);
+			String functionName = (String) toolProperties.remove("function_name");
+			output = MCPUtility.runPixelTool(this.engine, insight, functionName, toolProperties, params);
 			return output;
 		}
 
@@ -211,11 +214,11 @@ public class InternalMCP implements IMCP {
 
 	/**
 	 * 
-	 * @param functionName
+	 * @param inputName
 	 * @param jsonFileLoc
 	 * @return
 	 */
-	private JSONObject getFunction(String functionName, String jsonFileLoc) {
+	private JSONObject getFunction(String inputName, String jsonFileLoc) {
 		File jsonFile = new File(jsonFileLoc);
 		if (jsonFile.exists()) {
 			try {
@@ -228,10 +231,12 @@ public class InternalMCP implements IMCP {
 					for (int toolIndex = 0; toolIndex < toolObj.length(); toolIndex++) {
 						JSONObject thisTool = toolObj.getJSONObject(toolIndex);
 						String toolName = thisTool.getString("name");
-						if (toolName.contains(functionName)) {
+						if (toolName.contains(inputName)) {
 							// get everything else
 							JSONObject properties = ((JSONObject) thisTool.get("inputSchema"))
 									.getJSONObject("properties");
+							String functionName = ((JSONObject) thisTool.get("_meta")).optString("function_name");
+							properties.put("function_name", (functionName != null  && !functionName.isBlank()) ? functionName : inputName);
 							return properties;
 						}
 					}

--- a/src/prerna/reactor/agent/mcp/MCPUtility.java
+++ b/src/prerna/reactor/agent/mcp/MCPUtility.java
@@ -80,6 +80,7 @@ public final class MCPUtility {
 	public static final String SMSS_ENGINE_NAME = "SMSS_ENGINE_NAME";
 	public static final String SMSS_ENGINE_TYPE = "SMSS_ENGINE_TYPE";
 	public static final String SMSS_MCP_EXECUTION = "SMSS_MCP_EXECUTION";
+	public static final String SMSS_FUNCTION_NAME = "SMSS_FUNCTION_NAME";
 	public static final String SMSS_MCP_UI = "SMSS_MCP_UI";
 	public static final String UI_RESOURCE_URI = "resourceURI";
 	public static final String UI_LOADING_MESSAGE = "loadingMessage";

--- a/src/prerna/reactor/agent/mcp/MakeEngineMCPReactor.java
+++ b/src/prerna/reactor/agent/mcp/MakeEngineMCPReactor.java
@@ -176,6 +176,8 @@ public class MakeEngineMCPReactor extends AbstractReactor {
 			if (meta == null) {
 				meta = new JSONObject();
 			}
+			String functionName = reactorTool.getString("name");
+			meta.put(MCPUtility.SMSS_FUNCTION_NAME, functionName);
 
 			// Populate additional metadata from the parameter
 			Map<String, Object> additionalMeta = mcpMetaExists ? mcpMetadataList.get(i) : new HashMap<>();

--- a/src/prerna/reactor/agent/mcp/MakePixelMCPReactor.java
+++ b/src/prerna/reactor/agent/mcp/MakePixelMCPReactor.java
@@ -117,10 +117,12 @@ public class MakePixelMCPReactor extends AbstractReactor {
 			IReactor thisReactor = ReactorFactory.getReactor(this.insight, reactorNames.get(i), null,
 					this.insight.getCurFrame());
 			JSONObject reactorTool = thisReactor.asMcpTool();
+			String functionName = reactorTool.getString("name");
 			JSONObject meta = reactorTool.optJSONObject("_meta");
 			if (meta == null) {
 				meta = new JSONObject();
 			}
+			meta.put(MCPUtility.SMSS_FUNCTION_NAME, functionName);
 			// Populate additional metadata from the parameter
 			Map<String, Object> additionalMeta = mcpMetaExists ? mcpMetadataList.get(i) : new HashMap<>();
 			// Parse for specific known keys

--- a/src/prerna/reactor/agent/mcp/RunMCPToolReactor.java
+++ b/src/prerna/reactor/agent/mcp/RunMCPToolReactor.java
@@ -30,9 +30,6 @@ package prerna.reactor.agent.mcp;
 import java.util.List;
 import java.util.Map;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
-
 import prerna.auth.User;
 import prerna.engine.api.IEngine;
 import prerna.engine.api.IMCP;
@@ -95,14 +92,12 @@ public class RunMCPToolReactor extends AbstractReactor {
 		if (toolName == null || (toolName = toolName.trim()).isEmpty()) {
 			throw new IllegalArgumentException("Tool name must be passed in to execute the mcp tool");
 		}
-		
 		toolName = MCPUtility.removeEngineIdFromToolsMethodName(engine.getEngineId(), toolName);
 
 		// these are the params
 		Map<String, Object> paramMap = getMap();
 
 		IMCP mcp = MCPFactory.build(engine);
-
 		return new NounMetadata(mcp.callTool(toolName, paramMap, this.insight), PixelDataType.CONST_STRING,
 				PixelOperationType.MCP_TOOL_EXECUTION);
 	}

--- a/src/prerna/reactor/agent/mcp/RunMCPToolReactor.java
+++ b/src/prerna/reactor/agent/mcp/RunMCPToolReactor.java
@@ -30,6 +30,9 @@ package prerna.reactor.agent.mcp;
 import java.util.List;
 import java.util.Map;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
 import prerna.auth.User;
 import prerna.engine.api.IEngine;
 import prerna.engine.api.IMCP;
@@ -92,13 +95,40 @@ public class RunMCPToolReactor extends AbstractReactor {
 		if (toolName == null || (toolName = toolName.trim()).isEmpty()) {
 			throw new IllegalArgumentException("Tool name must be passed in to execute the mcp tool");
 		}
+		
 		toolName = MCPUtility.removeEngineIdFromToolsMethodName(engine.getEngineId(), toolName);
 
 		// these are the params
 		Map<String, Object> paramMap = getMap();
 
 		IMCP mcp = MCPFactory.build(engine);
-		return new NounMetadata(mcp.callTool(toolName, paramMap, this.insight), PixelDataType.CONST_STRING,
+
+		// Find the tool in the array whose "name" field matches toolName. Then, from the "_meta" json object, get the "function_name" field,
+		// apply MCPUtility.removeEngineIdFromToolsMethodName, and then pass that to mcp.callTool instead of toolName.
+
+		// Compatible with legacy approach as well, since if the tool doesn't have a _meta.function_name, it will just use toolName as the function name to call
+		JSONArray toolsArray = mcp.getMCPTools().getJSONArray("tools");
+		String functionNameToCall = toolName;
+		for (int i = 0; i < toolsArray.length(); i++) {
+			JSONObject tool = toolsArray.optJSONObject(i);
+			if (tool == null) {
+				continue;
+			}
+			String name = tool.optString("name", null);
+			if (!toolName.equals(name)) {
+				continue;
+			}
+			JSONObject meta = tool.optJSONObject("_meta");
+			if (meta != null) {
+				String functionName = meta.optString("function_name", "");
+				if (!functionName.isEmpty()) {
+					functionNameToCall = functionName;
+					break;
+				}
+			}
+		}
+
+		return new NounMetadata(mcp.callTool(functionNameToCall, paramMap, this.insight), PixelDataType.CONST_STRING,
 				PixelOperationType.MCP_TOOL_EXECUTION);
 	}
 

--- a/src/prerna/reactor/agent/mcp/RunMCPToolReactor.java
+++ b/src/prerna/reactor/agent/mcp/RunMCPToolReactor.java
@@ -103,32 +103,7 @@ public class RunMCPToolReactor extends AbstractReactor {
 
 		IMCP mcp = MCPFactory.build(engine);
 
-		// Find the tool in the array whose "name" field matches toolName. Then, from the "_meta" json object, get the "function_name" field,
-		// apply MCPUtility.removeEngineIdFromToolsMethodName, and then pass that to mcp.callTool instead of toolName.
-
-		// Compatible with legacy approach as well, since if the tool doesn't have a _meta.function_name, it will just use toolName as the function name to call
-		JSONArray toolsArray = mcp.getMCPTools().getJSONArray("tools");
-		String functionNameToCall = toolName;
-		for (int i = 0; i < toolsArray.length(); i++) {
-			JSONObject tool = toolsArray.optJSONObject(i);
-			if (tool == null) {
-				continue;
-			}
-			String name = tool.optString("name", null);
-			if (!toolName.equals(name)) {
-				continue;
-			}
-			JSONObject meta = tool.optJSONObject("_meta");
-			if (meta != null) {
-				String functionName = meta.optString("function_name", "");
-				if (!functionName.isEmpty()) {
-					functionNameToCall = functionName;
-					break;
-				}
-			}
-		}
-
-		return new NounMetadata(mcp.callTool(functionNameToCall, paramMap, this.insight), PixelDataType.CONST_STRING,
+		return new NounMetadata(mcp.callTool(toolName, paramMap, this.insight), PixelDataType.CONST_STRING,
 				PixelOperationType.MCP_TOOL_EXECUTION);
 	}
 


### PR DESCRIPTION
## Description
When mcp json is generated, store the function or reactor name in the _meta map, thereby allowing the user to change the name of the tool. When we execute a tool through RunMCPTool, if it's an InternalMCP, we look for the name of the tool and get the function/reactor name to run instead. If it's not present, we use the tool name so as to stay backwards compatible. This also allows us to designate multiple tools that call the same reactor/function with different enums/parameters using distinct tool names.

## Testing:
1. Create an MCP either through pixel or python.
2. Note that for each tool, _meta contains the name of the function/reactor
3. Change the name and title of the mcp tool to your liking. This can be done by modifying the json directly.
4. Add the MCP to a chat in playground and run the modified tools in question, verifying that the tool is run without issues finding the actual function to run.