### PR TITLE
fix: make sure all returns give the expected number of returns

### DIFF
--- a/py/gaas_tcp_server_handler.py
+++ b/py/gaas_tcp_server_handler.py
@@ -955,7 +955,7 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
         try:
             # Handle empty code
             if not code.strip():
-                return '""', False
+                return '""', False, False
 
             parsed_code = ast.parse(code)
 
@@ -976,7 +976,7 @@ class TCPServerHandler(socketserver.BaseRequestHandler):
                 # Evaluate print arguments to be the return value of this function
                 print_args = last_node.value.args
                 if len(print_args) == 1:
-                    return eval(ast.unparse(print_args[0]), insight_globals), False
+                    return eval(ast.unparse(print_args[0]), insight_globals), False, False
                 else:
                     # Return a tuple of evaluated arguments
                     return (


### PR DESCRIPTION
## Description
It was observed that some python executions were throwing errors related to "not enough values to unpack". 

<img width="937" height="568" alt="image" src="https://github.com/user-attachments/assets/55be4b92-43e5-4472-95d9-9ae27aad96bd" />

Some of the returns from the updated cancellable `execute_and_capture` weren't updated to the three return objects.

## Changes Made
Add a False for the third boolean on the affected blocks.

## How to Test
Call a `print` statement with one argument `print('hello')` to see the error. Note the two variable version was unaffected `print('hi', '')`

## Notes
<!-- Any further notes regarding changes -->