### PR TITLE
fix: actually use app_root on the specific engine app root lookup

### DIFF
--- a/src/prerna/util/EngineUtility.java
+++ b/src/prerna/util/EngineUtility.java
@@ -105,7 +105,7 @@ public class EngineUtility {
 	 * @return
 	 */
 	public static String getSpecificEngineAppRootFolder(IEngine.CATALOG_TYPE type, String engineId, String engineName) {
-		return getSpecificEngineBaseFolder(type, SmssUtilities.getUniqueName(engineName, engineId));
+		return getSpecificEngineAppRootFolder(type, SmssUtilities.getUniqueName(engineName, engineId));
 	}
 
 	/**


### PR DESCRIPTION
## Description
A recent Monolith change revealed an issue where `prerna.util.EngineUtility.getSpecificEngineAppRootFolder(CATALOG_TYPE, String, String)` was not yielding the actual app_root directory path.

## Changes Made
Use the appropriate getSpecificEngineAppRootFolder method.

## How to Test
1. Use the legacy editor UI to upload a file to a project (or call /Monolith/api/uploadFile/baseUpload) with an empty path
2. BEFORE CHANGE: Observe the file upload path gets placed in the base engine folder as a sibling to app_root.
3. AFTER CHANGE: Repeat. Observe the file upload path gets placed as a descendant to app_root.
