### PR TITLE
Support more usage restriction frequency intervals

### DIFF
--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -1724,27 +1724,9 @@ public class ModelInferenceLogsUtils {
 			throw new IllegalArgumentException("Must pass in a valid restriction mode");
 		}
 
-		// Initialize the date range map (start and end dates)
-		Map<String, ZonedDateTime> dates = new HashMap<>();
-		// Determine the start and end date based on the given frequency
-		if (frequency.equalsIgnoreCase("WEEK")) {
-			dates = Utility.getWeekStartEndDate(currentDateTime);
-		} else if (frequency.equalsIgnoreCase("MONTH")) {
-			// Get start and end date for the current month
-			dates = Utility.getMonthStartEndDate(currentDateTime);
-		} else if (frequency.equalsIgnoreCase("YEAR")) {
-			// Get start and end date for the current year
-			dates = Utility.getYearStartEndDate(currentDateTime);
-		} else if (frequency.equalsIgnoreCase("ALL_TIME")) {
-			// Get all time usage - from epoch to current time
-			dates = Utility.getEpochStartEndDate(currentDateTime);
-		} else {
-			// assume they want daily
-			ZonedDateTime startOfTodayUtc = currentDateTime.toLocalDate().atStartOfDay(ZoneOffset.UTC);
-			ZonedDateTime endOfTodayUtc = startOfTodayUtc.plusDays(1);
-			dates.put("start", startOfTodayUtc);
-			dates.put("end", endOfTodayUtc);
-		}
+		// Get the date range based on the frequency specification
+		// Supports: WEEK, MONTH, YEAR, ALL_TIME, YEAR_ROLLING, YEAR_FEB, YEAR_MAR-02, etc.
+		Map<String, ZonedDateTime> dates = Utility.getDateRangeFromFrequency(frequency, currentDateTime);
 
 		// Extract start and end dates from the map
 		ZonedDateTime startDate = dates.get("start");
@@ -1821,25 +1803,10 @@ public class ModelInferenceLogsUtils {
 			excludePSString = excludeSB.toString();
 		}
 
-		// Step 2: Get the date range based on the frequency
-		// Initialize the date range map (start and end dates)
-		Map<String, ZonedDateTime> dates = new HashMap<>();
-		// Determine the start and end date based on the given frequency
-		if (frequency.equals("WEEK")) {
-			dates = Utility.getWeekStartEndDate(currentDateTime);
-		} else if (frequency.equals("MONTH")) {
-			// Get start and end date for the current month
-			dates = Utility.getMonthStartEndDate(currentDateTime);
-		} else if (frequency.equals("YEAR")) {
-			// Get start and end date for the current year
-			dates = Utility.getYearStartEndDate(currentDateTime);
-		} else if (frequency.equals("ALL_TIME")) {
-			// Get all time usage - from epoch to current time
-			dates = Utility.getEpochStartEndDate(currentDateTime);
-		} else {
-			dates.put("start", Utility.getCurrentZonedDateTimeUTC());
-			dates.put("end", Utility.getCurrentZonedDateTimeUTC());
-		}
+		// Step 2: Get the date range based on the frequency specification
+		// Supports: WEEK, MONTH, YEAR, ALL_TIME, YEAR_ROLLING, YEAR_FEB, YEAR_MAR-02, etc.
+		Map<String, ZonedDateTime> dates = Utility.getDateRangeFromFrequency(frequency, currentDateTime);
+
 		// Extract start and end dates from the map
 		ZonedDateTime startDate = dates.get("start");
 		ZonedDateTime endDate = dates.get("end");

