### PR TITLE
feat: audit_log db index addition and query optimization

### DIFF
--- a/src/prerna/engine/api/IModelEngine.java
+++ b/src/prerna/engine/api/IModelEngine.java
@@ -159,11 +159,12 @@ public interface IModelEngine extends IEngine {
 	 */
 	@IgnoreEngineLogging
 	boolean keepsConversationHistory();
-	
+
 	/**
 	 * 
 	 * @return
 	 */
+	@IgnoreEngineLogging
 	int getContextWindow();
 
 }

--- a/src/prerna/engine/logging/AuditLogsDbUtils.java
+++ b/src/prerna/engine/logging/AuditLogsDbUtils.java
@@ -112,6 +112,74 @@ public class AuditLogsDbUtils {
 				}
 			}
 		}
+		if (allowIfExistsIndexs) {
+			String sql = queryUtil.createIndexIfNotExists("AUDIT_LOGS__REQUEST_ID_INDEX", "AUDIT_LOGS", "REQUEST_ID");
+			classLogger.info("Running sql " + sql);
+			executeSql(conn, sql);
+
+			sql = queryUtil.createIndexIfNotExists("AUDIT_LOGS__PROJECT_TS_INDEX", "AUDIT_LOGS",
+					List.of("PROJECT_ID", "LOG_TIMESTAMP"));
+			classLogger.info("Running sql " + sql);
+			executeSql(conn, sql);
+
+			sql = queryUtil.createIndexIfNotExists("AUDIT_LOGS__USER_TS_INDEX", "AUDIT_LOGS",
+					List.of("USER_ID", "LOG_TIMESTAMP"));
+			classLogger.info("Running sql " + sql);
+			executeSql(conn, sql);
+
+			sql = queryUtil.createIndexIfNotExists("AUDIT_LOGS__ENGINE_TS_INDEX", "AUDIT_LOGS",
+					List.of("ENGINE_ID", "LOG_TIMESTAMP"));
+			classLogger.info("Running sql " + sql);
+			executeSql(conn, sql);
+
+			sql = queryUtil.createIndexIfNotExists("AUDIT_LOGS__SESSION_ID_INDEX", "AUDIT_LOGS", "SESSION_ID");
+			classLogger.info("Running sql " + sql);
+			executeSql(conn, sql);
+
+			sql = queryUtil.createIndexIfNotExists("AUDIT_LOGS__ROOM_ID_INDEX", "AUDIT_LOGS", "ROOM_ID");
+			classLogger.info("Running sql " + sql);
+			executeSql(conn, sql);
+		} else {
+			// REQUEST_ID
+			if (!queryUtil.indexExists(auditLogsDb, "AUDIT_LOGS__REQUEST_ID_INDEX", "AUDIT_LOGS", database, schema)) {
+				String sql = queryUtil.createIndex("AUDIT_LOGS__REQUEST_ID_INDEX", "AUDIT_LOGS", "REQUEST_ID");
+				classLogger.info("Running sql " + sql);
+				executeSql(conn, sql);
+			}
+			// COMPOSITE INDEX PROJECT_ID + LOG_TIMESTAMP
+			if (!queryUtil.indexExists(auditLogsDb, "AUDIT_LOGS__PROJECT_TS_INDEX", "AUDIT_LOGS", database, schema)) {
+				String sql = queryUtil.createIndex("AUDIT_LOGS__PROJECT_TS_INDEX", "AUDIT_LOGS",
+						List.of("PROJECT_ID", "LOG_TIMESTAMP"));
+				classLogger.info("Running sql " + sql);
+				executeSql(conn, sql);
+			}
+			// COMPOSITE INDEX USER_ID + LOG_TIMESTAMP
+			if (!queryUtil.indexExists(auditLogsDb, "AUDIT_LOGS__USER_TS_INDEX", "AUDIT_LOGS", database, schema)) {
+				String sql = queryUtil.createIndex("AUDIT_LOGS__USER_TS_INDEX", "AUDIT_LOGS",
+						List.of("USER_ID", "LOG_TIMESTAMP"));
+				classLogger.info("Running sql " + sql);
+				executeSql(conn, sql);
+			}
+			// COMPOSITE INDEX ENGINE_ID + LOG_TIMESTAMP
+			if (!queryUtil.indexExists(auditLogsDb, "AUDIT_LOGS__ENGINE_TS_INDEX", "AUDIT_LOGS", database, schema)) {
+				String sql = queryUtil.createIndex("AUDIT_LOGS__ENGINE_TS_INDEX", "AUDIT_LOGS",
+						List.of("ENGINE_ID", "LOG_TIMESTAMP"));
+				classLogger.info("Running sql " + sql);
+				executeSql(conn, sql);
+			}
+			// SESSION_ID
+			if (!queryUtil.indexExists(auditLogsDb, "AUDIT_LOGS__SESSION_ID_INDEX", "AUDIT_LOGS", database, schema)) {
+				String sql = queryUtil.createIndex("AUDIT_LOGS__SESSION_ID_INDEX", "AUDIT_LOGS", "SESSION_ID");
+				classLogger.info("Running sql " + sql);
+				executeSql(conn, sql);
+			}
+			// ROOM_ID
+			if (!queryUtil.indexExists(auditLogsDb, "AUDIT_LOGS__ROOM_ID_INDEX", "AUDIT_LOGS", database, schema)) {
+				String sql = queryUtil.createIndex("AUDIT_LOGS__ROOM_ID_INDEX", "AUDIT_LOGS", "ROOM_ID");
+				classLogger.info("Running sql " + sql);
+				executeSql(conn, sql);
+			}
+		}
 	}
 
 	/**
@@ -224,6 +292,14 @@ public class AuditLogsDbUtils {
 				QueryFunctionSelector.makeFunctionSelector(QueryFunctionHelper.MAX, "AUDIT_LOGS__RESPONSE_END_TIME",
 						"END_TIME"),
 				"DURATION"));
+		// filter for minMaxDuration
+		addStartDateEndDateFitler(minMaxDuration, "AUDIT_LOGS__LOG_TIMESTAMP", startDate, endDate);
+		addFilter(minMaxDuration, "AUDIT_LOGS__USER_ID", "==", userId);
+		addFilter(minMaxDuration, "AUDIT_LOGS__PROJECT_ID", "==", projectId);
+		addFilter(minMaxDuration, "AUDIT_LOGS__ENGINE_ID", "==", engineId);
+		addFilter(minMaxDuration, "AUDIT_LOGS__ROOM_ID", "==", roomId);
+		addFilter(minMaxDuration, "AUDIT_LOGS__SESSION_ID", "==", sessionId);
+
 		minMaxDuration.addGroupBy(new QueryColumnSelector("AUDIT_LOGS__REQUEST_ID"));
 		IRelation subQuery = new SubqueryRelationship(minMaxDuration, "MIN_MAX_DURATION", "inner.join",
 				new String[] { "AUDIT_LOGS__REQUEST_ID", "MIN_MAX_DURATION__REQUEST_ID", "=" });
@@ -246,7 +322,7 @@ public class AuditLogsDbUtils {
 			String userIdFromRow = getOrDefault(map.get("USER_ID"), null);
 			String sessionIdFromRow = getOrDefault(map.get("SESSION_ID"), null);
 			String spanIdFromRow = getOrDefault(map.get("SPAN_ID"), null);
-			Timestamp logTimestamp = extractTimestamp(map.get("END_TIME"));
+			Timestamp logTimestamp = extractTimestamp(map.get("LOG_TIMESTAMP"));
 
 			activityList.add(new LogActivityDto(startTime, endTime, request, response, tokens, latency, status,
 					engineName, engineType, methodName, userIdFromRow, sessionIdFromRow, spanIdFromRow, logTimestamp));

--- a/src/prerna/engine/logging/AuditLogsDbUtils.java
+++ b/src/prerna/engine/logging/AuditLogsDbUtils.java
@@ -241,7 +241,7 @@ public class AuditLogsDbUtils {
 	 * @return
 	 * @throws SQLException
 	 */
