### PR TITLE
fix: guard against key error when no rows make it past filter

### DIFF
--- a/py/vector_database/utils/text_splitting.py
+++ b/py/vector_database/utils/text_splitting.py
@@ -178,6 +178,10 @@ def split_text(
     #     text_results_df = main_df
     #     other_modalities_df = pd.DataFrame()
 
+    # Guard against key error when checking for first row if there are no rows in the CSV file after dropping all invalid content
+    if main_df.empty:
+        raise Exception("No valid content found to chunk.")
+
     document_name = main_df["Source"][0]
 
     if chunking_method.lower() == "semantic":


### PR DESCRIPTION
## Description
Currently, if no rows make it past NaN filter on the Content column, a key error is returned. Guard against the key error by checking if the pandas df is empty before we need the first row, and return a more verbose message.

## How to Test
1. Try to embed the attached file: 
[FDA Launches Agency-Wide AI Tool to Opt...pdf](https://github.com/user-attachments/files/26030171/FDA.Launches.Agency-Wide.AI.Tool.to.Opt.pdf)

2. See verbose error