### PR TITLE
Fix gemini tool calling

### DIFF
--- a/py/genai_client/message_builders/google_genai/google_genai_builder.py
+++ b/py/genai_client/message_builders/google_genai/google_genai_builder.py
@@ -1,4 +1,4 @@
-import json
+import base64, json
 from typing import List, Dict, Any, Tuple, Union
 from google.genai.types import Content, Part
 from ..semoss_base.semoss_models import (
@@ -75,12 +75,23 @@ class GoogleGenAIMessageBuilder:
                         tool_id_to_name.update(
                             {p.toolCall.id: p.toolCall.function.name}
                         )
-                        parts.append(
-                            Part.from_function_call(
+                        ts_bytes = None
+                        if p.toolCall.thought_signature:
+                            ts_bytes = base64.b64decode(p.toolCall.thought_signature)
+                        if ts_bytes:
+                            fc_part = types.Part(
+                                function_call=types.FunctionCall(
+                                    name=p.toolCall.function.name,
+                                    args=p.toolCall.function.parameters,
+                                ),
+                                thought_signature=ts_bytes,
+                            )
+                        else:
+                            fc_part = Part.from_function_call(
                                 name=p.toolCall.function.name,
                                 args=p.toolCall.function.parameters,
                             )
-                        )
+                        parts.append(fc_part)
 
                     elif p.type == SEMOSSMessagePartType.TOOL_RESULT:
                         parts.append(
@@ -144,12 +155,25 @@ class GoogleGenAIMessageBuilder:
                             if isinstance(args, str):
                                 args = json.loads(args)
 
-                            parts.append(
-                                Part.from_function_call(
+                            ts_bytes = None
+                            ts_b64 = tool_call.get("thought_signature")
+                            if ts_b64:
+                                ts_bytes = base64.b64decode(ts_b64)
+
+                            if ts_bytes:
+                                fc_part = types.Part(
+                                    function_call=types.FunctionCall(
+                                        name=tool_call.get("function").get("name"),
+                                        args=args,
+                                    ),
+                                    thought_signature=ts_bytes,
+                                )
+                            else:
+                                fc_part = Part.from_function_call(
                                     name=tool_call.get("function").get("name"),
                                     args=args,
                                 )
-                            )
+                            parts.append(fc_part)
 
                         google_messages.append(
                             Content(

--- a/py/genai_client/message_builders/semoss_base/semoss_message_builder.py
+++ b/py/genai_client/message_builders/semoss_base/semoss_message_builder.py
@@ -85,6 +85,7 @@ class SEMOSSMessageBuilder:
                                 ),
                                 id=tc.get("id"),
                                 type="function",
+                                thought_signature=tc.get("thought_signature"),
                             )
                         )
                         process_parts.append(tool_call_part)

--- a/py/genai_client/message_builders/semoss_base/semoss_models.py
+++ b/py/genai_client/message_builders/semoss_base/semoss_models.py
@@ -63,6 +63,7 @@ class SEMOSSToolCall(BaseModel):
     function: SEMOSSToolFunction
     type: Literal["function"]
     id: Optional[str] = None
+    thought_signature: Optional[str] = None  # Base64-encoded, Gemini thinking models only
 
 
 class SEMOSSToolResponse(BaseModel):

--- a/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
+++ b/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
@@ -328,7 +328,7 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
 
             if len(getattr(event, "function_calls", None) or []) > 0:
                 for i, function_call in enumerate(event.function_calls):
-                    function_id = str(i)
+                    function_id = str(len(tool_result) + i)
                     this_content_block.update(
                         {
                             "id": function_id,

--- a/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
+++ b/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
@@ -238,7 +238,9 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
             if i < len(parts_with_fc):
                 ts = getattr(parts_with_fc[i], "thought_signature", None)
                 if ts:
-                    tool_entry["thought_signature"] = base64.b64encode(ts).decode("utf-8")
+                    tool_entry["thought_signature"] = base64.b64encode(ts).decode(
+                        "utf-8"
+                    )
             tools_result.append(tool_entry)
 
         return AskModelEngineResponse2(
@@ -289,8 +291,12 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
                             hasattr(part, "thought")
                             and part.thought
                             and hasattr(part, "text")
+                            and part.text
                         ):
                             thinking_response += part.text
+                            data = StreamUtil.create_thinking_chunk(part.text)
+                            smss_stream(data, stream_type="thinking")
+                            print(prefix + part.text, end="", flush=True)
                         if part.inline_data:
                             image_data.append(
                                 self._create_media_info(
@@ -383,7 +389,9 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
                     if i < len(parts_with_fc):
                         ts = getattr(parts_with_fc[i], "thought_signature", None)
                         if ts:
-                            tool_entry["thought_signature"] = base64.b64encode(ts).decode("utf-8")
+                            tool_entry["thought_signature"] = base64.b64encode(
+                                ts
+                            ).decode("utf-8")
                     tool_result.append(tool_entry)
 
                     content_array.append(this_content_block)

--- a/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
+++ b/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
@@ -213,17 +213,34 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
         prompt_tokens: int,
     ) -> AskModelEngineResponse2:
         tools_result = []
+
+        parts_with_fc = []
+        if (
+            hasattr(response, "candidates")
+            and response.candidates
+            and hasattr(response.candidates[0], "content")
+            and hasattr(response.candidates[0].content, "parts")
+        ):
+            parts_with_fc = [
+                p
+                for p in response.candidates[0].content.parts
+                if getattr(p, "function_call", None) is not None
+            ]
+
         for i, function_call in enumerate(response.function_calls):
             function_id = str(i)
+            tool_entry = {
+                "id": function_id,
+                "type": "function",
+                "name": function_call.name,
+                "arguments": getattr(function_call, "args", {}),
+            }
+            if i < len(parts_with_fc):
+                ts = getattr(parts_with_fc[i], "thought_signature", None)
+                if ts:
+                    tool_entry["thought_signature"] = base64.b64encode(ts).decode("utf-8")
+            tools_result.append(tool_entry)
 
-            tools_result.append(
-                {
-                    "id": function_id,
-                    "type": "function",
-                    "name": function_call.name,
-                    "arguments": getattr(function_call, "args", {}),
-                }
-            )
         return AskModelEngineResponse2(
             response=tools_result,
             prompt_tokens=prompt_tokens,
@@ -259,6 +276,7 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
         )
 
         for event in stream:
+            parts_with_fc = []
             if hasattr(event, "candidates") and event.candidates:
                 candidate = event.candidates[0]
                 if getattr(candidate, "grounding_metadata", None):
@@ -280,6 +298,8 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
                                     image_bytes=part.inline_data.data,
                                 )
                             )
+                        if getattr(part, "function_call", None) is not None:
+                            parts_with_fc.append(part)
 
             if event.text:
                 this_content_block["final_response"] = ""
@@ -354,14 +374,17 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
                         except Exception:
                             arguments = this_content_block["function"]["arguments"]
 
-                    tool_result.append(
-                        {
-                            "id": this_content_block["id"],
-                            "type": this_content_block["type"],
-                            "name": this_content_block["function"]["name"],
-                            "arguments": arguments,
-                        }
-                    )
+                    tool_entry = {
+                        "id": this_content_block["id"],
+                        "type": this_content_block["type"],
+                        "name": this_content_block["function"]["name"],
+                        "arguments": arguments,
+                    }
+                    if i < len(parts_with_fc):
+                        ts = getattr(parts_with_fc[i], "thought_signature", None)
+                        if ts:
+                            tool_entry["thought_signature"] = base64.b64encode(ts).decode("utf-8")
+                    tool_result.append(tool_entry)
 
                     content_array.append(this_content_block)
                     this_content_block = {}

--- a/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
+++ b/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
@@ -228,7 +228,7 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
             ]
 
         for i, function_call in enumerate(response.function_calls):
-            function_id = str(i)
+            function_id = function_call.id or str(uuid.uuid4())
             tool_entry = {
                 "id": function_id,
                 "type": "function",
@@ -328,7 +328,7 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
 
             if len(getattr(event, "function_calls", None) or []) > 0:
                 for i, function_call in enumerate(event.function_calls):
-                    function_id = str(len(tool_result) + i)
+                    function_id = function_call.id or str(uuid.uuid4())
                     this_content_block.update(
                         {
                             "id": function_id,
@@ -339,7 +339,7 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
                     this_content_block["function"]["name"] = function_call.name
 
                     data = StreamUtil.create_tool_id_chunk(
-                        index=len(tool_result), tool_id=function_call.id
+                        index=len(tool_result), tool_id=function_id
                     )
                     smss_stream(data, stream_type="tool")
                     print(prefix + str(data), end="")


### PR DESCRIPTION
## Description

Add support for Gemini thinking model `thought_signature` in tool calling, and fix tool call ID uniqueness. Gemini thinking models (e.g. `gemini-3-1-pro`) attach an encrypted `thought_signature` bytes field to each function call Part. Vertex AI requires this signature to be echoed back in the model turn when submitting tool results, otherwise the API returns a `400 INVALID_ARGUMENT: missing thought_signature` error. Additionally, tool call IDs were always being assigned `"0"` due to a per-event index reset in the streaming path.

## Changes Made

### Python Client Updates

**py/genai_client/text_generation/google_genai_clients/google_genai_client.py**
- `_parse_tools_call_response`: Scans `response.candidates[0].content.parts` to pair each function call with its Part, extracts `thought_signature` bytes, and base64-encodes it into the tool entry dict
- `_handle_streaming`: Same extraction from per-event `candidate.content.parts`; fixes tool call ID to use `function_call.id` or `uuid4()` (was always `"0"` because the per-event enumerate index reset each chunk)

**py/genai_client/message_builders/semoss_base/semoss_models.py**
- Added `thought_signature: Optional[str] = None` field to `SEMOSSToolCall`

**py/genai_client/message_builders/semoss_base/semoss_message_builder.py**
- Passes `thought_signature=tc.get("thought_signature")` when constructing `SEMOSSToolCall` from a `TOOL_CALL` part, so the signature survives the Java→Python message history round-trip

**py/genai_client/message_builders/google_genai/google_genai_builder.py**
- In both the parts-based `TOOL_CALL` path and the legacy `RESPONSE_TOOL` path, decodes the base64 signature and constructs `types.Part(function_call=..., thought_signature=bytes)` when present
- Falls back to `Part.from_function_call(...)` for non-thinking models

### Backend Updates

**Java Changes**
- No Java changes required — `ToolCallMessagePart.toolCall` is `Map<String, Object>`, so Gson transparently preserves any extra fields (including `thought_signature`) through DB serialization and deserialization

## How to Test

1. **Single Tool Call (Thinking Model)**
   - Configure a Gemini thinking model (e.g. `gemini-3-1-pro`) with an MCP tool (e.g. a stock price tool)
   - Send a message: `"what is the stock price of meta?"`
   - Confirm the tool is called and the `RESPONSE_TOOL` message's `toolCall` contains a non-empty `thought_signature` field
   - Confirm the tool result is returned and Gemini responds with a final text answer (no `400` error)

2. **Multiple Parallel Tool Calls (Thinking Model)**
   - Send a follow-up message: `"what about Tesla, Nvidia, and MSFT?"`
   - Confirm all three tool calls are returned in the `RESPONSE_TOOL` parts
   - Confirm each tool call has a unique ID (UUID) — previously all were `"0"`
   - Confirm Gemini responds with a final answer after all three tool results are submitted

3. **Regression Testing (Non-Thinking Model)**
   - Repeat steps 1–2 with a non-thinking Gemini model to confirm no regression
   - Tool calls should work normally without a `thought_signature` field

## Notes

- `thought_signature` is an opaque encrypted blob owned by Vertex AI — it is stored as a base64 string in the message history and decoded back to bytes only at request-build time
- The fix applies to both streaming and non-streaming code paths
- Tool call IDs now prefer the model-provided `function_call.id` (used by newer Gemini API versions) and fall back to `uuid4()` when the model returns `None` (current behavior for thinking models)