### PR TITLE
fix: added ToPdf to ReactorFactory

### DIFF
--- a/src/prerna/reactor/ReactorFactory.java
+++ b/src/prerna/reactor/ReactorFactory.java
@@ -157,6 +157,7 @@ import prerna.reactor.export.ToCsvReactor;
 import prerna.reactor.export.ToDatabaseReactor;
 import prerna.reactor.export.ToExcelReactor;
 import prerna.reactor.export.ToLoaderSheetReactor;
+import prerna.reactor.export.ToPdfReactor;
 import prerna.reactor.export.ToTsvReactor;
 import prerna.reactor.export.ToTxtReactor;
 import prerna.reactor.expression.IfError;
@@ -819,6 +820,7 @@ public class ReactorFactory {
 		reactorHash.put("ToTsv", ToTsvReactor.class); // take any task and output to a file
 		reactorHash.put("ToTxt", ToTxtReactor.class); // take any task and output to a file
 		reactorHash.put("ToExcel", ToExcelReactor.class); // take any task and output to a file
+		reactorHash.put("ToPdf", ToPdfReactor.class); // take any task and output to PDF
 		reactorHash.put("ToDatabase", ToDatabaseReactor.class);
 		reactorHash.put("ToLoaderSheet", ToLoaderSheetReactor.class);
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
The original problem was running `MakePixelMCP()` with the `ToPdf` reactor, as the descriptions were not populating properly. Also, running the command `ToPdf --help` had incorrect and incomplete descriptions.
The PR adds the ToPdf to the ReactorFactory file again, and after Updating the Project in Maven, the descriptions were properly populated. 

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
- Pull this repo and update project in Maven
- In an app, run a command similar to `MakePixelMCP(project="be75b2f5-c5a0-4edf-8669-da58892c99f0", reactor=["GenerateAPMContent","**ToPdf**"], mcpMetadata=[{"SMSS_MCP_EXECUTION": "auto"}, {"SMSS_MCP_EXECUTION": "auto"}]);`
Note the ToPdf 

2. Expected outcomes
- Check the description for ToPdf and see if a proper description for the tool and properties are there
## Notes
<!-- Any further notes regarding changes -->