### PR TITLE
fix: bedrock w/ 1m doesnt have stream in beta

### DIFF
--- a/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
+++ b/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
@@ -280,13 +280,17 @@ class AnthropicTextClient(AbstractTextGenerationClient):
 
         tool_result = []
 
-        stream_method = (
-            self.client.beta.messages.stream
-            if self.use_beta_header
-            else self.client.messages.stream
-        )
+        use_beta_stream = self.use_beta_header and hasattr(self.client.beta.messages, "stream")
+        stream_method = self.client.beta.messages.stream if use_beta_stream else self.client.messages.stream
 
-        with stream_method(**request_config.model_dump(exclude_none=True)) as stream:
+        stream_kwargs = request_config.model_dump(exclude_none=True)
+        if self.use_beta_header and not use_beta_stream:
+            # Bedrock: beta.messages has no .stream; pass beta via extra_headers so
+            # the Bedrock SDK converts anthropic-beta header → anthropic_beta body field
+            stream_kwargs.pop("betas", None)
+            stream_kwargs["extra_headers"] = {"anthropic-beta": self.beta_feature_name}
+
+        with stream_method(**stream_kwargs) as stream:
             final_message = None
             for event in stream:
                 if event.type == "message_start":


### PR DESCRIPTION
## Description
Fix streaming when `use_beta_header=true` is set on an `AnthropicBedrock` client. The Anthropic SDK's `AnthropicBedrock.beta.messages` does not expose a `.stream` method (only `.create`), causing an `AttributeError` at runtime. `AnthropicVertex` is unaffected as it uses the full Anthropic client which does expose `.stream` on the beta path.

## Changes Made
- In `_handle_streaming` of `AnthropicTextClient`, dynamically check whether `client.beta.messages` has a `.stream` attribute before routing to the beta stream path
- When it does not (Bedrock), fall back to `client.messages.stream` and pass the beta feature via `extra_headers={"anthropic-beta": <feature_name>}` — the Bedrock SDK already handles converting that header into the `anthropic_beta` request body field that AWS expects
- Strip `betas` from the request kwargs in this fallback path since `messages.stream` does not accept it as a parameter

## How to Test
1. Create a `BedrockEngine` SMSS with `USE_BETA_HEADER` true and a valid `BETA_FEATURE_NAME` (e.g. `context-1m-2025-08-07`)
2. Send a chat message through the engine
3. Expected: Response streams successfully
4. Previously: `AttributeError: 'Messages' object has no attribute 'stream'`

To confirm Vertex is unaffected:
1. Use an existing `VertexEngine` SMSS with `USE_BETA_HEADER` true
2. Send a chat message
3. Expected: Continues to work as before — routes through `client.beta.messages.stream`

## Notes
The Anthropic SDK intentionally limits the Bedrock beta messages interface to `.create` only. Beta features on Bedrock are passed as `anthropic_beta` in the request body rather than an HTTP header — the SDK handles this translation automatically when `anthropic-beta` is present in `extra_headers`.