### PR TITLE
fix: don't reset the searcher var on faiss if reopening an opened engine

### DIFF
--- a/src/prerna/engine/impl/vector/FaissDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/FaissDatabaseEngine.java
@@ -89,19 +89,20 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 	public void open(Properties smssProp) throws Exception {
 		super.open(smssProp);
 		this.enableHybridSearch = Boolean.parseBoolean(this.smssProp.getProperty(ENABLE_HYBRID_SEARCH, "true"));
-		
+
 		// if we've already opened don't automatically drop the searcher variable
-		if(this.vectorDatabaseSearcher == null) {
+		if (this.vectorDatabaseSearcher == null
+				|| (this.vectorDatabaseSearcher = this.vectorDatabaseSearcher.trim()).isEmpty()) {
 			this.vectorDatabaseSearcher = Utility.getRandomString(6);
 		}
 	}
-	
+
 	@Override
 	public void close() throws IOException {
 		this.vectorDatabaseSearcher = null;
 		super.close();
 	}
-	
+
 	@Override
 	protected String[] getServerStartCommands() {
 		String faissInitScript = this.vectorDatabaseSearcher + "=vector_database.FAISSDatabase("
@@ -609,7 +610,7 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 			callMaker.append(", ").append("use_hybrid_search").append(" = ").append(PyUtils
 					.determineStringType(parameters.get(VectorDatabaseParamOptionsEnum.USE_HYBRID_SEARCH.getKey())));
 		}
-		
+
 		if (parameters.containsKey(VectorDatabaseParamOptionsEnum.COLUMNS_TO_RETURN.getKey())) {
 			// add the columns based in the vector db query
 			callMaker.append(", ").append("columns_to_return").append(" = ").append(PyUtils

--- a/src/prerna/engine/impl/vector/FaissDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/FaissDatabaseEngine.java
@@ -89,9 +89,19 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 	public void open(Properties smssProp) throws Exception {
 		super.open(smssProp);
 		this.enableHybridSearch = Boolean.parseBoolean(this.smssProp.getProperty(ENABLE_HYBRID_SEARCH, "true"));
-		this.vectorDatabaseSearcher = Utility.getRandomString(6);
+		
+		// if we've already opened don't automatically drop the searcher variable
+		if(this.vectorDatabaseSearcher == null) {
+			this.vectorDatabaseSearcher = Utility.getRandomString(6);
+		}
 	}
-
+	
+	@Override
+	public void close() throws IOException {
+		this.vectorDatabaseSearcher = null;
+		super.close();
+	}
+	
 	@Override
 	protected String[] getServerStartCommands() {
 		String faissInitScript = this.vectorDatabaseSearcher + "=vector_database.FAISSDatabase("

--- a/test/prerna/engine/impl/vector/FaissDatabaseEngineUnitTests.java
+++ b/test/prerna/engine/impl/vector/FaissDatabaseEngineUnitTests.java
@@ -27,6 +27,7 @@
  *******************************************************************************/
 package prerna.engine.impl.vector;
 
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -40,6 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -56,7 +58,6 @@ import java.util.Vector;
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
@@ -145,6 +146,33 @@ public class FaissDatabaseEngineUnitTests extends SemossUnitTest {
 					assertTrue(engineProps.containsValue(testProp.getValue()));
 				}
 			}
+		}
+	}
+	
+	@Test
+	void testSearcherVarStateDuringOpensAndCloses() throws Exception {
+		Field searcherField = FaissDatabaseEngine.class.getDeclaredField("vectorDatabaseSearcher");
+		boolean accessible = searcherField.canAccess(engine);
+		
+		try {
+			searcherField.setAccessible(true);
+			
+			String prevValue = (String) searcherField.get(engine);
+			assertNull(prevValue);
+			
+			openEngine(tempDir, engine, null);
+			String afterOpenValue = (String) searcherField.get(engine);
+			assertNotNull(afterOpenValue);
+			
+			openEngine(tempDir, engine, null);
+			String afterReopenValue = (String) searcherField.get(engine);
+			assertEquals(afterOpenValue, afterReopenValue);
+			
+			engine.close();
+			String afterCloseValue = (String) searcherField.get(engine);
+			assertNull(afterCloseValue);
+		} finally {
+			searcherField.setAccessible(accessible);
 		}
 	}
 	


### PR DESCRIPTION
## Description
When calling MakeEngineMCP on a faiss vector engine it was observed that the searcher variable becomes invalid. It is updated despite the process wrapper remaining open. This means the server start commands to actually init the var weren't run.

## Changes Made
Check if the searcher var is already set during open. null the value when closing the engine to allow forceful reset when desired.

## How to Test
1. Go to: `/SemossWeb/packages/playground/dist/#/knowledge`
2. Create a knowledge store (observe the MakeEngineMCP call that follows completes)
3. Call the pixel `ListDocumentsInVectorDatabase(engine=["{UUID}"]);` or view the file on the UI:
`/SemossWeb/packages/client/dist/#/engine/vector/{UUID}/documents`
`/SemossWeb/packages/playground/dist/#/knowledge/{UUID}`

## Notes
<!-- Any further notes regarding changes -->