-	public static List<LogActivityDto> getAuditLogsTimeLineDatas(String userId, String projectId, String engineId,
+	public static List<LogActivityDto> getAuditLogsTimeLineData(String userId, String projectId, String engineId,
 			SemossDate startDate, SemossDate endDate, String roomId, String sessionId, int limit, int offset)
 			throws SQLException {
 

--- a/src/prerna/logging/AuditLogReportReactor.java
+++ b/src/prerna/logging/AuditLogReportReactor.java
@@ -157,7 +157,7 @@ public class AuditLogReportReactor extends AbstractReactor {
 		List<LogActivityDto> result = Collections.emptyList();
 		long totalCount = 0;
 		try {
-			result = AuditLogsDbUtils.getAuditLogsTimeLineDatas(filterUserId, projectId, engineId, startDate, endDate,
+			result = AuditLogsDbUtils.getAuditLogsTimeLineData(filterUserId, projectId, engineId, startDate, endDate,
 					roomId, sessionId, limit, offset);
 			// Get total record count
 			totalCount = AuditLogsDbUtils.getAuditLogsCount(filterUserId, projectId, engineId, startDate, endDate,


### PR DESCRIPTION
## Description
In this PR, added indexes for `AUDIT_LOG` Database to improve overall performance of AUDIT_LOG db operations. Also added improvised version of query to increase the speed of logs-fetching.


## Changes Made

- Query Optimization
Added `PROJECT_ID` and `LOG_TIMESTAMP` (and other optional filters like `USER_ID`, `ENGINE_ID`, `ROOM_ID`, `SESSION_ID`) inside the `MIN_MAX_DURATION ` subquery.
-This ensures the aggregation (MIN/MAX) runs only on relevant rows instead of the full `AUDIT_LOGS ` table.

- Indexes Addition

1. REQUEST_ID index
2. Composite index on (PROJECT_ID, LOG_TIMESTAMP)
3. Composite index on (USER_ID, LOG_TIMESTAMP)
4. Composite index on (ENGINE_ID, LOG_TIMESTAMP)
5. Index on SESSION_ID
6. Index on ROOM_ID

These indexes improve query execution for filtering + ordering (ORDER BY LOG_TIMESTAMP DESC LIMIT ).

## How to Test
Testing team can conduct any "load test" can use JMeter tool
