### PR TITLE
Handling OpenAi built-in tools from Codex

### DIFF
--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -590,8 +590,14 @@ class AnthropicMessageBuilder:
             param_map_budget_tokens = param_map.get("thinking_budget", 0)
 
         resolved_thinking = (
-            "enabled" if param_map_thinking or smss_thinking else "disabled"
+            "enabled"
+            if param_map_thinking == "enabled" or smss_thinking == "enabled"
+            else "disabled"
         )
+
+        if resolved_thinking == "disabled":
+            return None
+
         # If you set thinking as enabled but don't have a thinking budget I am going to set it for you..
         if param_map_budget_tokens >= 1024:
             resolved_thinking_budget = param_map_budget_tokens
@@ -600,7 +606,7 @@ class AnthropicMessageBuilder:
         else:
             resolved_thinking_budget = 1024
 
-        return {"type": resolved_thinking, "budget_tokens": resolved_thinking_budget}
+        return {"type": "enabled", "budget_tokens": resolved_thinking_budget}
 
     def _convert_args_to_provider_config(
         self,
@@ -634,7 +640,7 @@ class AnthropicMessageBuilder:
         )
 
         # MAX TOKENS MUST BE LARGER THAN THINKING BUDGET
-        if (
+        if thinking_map and (
             thinking_map.get("type") == "enabled"
             and thinking_map.get("budget_tokens", 0) <= max_tokens
         ):

--- a/py/genai_client/message_builders/openai/openai_message_builder.py
+++ b/py/genai_client/message_builders/openai/openai_message_builder.py
@@ -162,7 +162,10 @@ class OpenAIMessageBuilder:
         # convert tools into openai responses format if present
         if param_map.get("tools"):
             tools = self._handle_responses_tools(param_map["tools"])
-            param_map["tools"] = [tool.model_dump() for tool in tools]
+            param_map["tools"] = [
+                tool.model_dump() if hasattr(tool, "model_dump") else tool
+                for tool in tools
+            ]
         else:
             param_map.pop("tools", None)
 
@@ -263,9 +266,13 @@ class OpenAIMessageBuilder:
 
         # convert tools into openai chat-completion format if present
         if not has_schema and param_map.get("tools"):
-            param_map["tools"] = self.convert_mcp_to_openai_chat_completions_tools(
+            tools = self.convert_mcp_to_openai_chat_completions_tools(
                 param_map["tools"]
             )
+            param_map["tools"] = [
+                tool.model_dump() if hasattr(tool, "model_dump") else tool
+                for tool in tools
+            ]
         else:
             param_map.pop("tools", None)
 
@@ -447,7 +454,7 @@ class OpenAIMessageBuilder:
 
     def convert_mcp_to_openai_chat_completions_tools(
         self, mcp_tools: List[Dict]
-    ) -> List[Dict]:
+    ) -> List[Any]:
         """
         Convert MCP-formatted tools to OpenAI function calling format.
         Args:
@@ -458,6 +465,17 @@ class OpenAIMessageBuilder:
         openai_tools = []
 
         for tool in mcp_tools:
+            tool_type = tool.get("type", "function")
+
+            # built-in tools
+            if (
+                tool_type != "function"
+                and "inputSchema" not in tool
+                and "parameters" not in tool
+            ):
+                openai_tools.append(tool)
+                continue
+
             openai_tool = {
                 "name": tool["name"],
                 "description": tool["description"],
@@ -487,12 +505,25 @@ class OpenAIMessageBuilder:
 
         return openai_tools
 
-    def _handle_responses_tools(
-        self, tools: List[Dict]
-    ) -> List[OpenAIToolResponsesContentPart]:
-        # We need to detect if each tool is already in OpenAI format or MCP format
+    def _handle_responses_tools(self, tools: List[Dict]) -> List[Any]:
+        """
+        I'm returning a mix of pydantic models and raw dictionaries because of OpenAI's built in tools.
+        I want to be able to explictly define non-built-in tools but I'm not going to try to update or keep track
+        of OpenAI's built-in tool's parameters.
+        """
         openai_tools = []
         for tool in tools:
+            tool_type = tool.get("type", "function")
+
+            # Built-in tools (web_search, code_interpreter, etc.)
+            if (
+                tool_type != "function"
+                and "inputSchema" not in tool
+                and "parameters" not in tool
+            ):
+                openai_tools.append(tool)
+                continue
+
             if "parameters" in tool:
                 # Already in OpenAI format
                 openai_tools.append(

--- a/src/prerna/engine/impl/model/message/MessageUtils.java
+++ b/src/prerna/engine/impl/model/message/MessageUtils.java
@@ -455,49 +455,62 @@ public class MessageUtils {
 //	}
 
 	public static List<Map<String, Object>> convertOpenAIToMCPTools(List<Map<String, Object>> inputTools) {
-		List<Map<String, Object>> newTools = new ArrayList<>();
-		for (Map<String, Object> tool : inputTools) {
-			Map<String, Object> result = new LinkedHashMap<>();
-			String name = null, description = null, title = null;
-			Map<String, Object> inputSchema = null;
+	    List<Map<String, Object>> newTools = new ArrayList<>();
+	    for (Map<String, Object> tool : inputTools) {
+	        String type = (String) tool.get("type");
 
-			// Handle OpenAI style with nested "function"
-			if (tool.containsKey("function") && tool.get("function") instanceof Map) {
-				@SuppressWarnings("unchecked")
-				Map<String, Object> function = (Map<String, Object>) tool.get("function");
-				name = function.containsKey("name") ? (String) function.get("name") : (String) tool.get("name");
-				description = function.containsKey("description") ? (String) function.get("description")
-						: (String) tool.get("description");
-				Object params = function.get("parameters");
-				if (params instanceof Map) {
-					inputSchema = new LinkedHashMap<>((Map) params);
-				}
-			} else {
-				// Already MCP-style or close-to
-				name = (String) tool.get("name");
-				description = (String) tool.get("description");
-				title = (String) tool.get("title");
-				if (tool.containsKey("inputSchema") && tool.get("inputSchema") instanceof Map) {
-					inputSchema = new LinkedHashMap<>((Map) tool.get("inputSchema"));
-				} else if (tool.containsKey("parameters") && tool.get("parameters") instanceof Map) {
-					inputSchema = new LinkedHashMap<>((Map) tool.get("parameters"));
-				}
-			}
+	        // Built-in tools (from OpenAI) (web_search, code_interpreter, file_search, etc.)
+	        // have a non-"function" type and no nested function/inputSchema/parameters definition.
+	        // Pass these through unchanged
+	        // Maybe a better way to identify these eventually? But I have to pass these on as is..
+	        if (type != null && !"function".equals(type)
+	                && !tool.containsKey("function")
+	                && !tool.containsKey("inputSchema")
+	                && !tool.containsKey("parameters")) {
+	            newTools.add(new LinkedHashMap<>(tool));
+	            continue;
+	        }
 
-			// Use provided title, or generate from name
-			if (title == null || title.trim().isEmpty()) {
-				title = MCPUtility.formatToTitleCase(name);
-			}
+	        Map<String, Object> result = new LinkedHashMap<>();
+	        String name = null, description = null, title = null;
+	        Map<String, Object> inputSchema = null;
 
-			result.put("name", name);
-			result.put("description", description);
-			result.put("title", title);
-			if (inputSchema != null) {
-				result.put("inputSchema", inputSchema);
-			}
-			newTools.add(result);
-		}
-		return newTools;
+	        // Handle OpenAI style with nested "function"
+	        if (tool.containsKey("function") && tool.get("function") instanceof Map) {
+	            @SuppressWarnings("unchecked")
+	            Map<String, Object> function = (Map<String, Object>) tool.get("function");
+	            name = function.containsKey("name") ? (String) function.get("name") : (String) tool.get("name");
+	            description = function.containsKey("description") ? (String) function.get("description")
+	                    : (String) tool.get("description");
+	            Object params = function.get("parameters");
+	            if (params instanceof Map) {
+	                inputSchema = new LinkedHashMap<>((Map) params);
+	            }
+	        } else {
+	            // Already MCP-style or close-to
+	            name = (String) tool.get("name");
+	            description = (String) tool.get("description");
+	            title = (String) tool.get("title");
+	            if (tool.containsKey("inputSchema") && tool.get("inputSchema") instanceof Map) {
+	                inputSchema = new LinkedHashMap<>((Map) tool.get("inputSchema"));
+	            } else if (tool.containsKey("parameters") && tool.get("parameters") instanceof Map) {
+	                inputSchema = new LinkedHashMap<>((Map) tool.get("parameters"));
+	            }
+	        }
+
+	        if (title == null || title.trim().isEmpty()) {
+	            title = MCPUtility.formatToTitleCase(name);
+	        }
+
+	        result.put("name", name);
+	        result.put("description", description);
+	        result.put("title", title);
+	        if (inputSchema != null) {
+	            result.put("inputSchema", inputSchema);
+	        }
+	        newTools.add(result);
+	    }
+	    return newTools;
 	}
 
 	public static Map<String, Object> toMCPToolChoice(Object toolChoiceInput) {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Allowing for Codex to send built-in tools format to our OpenAI endpoints and let them passthrough the tools data transformation on the Java side. 

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->