### PR TITLE
fix: honor limit request in hybrid search

### DIFF
--- a/py/vector_database/faiss/faiss_client.py
+++ b/py/vector_database/faiss/faiss_client.py
@@ -211,7 +211,7 @@ class FAISSSearcher:
         if columns_to_return is None:
             columns_to_return = list(self.ds.features)
 
-        fusion_limit = max(total_limit * 2, 20)
+        fusion_limit = max(total_limit * 2, limit * 2,  20)
 
         # 1. Do vector search
         vector_results = self._vector_only_search(


### PR DESCRIPTION
## Description
This change ensures that hybrid search executes correctly when users request more results than the default total_limit parameter. Previously, the fusion_limit calculation only considered total_limit, causing the search to fetch insufficient candidates from both vector and BM25 searches. This resulted in fewer results being returned than requested when limit exceeded total_limit. 

## Changes Made
The fusion_limit variable is now calculated using both `limit` and `total_limit`, instead of just `total_limit`. This ensures fusion always fetches at least 2x the requested limit from each search method, guaranteeing sufficient candidates for rank fusion.

## How to Test
Use any query that calls this class, such as nearestNeighbor from python sdk or VectorDatabaseQuery reactor. With this fix, you should return the same number of results as indicated in `limit` parameter. Currently, if limit is > 40, you will not get the number of results you request.

results = searcher.nearestNeighbor(
    question="test query",
    limit=100,   # greater than default total_limit * 2          
    use_hybrid_search=True
)