--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -1732,6 +1732,12 @@ public class ModelInferenceLogsUtils {
 		} else if (frequency.equalsIgnoreCase("MONTH")) {
 			// Get start and end date for the current month
 			dates = Utility.getMonthStartEndDate(currentDateTime);
+		} else if (frequency.equalsIgnoreCase("YEAR")) {
+			// Get start and end date for the current year
+			dates = Utility.getYearStartEndDate(currentDateTime);
+		} else if (frequency.equalsIgnoreCase("ALL_TIME")) {
+			// Get all time usage - from epoch to current time
+			dates = Utility.getEpochStartEndDate(currentDateTime);
 		} else {
 			// assume they want daily
 			ZonedDateTime startOfTodayUtc = currentDateTime.toLocalDate().atStartOfDay(ZoneOffset.UTC);
@@ -1824,6 +1830,12 @@ public class ModelInferenceLogsUtils {
 		} else if (frequency.equals("MONTH")) {
 			// Get start and end date for the current month
 			dates = Utility.getMonthStartEndDate(currentDateTime);
+		} else if (frequency.equals("YEAR")) {
+			// Get start and end date for the current year
+			dates = Utility.getYearStartEndDate(currentDateTime);
+		} else if (frequency.equals("ALL_TIME")) {
+			// Get all time usage - from epoch to current time
+			dates = Utility.getEpochStartEndDate(currentDateTime);
 		} else {
 			dates.put("start", Utility.getCurrentZonedDateTimeUTC());
 			dates.put("end", Utility.getCurrentZonedDateTimeUTC());

--- a/src/prerna/util/Utility.java
+++ b/src/prerna/util/Utility.java
@@ -6100,6 +6100,358 @@ public final class Utility {
 	}
 
 	/**
+	 * Parse a frequency string and return the appropriate date range.
+	 * Supports complex frequency specifications:
+	 * - Simple: WEEK, MONTH, YEAR, ALL_TIME, DAY
+	 * - Rolling: WEEK_ROLLING, MONTH_ROLLING, YEAR_ROLLING
+	 * - Custom year: YEAR_FEB (Feb 1 start), YEAR_MAR-02 (Mar 2 start)
+	 * - Custom month: MONTH_15 (15th of month start)
+	 * - Custom week: WEEK_MON (Monday start), WEEK_TUE (Tuesday start)
+	 *
+	 * @param frequency The frequency string
+	 * @param currentDateTime The current date/time
+	 * @return Map containing "start" and "end" ZonedDateTime values
+	 */
+	public static Map<String, ZonedDateTime> getDateRangeFromFrequency(String frequency, ZonedDateTime currentDateTime) {
+		if (frequency == null || frequency.isEmpty()) {
+			// Default to daily
+			return getDayStartEndDate(currentDateTime);
+		}
+
+		String freq = frequency.toUpperCase().trim();
+
+		// Handle simple calendar-based cases
+		if (freq.equals("WEEK")) {
+			return getWeekStartEndDate(currentDateTime);
+		} else if (freq.equals("MONTH")) {
+			return getMonthStartEndDate(currentDateTime);
+		} else if (freq.equals("YEAR")) {
+			return getYearStartEndDate(currentDateTime);
+		} else if (freq.equals("ALL_TIME")) {
+			return getEpochStartEndDate(currentDateTime);
+		} else if (freq.equals("DAY")) {
+			return getDayStartEndDate(currentDateTime);
+		}
+
+		// Handle rolling periods
+		if (freq.equals("WEEK_ROLLING")) {
+			return getRollingWeekStartEndDate(currentDateTime);
+		} else if (freq.equals("MONTH_ROLLING")) {
+			return getRollingMonthStartEndDate(currentDateTime);
+		} else if (freq.equals("YEAR_ROLLING")) {
+			return getRollingYearStartEndDate(currentDateTime);
+		}
+
+		// Handle custom year starts (YEAR_FEB, YEAR_MAR-02, etc.)
+		if (freq.startsWith("YEAR_")) {
+			return getCustomYearStartEndDate(currentDateTime, freq);
+		}
+
+		// Handle custom month starts (MONTH_15 for 15th of each month)
+		if (freq.startsWith("MONTH_")) {
+			return getCustomMonthStartEndDate(currentDateTime, freq);
+		}
+
+		// Handle custom week starts (WEEK_MON, WEEK_TUE, etc.)
+		if (freq.startsWith("WEEK_")) {
+			return getCustomWeekStartEndDate(currentDateTime, freq);
+		}
+
+		// Default to daily
+		return getDayStartEndDate(currentDateTime);
+	}
+
+	/**
+	 * Get start and end of the current day in UTC.
+	 *
+	 * @param utcDateTime The current date/time
+	 * @return Map with start (00:00:00) and end (23:59:59.999999999) of the day
+	 */
+	public static Map<String, ZonedDateTime> getDayStartEndDate(ZonedDateTime utcDateTime) {
+		Map<String, ZonedDateTime> dates = new HashMap<>();
+		ZonedDateTime startOfDay = utcDateTime.toLocalDate().atStartOfDay(ZoneOffset.UTC);
+		ZonedDateTime endOfDay = startOfDay.plusDays(1).minusNanos(1);
+		dates.put("start", startOfDay);
+		dates.put("end", endOfDay);
+		return dates;
+	}
+
+	/**
+	 * Get rolling 7-day period (7 days back from current time).
+	 *
+	 * @param utcDateTime The current date/time
+	 * @return Map with start (7 days ago) and end (current time)
+	 */
+	public static Map<String, ZonedDateTime> getRollingWeekStartEndDate(ZonedDateTime utcDateTime) {
+		Map<String, ZonedDateTime> dates = new HashMap<>();
+		dates.put("start", utcDateTime.minusDays(7));
+		dates.put("end", utcDateTime);
+		return dates;
+	}
+
+	/**
+	 * Get rolling 30-day period (30 days back from current time).
+	 *
+	 * @param utcDateTime The current date/time
+	 * @return Map with start (30 days ago) and end (current time)
+	 */
+	public static Map<String, ZonedDateTime> getRollingMonthStartEndDate(ZonedDateTime utcDateTime) {
+		Map<String, ZonedDateTime> dates = new HashMap<>();
+		dates.put("start", utcDateTime.minusDays(30));
+		dates.put("end", utcDateTime);
+		return dates;
+	}
+
+	/**
+	 * Get rolling 365-day period (365 days back from current time).
+	 *
+	 * @param utcDateTime The current date/time
+	 * @return Map with start (365 days ago) and end (current time)
+	 */
+	public static Map<String, ZonedDateTime> getRollingYearStartEndDate(ZonedDateTime utcDateTime) {
+		Map<String, ZonedDateTime> dates = new HashMap<>();
+		dates.put("start", utcDateTime.minusDays(365));
+		dates.put("end", utcDateTime);
+		return dates;
+	}
+
+	/**
+	 * Get custom year date range based on specified start month/day.
+	 * Examples: YEAR_FEB (starts Feb 1), YEAR_MAR-02 (starts Mar 2), YEAR_APR-15 (starts Apr 15)
+	 *
+	 * @param utcDateTime The current date/time
+	 * @param frequency The frequency string (e.g., "YEAR_FEB", "YEAR_MAR-02")
+	 * @return Map with start and end dates for the custom year
+	 */
+	public static Map<String, ZonedDateTime> getCustomYearStartEndDate(ZonedDateTime utcDateTime, String frequency) {
+		Map<String, ZonedDateTime> dates = new HashMap<>();
+
+		// Parse the frequency string: YEAR_FEB or YEAR_MAR-02
+		String[] parts = frequency.split("_");
+		if (parts.length < 2) {
+			// Invalid format, fall back to calendar year
+			return getYearStartEndDate(utcDateTime);
+		}
+
+		String monthDayPart = parts[1]; // e.g., "FEB" or "MAR-02"
+		int startMonth;
+		int startDay = 1; // Default to 1st of the month
+
+		// Check if day is specified (e.g., "MAR-02")
+		if (monthDayPart.contains("-")) {
+			String[] monthDay = monthDayPart.split("-");
+			startMonth = parseMonth(monthDay[0]);
+			try {
+				startDay = Integer.parseInt(monthDay[1]);
+			} catch (NumberFormatException e) {
+				startDay = 1; // Default to 1st if parsing fails
+			}
+		} else {
+			// Just month (e.g., "FEB")
+			startMonth = parseMonth(monthDayPart);
+		}
+
+		// Validate month and day
+		if (startMonth < 1 || startMonth > 12) {
+			return getYearStartEndDate(utcDateTime); // Fall back to calendar year
+		}
+		if (startDay < 1 || startDay > 31) {
+			startDay = 1;
+		}
+
+		// Determine if we're before or after the custom year start in the current year
+		ZonedDateTime customYearStartThisYear;
+		try {
+			customYearStartThisYear = utcDateTime.withMonth(startMonth).withDayOfMonth(startDay)
+					.toLocalDate().atStartOfDay(ZoneOffset.UTC);
+		} catch (Exception e) {
+			// Invalid day for the month (e.g., Feb 30), fall back to calendar year
+			return getYearStartEndDate(utcDateTime);
+		}
+
+		ZonedDateTime customYearStart;
+		ZonedDateTime customYearEnd;
+
+		if (utcDateTime.isBefore(customYearStartThisYear)) {
+			// We're before the custom year start in current year, so use previous year's start
+			customYearStart = customYearStartThisYear.minusYears(1);
+			customYearEnd = customYearStartThisYear.minusNanos(1);
+		} else {
+			// We're after the custom year start, so use this year's start
+			customYearStart = customYearStartThisYear;
+			customYearEnd = customYearStartThisYear.plusYears(1).minusNanos(1);
+		}
+
+		dates.put("start", customYearStart);
+		dates.put("end", customYearEnd);
+		return dates;
+	}
+
+	/**
+	 * Get custom month date range based on specified start day.
+	 * Examples: MONTH_15 (starts on 15th), MONTH_01 (starts on 1st)
+	 *
+	 * @param utcDateTime The current date/time
+	 * @param frequency The frequency string (e.g., "MONTH_15")
+	 * @return Map with start and end dates for the custom month
+	 */
+	public static Map<String, ZonedDateTime> getCustomMonthStartEndDate(ZonedDateTime utcDateTime, String frequency) {
+		Map<String, ZonedDateTime> dates = new HashMap<>();
+
+		// Parse the frequency string: MONTH_15
+		String[] parts = frequency.split("_");
+		if (parts.length < 2) {
+			// Invalid format, fall back to calendar month
+			return getMonthStartEndDate(utcDateTime);
+		}
+
+		int startDay;
+		try {
+			startDay = Integer.parseInt(parts[1]);
+		} catch (NumberFormatException e) {
+			// Check if it's MONTH_ROLLING
+			if ("ROLLING".equalsIgnoreCase(parts[1])) {
+				return getRollingMonthStartEndDate(utcDateTime);
+			}
+			// Invalid day, fall back to calendar month
+			return getMonthStartEndDate(utcDateTime);
+		}
+
+		// Validate day
+		if (startDay < 1 || startDay > 28) { // Use 28 to be safe across all months
+			return getMonthStartEndDate(utcDateTime);
+		}
+
+		// Determine if we're before or after the custom month start in the current month
+		ZonedDateTime customMonthStartThisMonth;
+		try {
+			customMonthStartThisMonth = utcDateTime.withDayOfMonth(startDay)
+					.toLocalDate().atStartOfDay(ZoneOffset.UTC);
+		} catch (Exception e) {
+			// Invalid day for this month
+			return getMonthStartEndDate(utcDateTime);
+		}
+
+		ZonedDateTime customMonthStart;
+		ZonedDateTime customMonthEnd;
+
+		if (utcDateTime.isBefore(customMonthStartThisMonth)) {
+			// We're before the custom month start, so use previous month's start
+			customMonthStart = customMonthStartThisMonth.minusMonths(1);
+			customMonthEnd = customMonthStartThisMonth.minusNanos(1);
+		} else {
+			// We're after the custom month start, so use this month's start
+			customMonthStart = customMonthStartThisMonth;
+			customMonthEnd = customMonthStartThisMonth.plusMonths(1).minusNanos(1);
+		}
+
+		dates.put("start", customMonthStart);
+		dates.put("end", customMonthEnd);
+		return dates;
+	}
+
+	/**
+	 * Get custom week date range based on specified start day.
+	 * Examples: WEEK_MON (Monday-Sunday), WEEK_TUE (Tuesday-Monday)
+	 *
+	 * @param utcDateTime The current date/time
+	 * @param frequency The frequency string (e.g., "WEEK_MON", "WEEK_TUE")
+	 * @return Map with start and end dates for the custom week
+	 */
+	public static Map<String, ZonedDateTime> getCustomWeekStartEndDate(ZonedDateTime utcDateTime, String frequency) {
+		Map<String, ZonedDateTime> dates = new HashMap<>();
+
+		// Parse the frequency string: WEEK_MON
+		String[] parts = frequency.split("_");
+		if (parts.length < 2) {
+			// Invalid format, fall back to calendar week (Sunday start)
+			return getWeekStartEndDate(utcDateTime);
+		}
+
+		DayOfWeek startDayOfWeek = parseDayOfWeek(parts[1]);
+		if (startDayOfWeek == null) {
+			// Check if it's WEEK_ROLLING
+			if ("ROLLING".equalsIgnoreCase(parts[1])) {
+				return getRollingWeekStartEndDate(utcDateTime);
+			}
+			// Invalid day, fall back to calendar week
+			return getWeekStartEndDate(utcDateTime);
+		}
+
+		// Find the most recent occurrence of the start day (could be today)
+		ZonedDateTime weekStart = utcDateTime;
+		while (weekStart.getDayOfWeek() != startDayOfWeek) {
+			weekStart = weekStart.minusDays(1);
+		}
+		weekStart = weekStart.toLocalDate().atStartOfDay(ZoneOffset.UTC);
+
+		// End is 7 days later minus 1 nanosecond
+		ZonedDateTime weekEnd = weekStart.plusDays(7).minusNanos(1);
+
+		dates.put("start", weekStart);
+		dates.put("end", weekEnd);
+		return dates;
+	}
+
+	/**
+	 * Parse a month name to its numeric value (1-12).
+	 *
+	 * @param monthStr Month name (JAN, FEB, MAR, etc.)
+	 * @return Month number (1-12) or 1 if invalid
+	 */
+	private static int parseMonth(String monthStr) {
+		if (monthStr == null || monthStr.isEmpty()) {
+			return 1;
+		}
+
+		switch (monthStr.toUpperCase().trim()) {
+			case "JAN": case "JANUARY": return 1;
+			case "FEB": case "FEBRUARY": return 2;
+			case "MAR": case "MARCH": return 3;
+			case "APR": case "APRIL": return 4;
+			case "MAY": return 5;
+			case "JUN": case "JUNE": return 6;
+			case "JUL": case "JULY": return 7;
+			case "AUG": case "AUGUST": return 8;
+			case "SEP": case "SEPTEMBER": return 9;
+			case "OCT": case "OCTOBER": return 10;
+			case "NOV": case "NOVEMBER": return 11;
+			case "DEC": case "DECEMBER": return 12;
+			default:
+				// Try to parse as number
+				try {
+					int month = Integer.parseInt(monthStr);
+					return (month >= 1 && month <= 12) ? month : 1;
+				} catch (NumberFormatException e) {
+					return 1;
+				}
+		}
+	}
+
+	/**
+	 * Parse a day of week name to DayOfWeek enum.
+	 *
+	 * @param dayStr Day name (MON, TUE, WED, etc.)
+	 * @return DayOfWeek or null if invalid
+	 */
+	private static DayOfWeek parseDayOfWeek(String dayStr) {
+		if (dayStr == null || dayStr.isEmpty()) {
+			return null;
+		}
+
+		switch (dayStr.toUpperCase().trim()) {
+			case "MON": case "MONDAY": return DayOfWeek.MONDAY;
+			case "TUE": case "TUESDAY": return DayOfWeek.TUESDAY;
+			case "WED": case "WEDNESDAY": return DayOfWeek.WEDNESDAY;
+			case "THU": case "THURSDAY": return DayOfWeek.THURSDAY;
+			case "FRI": case "FRIDAY": return DayOfWeek.FRIDAY;
+			case "SAT": case "SATURDAY": return DayOfWeek.SATURDAY;
+			case "SUN": case "SUNDAY": return DayOfWeek.SUNDAY;
+			default: return null;
+		}
+	}
+
+	/**
 	 *
 	 * @param size
 	 * @return

--- a/src/prerna/util/Utility.java
+++ b/src/prerna/util/Utility.java
@@ -70,6 +70,7 @@ import java.text.SimpleDateFormat;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -6072,7 +6073,34 @@ public final class Utility {
 	}
 
 	/**
-	 * 
+	 *
+	 * @param utcDateTime
+	 * @return the map containing start and end of the year.
+	 */
+	public static Map<String, ZonedDateTime> getYearStartEndDate(ZonedDateTime utcDateTime) {
+		Map<String, ZonedDateTime> dates = new HashMap<>();
+		// Find the start of the year by setting the day to January 1.
+		dates.put("start", utcDateTime.withDayOfYear(1));
+		// Find the end of the year by setting the day to the last day of the year.
+		dates.put("end", utcDateTime.withDayOfYear(utcDateTime.toLocalDate().lengthOfYear()));
+
+		return dates;
+	}
+
+	/**
+	 *
+	 * @param utcDateTime
+	 * @return the map containing start of epoch and current datetime.
+	 */
+	public static Map<String, ZonedDateTime> getEpochStartEndDate(ZonedDateTime utcDateTime) {
+		Map<String, ZonedDateTime> dates = new HashMap<>();
+		dates.put("start", ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC));
+		dates.put("end", utcDateTime);
+		return dates;
+	}
+
+	/**
+	 *
 	 * @param size
 	 * @return
 	 */

--- a/test/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtilsUnitTests.java
+++ b/test/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtilsUnitTests.java
@@ -813,7 +813,7 @@ public class ModelInferenceLogsUtilsUnitTests extends SemossUnitTest {
 	void getRoomById() throws Exception {
 		Room expected = new Room("", "", "", "", "", "", true, new Timestamp(0), new Timestamp(0), "", true, "", "");
 
-		when(engine.getPreparedStatement("SELECT *  FROM ROOM WHERE ROOM_ID = ? and USER_ID = ? "))
+		when(engine.getPreparedStatement("SELECT * FROM ROOM WHERE ROOM_ID = ? and USER_ID = ?"))
 				.thenThrow(SQLException.class).thenReturn(ps);
 		when(ps.executeQuery()).thenReturn(rs);
 		when(rs.next()).thenReturn(false).thenReturn(true);
@@ -1219,5 +1219,161 @@ public class ModelInferenceLogsUtilsUnitTests extends SemossUnitTest {
 		verify(ps, times(2)).execute();
 		verify(conn).getAutoCommit();
 		verify(conn).commit();
+	}
+
+	// ====================================================================
+	// Frequency Parsing Tests - New functionality
+	// ====================================================================
+
+	@Test
+	void testSimpleFrequencies() {
+		java.time.ZonedDateTime testDate = java.time.ZonedDateTime.of(2026, 3, 6, 14, 30, 0, 0, java.time.ZoneOffset.UTC);
+
+		// Test YEAR
+		java.util.Map<String, java.time.ZonedDateTime> yearRange = prerna.util.Utility.getDateRangeFromFrequency("YEAR", testDate);
+		assertEquals(2026, yearRange.get("start").getYear());
+		assertEquals(1, yearRange.get("start").getMonthValue());
+		assertEquals(1, yearRange.get("start").getDayOfMonth());
+		assertEquals(2026, yearRange.get("end").getYear());
+		assertEquals(12, yearRange.get("end").getMonthValue());
+		assertEquals(31, yearRange.get("end").getDayOfMonth());
+
+		// Test MONTH
+		java.util.Map<String, java.time.ZonedDateTime> monthRange = prerna.util.Utility.getDateRangeFromFrequency("MONTH", testDate);
+		assertEquals(2026, monthRange.get("start").getYear());
+		assertEquals(3, monthRange.get("start").getMonthValue());
+		assertEquals(1, monthRange.get("start").getDayOfMonth());
+		assertEquals(2026, monthRange.get("end").getYear());
+		assertEquals(3, monthRange.get("end").getMonthValue());
+		assertEquals(31, monthRange.get("end").getDayOfMonth()); // March has 31 days
+
+		// Test WEEK (Sunday-Saturday)
+		java.util.Map<String, java.time.ZonedDateTime> weekRange = prerna.util.Utility.getDateRangeFromFrequency("WEEK", testDate);
+		assertEquals(java.time.DayOfWeek.SUNDAY, weekRange.get("start").getDayOfWeek());
+		assertEquals(java.time.DayOfWeek.SATURDAY, weekRange.get("end").getDayOfWeek());
+
+		// Test DAY
+		java.util.Map<String, java.time.ZonedDateTime> dayRange = prerna.util.Utility.getDateRangeFromFrequency("DAY", testDate);
+		assertEquals(6, dayRange.get("start").getDayOfMonth());
+		assertEquals(0, dayRange.get("start").getHour());
+		assertEquals(6, dayRange.get("end").getDayOfMonth());
+		assertEquals(23, dayRange.get("end").getHour());
+	}
+
+	@Test
+	void testRollingFrequencies() {
+		java.time.ZonedDateTime testDate = java.time.ZonedDateTime.of(2026, 3, 6, 14, 30, 0, 0, java.time.ZoneOffset.UTC);
+
+		// Test YEAR_ROLLING (365 days back)
+		java.util.Map<String, java.time.ZonedDateTime> yearRolling = prerna.util.Utility.getDateRangeFromFrequency("YEAR_ROLLING", testDate);
+		assertEquals(testDate.minusDays(365), yearRolling.get("start"));
+		assertEquals(testDate, yearRolling.get("end"));
+
+		// Test MONTH_ROLLING (30 days back)
+		java.util.Map<String, java.time.ZonedDateTime> monthRolling = prerna.util.Utility.getDateRangeFromFrequency("MONTH_ROLLING", testDate);
+		assertEquals(testDate.minusDays(30), monthRolling.get("start"));
+		assertEquals(testDate, monthRolling.get("end"));
+
+		// Test WEEK_ROLLING (7 days back)
+		java.util.Map<String, java.time.ZonedDateTime> weekRolling = prerna.util.Utility.getDateRangeFromFrequency("WEEK_ROLLING", testDate);
+		assertEquals(testDate.minusDays(7), weekRolling.get("start"));
+		assertEquals(testDate, weekRolling.get("end"));
+	}
+
+	@Test
+	void testCustomYearFrequencies() {
+		java.time.ZonedDateTime testDate = java.time.ZonedDateTime.of(2026, 3, 6, 14, 30, 0, 0, java.time.ZoneOffset.UTC);
+
+		// Test YEAR_FEB (Fiscal year starting Feb 1)
+		// Since we're in March, we're in the Feb 2026 - Jan 2027 period
+		java.util.Map<String, java.time.ZonedDateTime> yearFeb = prerna.util.Utility.getDateRangeFromFrequency("YEAR_FEB", testDate);
+		assertEquals(2026, yearFeb.get("start").getYear());
+		assertEquals(2, yearFeb.get("start").getMonthValue()); // February
+		assertEquals(1, yearFeb.get("start").getDayOfMonth());
+		assertEquals(2027, yearFeb.get("end").getYear());
+		assertEquals(1, yearFeb.get("end").getMonthValue()); // January 31st end
+
+		// Test YEAR_APR (April start)
+		// Since we're in March, we should be in the Apr 2025 - Mar 2026 period
+		java.util.Map<String, java.time.ZonedDateTime> yearApr = prerna.util.Utility.getDateRangeFromFrequency("YEAR_APR", testDate);
+		assertEquals(2025, yearApr.get("start").getYear());
+		assertEquals(4, yearApr.get("start").getMonthValue()); // April
+		assertEquals(1, yearApr.get("start").getDayOfMonth());
+
+		// Test YEAR_MAR-02 (March 2 start)
+		// Since we're on March 6, we're in the Mar 2 2026 - Mar 1 2027 period
+		java.util.Map<String, java.time.ZonedDateTime> yearMar02 = prerna.util.Utility.getDateRangeFromFrequency("YEAR_MAR-02", testDate);
+		assertEquals(2026, yearMar02.get("start").getYear());
+		assertEquals(3, yearMar02.get("start").getMonthValue());
+		assertEquals(2, yearMar02.get("start").getDayOfMonth());
+
+		// Test YEAR_JUL (US Government fiscal year)
+		java.util.Map<String, java.time.ZonedDateTime> yearJul = prerna.util.Utility.getDateRangeFromFrequency("YEAR_JUL", testDate);
+		assertEquals(2025, yearJul.get("start").getYear());
+		assertEquals(7, yearJul.get("start").getMonthValue());
+		assertEquals(1, yearJul.get("start").getDayOfMonth());
+	}
+
+	@Test
+	void testCustomMonthFrequencies() {
+		java.time.ZonedDateTime testDate = java.time.ZonedDateTime.of(2026, 3, 20, 14, 30, 0, 0, java.time.ZoneOffset.UTC);
+
+		// Test MONTH_15 (starts on 15th)
+		// Since we're on March 20, we're in the Mar 15 - Apr 14 period
+		java.util.Map<String, java.time.ZonedDateTime> month15 = prerna.util.Utility.getDateRangeFromFrequency("MONTH_15", testDate);
+		assertEquals(3, month15.get("start").getMonthValue());
+		assertEquals(15, month15.get("start").getDayOfMonth());
+		assertEquals(4, month15.get("end").getMonthValue());
+		assertEquals(14, month15.get("end").getDayOfMonth());
+
+		// Test MONTH_10 (starts on 10th)
+		// Since we're on March 20, we're in the Mar 10 - Apr 9 period
+		java.util.Map<String, java.time.ZonedDateTime> month10 = prerna.util.Utility.getDateRangeFromFrequency("MONTH_10", testDate);
+		assertEquals(3, month10.get("start").getMonthValue());
+		assertEquals(10, month10.get("start").getDayOfMonth());
+	}
+
+	@Test
+	void testCustomWeekFrequencies() {
+		// March 6, 2026 is a Friday
+		java.time.ZonedDateTime testDate = java.time.ZonedDateTime.of(2026, 3, 6, 14, 30, 0, 0, java.time.ZoneOffset.UTC);
+
+		// Test WEEK_MON (Monday start)
+		java.util.Map<String, java.time.ZonedDateTime> weekMon = prerna.util.Utility.getDateRangeFromFrequency("WEEK_MON", testDate);
+		assertEquals(java.time.DayOfWeek.MONDAY, weekMon.get("start").getDayOfWeek());
+		assertEquals(java.time.DayOfWeek.SUNDAY, weekMon.get("end").getDayOfWeek());
+
+		// Test WEEK_FRI (Friday start)
+		java.util.Map<String, java.time.ZonedDateTime> weekFri = prerna.util.Utility.getDateRangeFromFrequency("WEEK_FRI", testDate);
+		assertEquals(java.time.DayOfWeek.FRIDAY, weekFri.get("start").getDayOfWeek());
+		assertEquals(6, weekFri.get("start").getDayOfMonth()); // Should be today since today is Friday
+
+		// Test WEEK_SUN (Sunday start, same as default WEEK)
+		java.util.Map<String, java.time.ZonedDateTime> weekSun = prerna.util.Utility.getDateRangeFromFrequency("WEEK_SUN", testDate);
+		assertEquals(java.time.DayOfWeek.SUNDAY, weekSun.get("start").getDayOfWeek());
+		assertEquals(java.time.DayOfWeek.SATURDAY, weekSun.get("end").getDayOfWeek());
+	}
+
+	@Test
+	void testAllTimeFrequency() {
+		java.time.ZonedDateTime testDate = java.time.ZonedDateTime.of(2026, 3, 6, 14, 30, 0, 0, java.time.ZoneOffset.UTC);
+
+		java.util.Map<String, java.time.ZonedDateTime> allTime = prerna.util.Utility.getDateRangeFromFrequency("ALL_TIME", testDate);
+		assertEquals(1970, allTime.get("start").getYear());
+		assertEquals(1, allTime.get("start").getMonthValue());
+		assertEquals(1, allTime.get("start").getDayOfMonth());
+		assertEquals(testDate, allTime.get("end"));
+	}
+
+	@Test
+	void testInvalidFrequencyDefaultsToDay() {
+		java.time.ZonedDateTime testDate = java.time.ZonedDateTime.of(2026, 3, 6, 14, 30, 0, 0, java.time.ZoneOffset.UTC);
+
+		// Invalid frequency should default to DAY
+		java.util.Map<String, java.time.ZonedDateTime> invalid = prerna.util.Utility.getDateRangeFromFrequency("INVALID_FREQ", testDate);
+		assertEquals(6, invalid.get("start").getDayOfMonth());
+		assertEquals(0, invalid.get("start").getHour());
+		assertEquals(6, invalid.get("end").getDayOfMonth());
+		assertEquals(23, invalid.get("end").getHour());
 	}
 }

--- a/test/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtilsUnitTests.java
+++ b/test/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtilsUnitTests.java
@@ -673,18 +673,40 @@ public class ModelInferenceLogsUtilsUnitTests extends SemossUnitTest {
 			staticRDBMSWrapper
 					.when(() -> RawRDBMSSelectWrapper.directExecutionPreparedStatement(eq(engine), eq(conn), eq(ps),
 							anyString(), eq(false)))
-					.thenReturn(rawRDBMSSelectWrapper).thenReturn(rawRDBMSSelectWrapper).thenThrow(Exception.class);
+					.thenReturn(rawRDBMSSelectWrapper)
+					.thenReturn(rawRDBMSSelectWrapper)
+					.thenReturn(rawRDBMSSelectWrapper)
+					.thenReturn(rawRDBMSSelectWrapper)
+					.thenReturn(rawRDBMSSelectWrapper)
+					.thenThrow(Exception.class);
 			when(rawRDBMSSelectWrapper.hasNext()).thenReturn(true);
 			when(rawRDBMSSelectWrapper.next()).thenReturn(dataRow);
-			when(dataRow.getValues()).thenReturn(new Object[] { 1 }).thenReturn(new Object[] { null });
+			when(dataRow.getValues())
+				.thenReturn(new Object[] { 0 })
+				.thenReturn(new Object[] { 0 })
+				.thenReturn(new Object[] { 1 })
+				.thenReturn(new Object[] { 1 })
+				.thenReturn(new Object[] { null });
 
-			assertEquals(1, ModelInferenceLogsUtils.getTotalTokensOrTotalResponseTime("token", user, "engineId",
+			// dataRow value returns as given
+			assertEquals(0, ModelInferenceLogsUtils.getTotalTokensOrTotalResponseTime("token", user, "engineId",
+					ZonedDateTime.now(), "DAILY"));
+			assertEquals(0, ModelInferenceLogsUtils.getTotalTokensOrTotalResponseTime("token", user, "engineId",
 					ZonedDateTime.now(), "WEEK"));
+			assertEquals(1, ModelInferenceLogsUtils.getTotalTokensOrTotalResponseTime("token", user, "engineId",
+					ZonedDateTime.now(), "YEAR"));
+			assertEquals(1, ModelInferenceLogsUtils.getTotalTokensOrTotalResponseTime("token", user, "engineId",
+					ZonedDateTime.now(), "ALL_TIME"));
+			
+			// null assumed as 0
 			assertEquals(0, ModelInferenceLogsUtils.getTotalTokensOrTotalResponseTime("compute", user, "engineId",
 					ZonedDateTime.now(), "MONTH"));
+			
+			// exception during query generates null return
 			assertNull(ModelInferenceLogsUtils.getTotalTokensOrTotalResponseTime("compute", user, "engineId",
 					ZonedDateTime.now(), "DAILY"));
-
+			
+			// bad inputs generate thrown exception
 			IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> ModelInferenceLogsUtils
 					.getTotalTokensOrTotalResponseTime(null, user, "engineId", ZonedDateTime.now(), "freq"));
 			assertEquals("Must pass in a valid restriction mode", e.getMessage());
@@ -713,7 +735,12 @@ public class ModelInferenceLogsUtilsUnitTests extends SemossUnitTest {
 			staticSecEngineUtils.when(() -> SecurityEngineUtils.getModelEngineIdsWithRestrictions(user, "engineId"))
 					.thenReturn(engineList);
 
-			when(engine.getPreparedStatement(anyString())).thenReturn(ps).thenReturn(ps).thenThrow(SQLException.class);
+			when(engine.getPreparedStatement(anyString()))
+				.thenReturn(ps)
+				.thenReturn(ps)
+				.thenReturn(ps)
+				.thenReturn(ps)
+				.thenThrow(SQLException.class);
 
 			when(user.getLogins()).thenReturn(logins);
 			when(user.getAccessToken(auth)).thenReturn(access);
@@ -724,12 +751,25 @@ public class ModelInferenceLogsUtilsUnitTests extends SemossUnitTest {
 
 			when(rawRDBMSSelectWrapper.hasNext()).thenReturn(true);
 			when(rawRDBMSSelectWrapper.next()).thenReturn(dataRow);
-			when(dataRow.getValues()).thenReturn(new Object[] { null }).thenReturn(new Object[] { 1 });
+			when(dataRow.getValues())
+				.thenReturn(new Object[] { null })
+				.thenReturn(new Object[] { 0 })
+				.thenReturn(new Object[] { 0 })
+				.thenReturn(new Object[] { 1 });
 
+			// null treated as 0
 			assertEquals(0, ModelInferenceLogsUtils.getTotalUsageForUser("token", user, "engineId", ZonedDateTime.now(),
 					"WEEK"));
-			assertEquals(1, ModelInferenceLogsUtils.getTotalUsageForUser("compute", user, "engineId",
+			
+			// non-null returned as-is
+			assertEquals(0, ModelInferenceLogsUtils.getTotalUsageForUser("compute", user, "engineId",
 					ZonedDateTime.now(), "MONTH"));
+			assertEquals(0, ModelInferenceLogsUtils.getTotalUsageForUser("compute", user, "engineId",
+					ZonedDateTime.now(), "YEAR"));
+			assertEquals(1, ModelInferenceLogsUtils.getTotalUsageForUser("compute", user, "engineId",
+					ZonedDateTime.now(), "ALL_TIME"));
+			
+			// exception during query yields null
 			assertNull(ModelInferenceLogsUtils.getTotalUsageForUser("compute", user, "engineId", ZonedDateTime.now(),
 					"DAILY"));
 		}


### PR DESCRIPTION
## Description
Currently we support usage restriction frequencies based on calendar month, calendar week, and daily. Additional customization on these limiters was requested.

## Changes Made
Supported frequency format examples:

```
  Simple (Calendar-Based)

  - DAY - Current day (midnight to midnight)
  - WEEK - Sunday to Saturday
  - MONTH - 1st to last day of month
  - YEAR - January 1 to December 31
  - ALL_TIME - Epoch (1970-01-01) to now

  Rolling (Relative)

  - WEEK_ROLLING - Last 7 days
  - MONTH_ROLLING - Last 30 days
  - YEAR_ROLLING - Last 365 days

  Custom Year (Fiscal/Custom)

  - YEAR_FEB - Feb 1 to Jan 31
  - YEAR_JUL - Jul 1 to Jun 30 (US Government fiscal year)
  - YEAR_MAR-02 - Mar 2 to Mar 1

  Custom Month

  - MONTH_15 - 15th to 14th
  - MONTH_10 - 10th to 9th
  - Numbers restricted to 1-28

  Custom Week

  - WEEK_MON - Monday to Sunday
  - WEEK_TUE - Tuesday to Monday
  - WEEK_FRI - Friday to Thursday
``` 

## How to Test
<!-- Explain how reviewers can test your changes -->

## Notes
<!-- Any further notes regarding changes -->