### PR TITLE
fix: symlink user asset folder into chroot on boot to persist across sessions

### DIFF
--- a/src/prerna/auth/User.java
+++ b/src/prerna/auth/User.java
@@ -688,6 +688,12 @@ public class User implements Serializable {
 				// unique user is just for testing so when i ls on R, I can see it is me and not
 				// someone else
 				symlinkHelper = new SymlinkHelper(chrootPath);
+				// symlink the user asset folder into the chroot on boot
+				try {
+					symlinkHelper.symlinkUserAsset(this);
+				} catch (Exception e) {
+					classLogger.warn("Unable to symlink user asset folder into chroot", e);
+				}
 			}
 			return symlinkHelper;
 		}

--- a/src/prerna/cluster/util/ClusterSynchronizer.java
+++ b/src/prerna/cluster/util/ClusterSynchronizer.java
@@ -29,7 +29,6 @@ package prerna.cluster.util;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.lang.reflect.Method;
@@ -47,11 +46,8 @@ import org.apache.curator.framework.recipes.cache.PathChildrenCacheListener;
 import org.apache.curator.retry.RetryNTimes;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.zookeeper.ZooKeeper;
 
 import prerna.cluster.util.clients.AppCloudClientProperties;
-import prerna.project.api.IProject;
-import prerna.tcp.client.workers.NativePyEngineWorker;
 import prerna.util.Constants;
 import prerna.util.DIHelper;
 import prerna.util.Utility;
@@ -62,17 +58,18 @@ public class ClusterSynchronizer {
 
 	private static final Logger classLogger = LogManager.getLogger(ClusterSynchronizer.class);
 
-	
 	public static final String ZK_SERVER_STRING = "ZK_SERVER";
 	public static final String HOST_IP = "HOST_IP";
 
 	public static final String SYNC_PROJECT_PATH = "/sync/project";
 	public static final String SYNC_ENGINE_PATH = "/sync/engine";
+	public static final String SYNC_USER_PATH = "/sync/user";
 
 	private CuratorFramework client = null;
 	private CuratorCache projectCache;
 	private CuratorCache engineCache;
-	
+	private CuratorCache userCache;
+
 	String host;
 
 	private ClusterSynchronizer() {
@@ -82,124 +79,172 @@ public class ClusterSynchronizer {
 	private void initalizeClusterSyncronizer() {
 		classLogger.info("Starting up cluster synchronizer");
 		AppCloudClientProperties clientProps = new AppCloudClientProperties();
-		
+
 		// what is the zk server ip
 		String zk_server = clientProps.get(ZK_SERVER_STRING);
-		//zk_server="localhost:2181";
+		// zk_server="localhost:2181";
 
 		if (zk_server == null || zk_server.isEmpty()) {
 			throw new IllegalArgumentException("Zookeeper Server endpoint is not defined");
-			}
-		
-		// what is the host ip of the container/pod/box - this is used as a unique id for the container/singleton
+		}
+
+		// what is the host ip of the container/pod/box - this is used as a unique id
+		// for the container/singleton
 		host = clientProps.get(HOST_IP);
 		if (host == null || host.isEmpty()) {
 			classLogger.info("Host IP is not set");
-		   host="node_"+Utility.getRandomString(5);
+			host = "node_" + Utility.getRandomString(5);
 		}
 
-		
 		// make the curator
 		try {
-			client =  CuratorFrameworkFactory.newClient(zk_server, new RetryNTimes(3, 10));
+			client = CuratorFrameworkFactory.newClient(zk_server, new RetryNTimes(3, 10));
 			client.start();
-			
-			
-	        // Check if the ZNode exists before trying to create it - project
-	        if (client.checkExists().forPath(SYNC_PROJECT_PATH) == null) {
-	            client.create().creatingParentsIfNeeded().forPath(SYNC_PROJECT_PATH);
-	        }
-	        
-	        // Check if the ZNode exists before trying to create it - engine
-	        if (client.checkExists().forPath(SYNC_ENGINE_PATH) == null) {
-	            client.create().creatingParentsIfNeeded().forPath(SYNC_ENGINE_PATH);
-	        }
-	        
-	        projectCache= createCacheListener(SYNC_PROJECT_PATH);
-	        engineCache=createCacheListener(SYNC_ENGINE_PATH);
+
+			// Check if the ZNode exists before trying to create it - project
+			if (client.checkExists().forPath(SYNC_PROJECT_PATH) == null) {
+				client.create().creatingParentsIfNeeded().forPath(SYNC_PROJECT_PATH);
+			}
+
+			// Check if the ZNode exists before trying to create it - engine
+			if (client.checkExists().forPath(SYNC_ENGINE_PATH) == null) {
+				client.create().creatingParentsIfNeeded().forPath(SYNC_ENGINE_PATH);
+			}
+
+			// Check if the ZNode exists before trying to create it - user
+			if (client.checkExists().forPath(SYNC_USER_PATH) == null) {
+				client.create().creatingParentsIfNeeded().forPath(SYNC_USER_PATH);
+			}
+
+			projectCache = createCacheListener(SYNC_PROJECT_PATH);
+			engineCache = createCacheListener(SYNC_ENGINE_PATH);
+			userCache = createCacheListener(SYNC_USER_PATH);
 
 		} catch (Exception e) {
-			// TODO Auto-generated catch block
 			classLogger.error(Constants.STACKTRACE, e);
 		}
-		
-		
 
 	}
 
 	private CuratorCache createCacheListener(String pathToWatch) {
-	    CuratorCache cache = CuratorCache.build(client, pathToWatch);
-	    CuratorCacheListener listener = CuratorCacheListener.builder()
-	            .forPathChildrenCache(pathToWatch, client, new PathChildrenCacheListener() {
-	                @Override
-	                public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
-	                    if (event.getType() == PathChildrenCacheEvent.Type.CHILD_UPDATED) {
-	                        ByteArrayInputStream byteIn = new ByteArrayInputStream(event.getData().getData());
-	                        ObjectInputStream in = new ObjectInputStream(byteIn);
-	                        //Map<String, String> dataMap = (Map<String, String>) in.readObject();
-	                        Map<String, Object> dataMap = (Map<String, Object>) in.readObject();
+		CuratorCache cache = CuratorCache.build(client, pathToWatch);
+		CuratorCacheListener listener = CuratorCacheListener.builder()
+				.forPathChildrenCache(pathToWatch, client, new PathChildrenCacheListener() {
+					@Override
+					public void childEvent(CuratorFramework client, PathChildrenCacheEvent event) throws Exception {
+						if (event.getType() == PathChildrenCacheEvent.Type.CHILD_UPDATED) {
+							ByteArrayInputStream byteIn = new ByteArrayInputStream(event.getData().getData());
+							ObjectInputStream in = new ObjectInputStream(byteIn);
+							// Map<String, String> dataMap = (Map<String, String>) in.readObject();
+							Map<String, Object> dataMap = (Map<String, Object>) in.readObject();
 
-	                        String updatedByNodeId = (String) dataMap.get("nodeId");
-	                        // if the host updated it, then its already ready - other nodes have to pull
-	                        if (!updatedByNodeId.equals(host)) {
-	                            String fullPath = event.getData().getPath();
-	                            classLogger.info( fullPath + " updated, pulling latest data from cloud storage");
-	                            String id;
-	                            boolean pull;
-	                            if(fullPath.startsWith(SYNC_PROJECT_PATH)) {
-	                                String[] path = fullPath.split(SYNC_PROJECT_PATH+"/");
-	                                id = path[1];
-	                                pull = projectLoaded(id);
-	                            } else {
-	                                String[] path = fullPath.split(SYNC_ENGINE_PATH+"/");
-	                                 id = path[1];
-		                             pull = engineLoaded(id);
-	                            }
-	                            
-	                            // always check if the engine has been loaded before pulling. 
+							String updatedByNodeId = (String) dataMap.get("nodeId");
+							// if the host updated it, then its already ready - other nodes have to pull
+							if (!updatedByNodeId.equals(host)) {
+								String fullPath = event.getData().getPath();
+								classLogger.info(fullPath + " updated, pulling latest data from cloud storage");
+								String id;
+								boolean pull;
+								if (fullPath.startsWith(SYNC_PROJECT_PATH)) {
+									String[] path = fullPath.split(SYNC_PROJECT_PATH + "/");
+									id = path[1];
+									pull = projectLoaded(id);
+								} else if (fullPath.startsWith(SYNC_USER_PATH)) {
+									String[] path = fullPath.split(SYNC_USER_PATH + "/");
+									id = path[1];
+									pull = userLoaded(id);
+								} else {
+									String[] path = fullPath.split(SYNC_ENGINE_PATH + "/");
+									id = path[1];
+									pull = engineLoaded(id);
+								}
 
-	                            if(pull) {
-	                            try {
-	                                List<String> params = (List<String>) dataMap.get("params");
-	                                Class<?>[] paramTypes = new Class[params.size()];
-	                                for (int i = 0; i < params.size(); i++) {
-	                                    paramTypes[i] = params.get(i).getClass();
-	                                }
-	                                Method method = ClusterUtil.class.getMethod(dataMap.get("methodName").toString(), paramTypes);
-	                                method.invoke(null, params.toArray());
-	                            } catch (Exception e) {
-	                            	classLogger.error(Constants.STACKTRACE, e);
-	                            }
-	                           }
-	                            
-	                        }
-	                    }
-	                }
-	            })
-	            .build();
+								// always check if the engine has been loaded before pulling.
 
-	    cache.listenable().addListener(listener);
-	    cache.start();
+								if (pull) {
+									try {
+										List<Object> params = (List<Object>) dataMap.get("params");
+										String methodName = dataMap.get("methodName").toString();
+										Method method = findMethod(methodName, params);
+										method.invoke(null, params.toArray());
+									} catch (Exception e) {
+										classLogger.error(Constants.STACKTRACE, e);
+									}
+								}
 
-	    return cache;
+							}
+						}
+					}
+				})
+				.build();
+
+		cache.listenable().addListener(listener);
+		cache.start();
+
+		return cache;
 	}
-	
-	
+
+	/**
+	 * Finds a public static method on ClusterUtil by name and parameter
+	 * compatibility.
+	 * Handles primitive/boxed type mismatches (e.g. boolean vs Boolean).
+	 */
+	private static Method findMethod(String methodName, List<Object> params) {
+		for (Method method : ClusterUtil.class.getMethods()) {
+			if (!method.getName().equals(methodName)) {
+				continue;
+			}
+			Class<?>[] methodParamTypes = method.getParameterTypes();
+			if (methodParamTypes.length != params.size()) {
+				continue;
+			}
+			boolean match = true;
+			for (int i = 0; i < methodParamTypes.length; i++) {
+				Class<?> paramType = methodParamTypes[i];
+				Class<?> argType = params.get(i).getClass();
+				if (!paramType.isAssignableFrom(argType) && !isBoxedMatch(paramType, argType)) {
+					match = false;
+					break;
+				}
+			}
+			if (match) {
+				return method;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Checks if a primitive type matches its boxed equivalent.
+	 */
+	private static boolean isBoxedMatch(Class<?> paramType, Class<?> argType) {
+		return (paramType == boolean.class && argType == Boolean.class)
+				|| (paramType == int.class && argType == Integer.class)
+				|| (paramType == long.class && argType == Long.class)
+				|| (paramType == double.class && argType == Double.class)
+				|| (paramType == float.class && argType == Float.class)
+				|| (paramType == short.class && argType == Short.class)
+				|| (paramType == byte.class && argType == Byte.class)
+				|| (paramType == char.class && argType == Character.class);
+	}
+
 	private static boolean projectLoaded(String projectId) {
 		String projects = DIHelper.getInstance().getProjectProperty(Constants.PROJECTS) + "";
 
-		if (projects.startsWith(projectId) || projects.contains(";" + projectId + ";") || projects.endsWith(";" + projectId)) {
+		if (projects.startsWith(projectId) || projects.contains(";" + projectId + ";")
+				|| projects.endsWith(";" + projectId)) {
 			classLogger.info("Loaded project " + projectId + " is out of date. Pulling latest changes");
 			return true;
 		} else {
 			return false;
 		}
 	}
-	
+
 	private static boolean engineLoaded(String engineId) {
 		String engines = DIHelper.getInstance().getEngineProperty(Constants.ENGINES) + "";
 
-		if (engines.startsWith(engineId) || engines.contains(";" + engineId + ";") || engines.endsWith(";" + engineId)) {
+		if (engines.startsWith(engineId) || engines.contains(";" + engineId + ";")
+				|| engines.endsWith(";" + engineId)) {
 			classLogger.info("Loaded engine " + engineId + " is out of date. Pulling latest changes");
 			return true;
 		} else {
@@ -207,142 +252,176 @@ public class ClusterSynchronizer {
 		}
 	}
 
+	private static boolean userLoaded(String projectId) {
+		String projects = DIHelper.getInstance().getProjectProperty(Constants.PROJECTS) + "";
+
+		if (projects.startsWith(projectId) || projects.contains(";" + projectId + ";")
+				|| projects.endsWith(";" + projectId)) {
+			classLogger.info("Loaded user asset/workspace " + projectId + " is out of date. Pulling latest changes");
+			return true;
+		} else {
+			return false;
+		}
+	}
+
 	public static ClusterSynchronizer getInstance() throws Exception {
-		if(sync != null) {
+		if (sync != null) {
 			return sync;
 		}
-		
-		if(sync == null) {
+
+		if (sync == null) {
 			synchronized (ClusterSynchronizer.class) {
-				if(sync != null) {
+				if (sync != null) {
 					return sync;
 				}
-				
+
 				sync = new ClusterSynchronizer();
 			}
 		}
-		
+
 		return sync;
 	}
-	
-	
-	public void publishEngineChange(String engineId, String methodName,  Object... params) throws Exception {
-		
+
+	public void publishEngineChange(String engineId, String methodName, Object... params) throws Exception {
+
 		String enginePath = SYNC_ENGINE_PATH + "/" + engineId;
-		
-		//this creates the path if it doesnt exist
+
+		// this creates the path if it doesnt exist
 		if (client.checkExists().forPath(enginePath) == null) {
-		    client.create().creatingParentsIfNeeded().forPath(enginePath);
+			client.create().creatingParentsIfNeeded().forPath(enginePath);
 		}
-		
-	   classLogger.info("Publishing change for engine " + engineId + " and for nodes to " + methodName);
-	   Map<String, Object> dataMap = new HashMap<>();
-       dataMap.put("nodeId", host);
-       dataMap.put("methodName", methodName);
-       List<Object> paramList = Arrays.asList(params);
-       dataMap.put("params", paramList);
 
-       ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
-       ObjectOutputStream out = new ObjectOutputStream(byteOut);
-       out.writeObject(dataMap);
-	
-       client.setData().forPath(enginePath, byteOut.toByteArray());
+		classLogger.info("Publishing change for engine " + engineId + " and for nodes to " + methodName);
+		Map<String, Object> dataMap = new HashMap<>();
+		dataMap.put("nodeId", host);
+		dataMap.put("methodName", methodName);
+		List<Object> paramList = Arrays.asList(params);
+		dataMap.put("params", paramList);
+
+		ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+		ObjectOutputStream out = new ObjectOutputStream(byteOut);
+		out.writeObject(dataMap);
+
+		client.setData().forPath(enginePath, byteOut.toByteArray());
 
 	}
-	
-	public void publishProjectChange(String projectId, String methodName,  Object... params) throws Exception {
-		
+
+	public void publishUserChange(String projectId, String methodName, Object... params) throws Exception {
+
+		String userPath = SYNC_USER_PATH + "/" + projectId;
+
+		// this creates the path if it doesnt exist
+		if (client.checkExists().forPath(userPath) == null) {
+			client.create().creatingParentsIfNeeded().forPath(userPath);
+		}
+
+		classLogger.info("Publishing change for user asset/workspace " + projectId + " and for nodes to " + methodName);
+		Map<String, Object> dataMap = new HashMap<>();
+		dataMap.put("nodeId", host);
+		dataMap.put("methodName", methodName);
+		List<Object> paramList = Arrays.asList(params);
+		dataMap.put("params", paramList);
+
+		ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+		ObjectOutputStream out = new ObjectOutputStream(byteOut);
+		out.writeObject(dataMap);
+
+		client.setData().forPath(userPath, byteOut.toByteArray());
+
+	}
+
+	public void publishProjectChange(String projectId, String methodName, Object... params) throws Exception {
+
 		String projectPath = SYNC_PROJECT_PATH + "/" + projectId;
-		
-		//this creates the path if it doesnt exist
-		if (client.checkExists().forPath(projectPath) == null) {
-		    client.create().creatingParentsIfNeeded().forPath(projectPath);
-		}
-		
-	   classLogger.info("Publishing change for project " + projectId + " and for nodes to " + methodName);
-	   Map<String, Object> dataMap = new HashMap<>();
-       dataMap.put("nodeId", host);
-       dataMap.put("methodName", methodName);
-       List<Object> paramList = Arrays.asList(params);
-       dataMap.put("params", paramList);
 
-       ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
-       ObjectOutputStream out = new ObjectOutputStream(byteOut);
-       out.writeObject(dataMap);
-	
-       client.setData().forPath(projectPath, byteOut.toByteArray());
+		// this creates the path if it doesnt exist
+		if (client.checkExists().forPath(projectPath) == null) {
+			client.create().creatingParentsIfNeeded().forPath(projectPath);
+		}
+
+		classLogger.info("Publishing change for project " + projectId + " and for nodes to " + methodName);
+		Map<String, Object> dataMap = new HashMap<>();
+		dataMap.put("nodeId", host);
+		dataMap.put("methodName", methodName);
+		List<Object> paramList = Arrays.asList(params);
+		dataMap.put("params", paramList);
+
+		ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+		ObjectOutputStream out = new ObjectOutputStream(byteOut);
+		out.writeObject(dataMap);
+
+		client.setData().forPath(projectPath, byteOut.toByteArray());
 
 	}
-	
-	
-//	
-//	//TODO - break this out smarter to be for all different pushes
-//	public void publishEngineChange(String engineId, String methodName) throws Exception {
-//		
-//		String enginePath = SYNC_ENGINE_PATH + "/" + engineId;
-//		
-//		//this creates the path if it doesnt exist
-//		if (client.checkExists().forPath(enginePath) == null) {
-//		    client.create().creatingParentsIfNeeded().forPath(enginePath);
-//		}
-//		
-//	   Map<String, String> dataMap = new HashMap<>();
-//       dataMap.put("nodeId", host);
-//       dataMap.put("methodName", methodName);
-//       
-//       ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
-//       ObjectOutputStream out = new ObjectOutputStream(byteOut);
-//       out.writeObject(dataMap);
-//	
-//		// this updates the path and the watcher is watching for updates
-//		//TODO - pass a full map as the data where host will be a key along with the function used - ex. pushOwl, pushInsightDB
-//		 //client.setData().forPath(enginePath, host.getBytes());
-//       client.setData().forPath(enginePath, byteOut.toByteArray());
-//
-//	}
-//	
-//	//TODO - break this out smarter to be for all different pushes
-//	public void publishProjectChange(String projectId, String methodName) throws Exception {
-//		
-//		String projectPath = SYNC_PROJECT_PATH + "/" + projectId;
-//		
-//		//this creates the path if it doesnt exist
-//		if (client.checkExists().forPath(projectPath) == null) {
-//		    client.create().creatingParentsIfNeeded().forPath(projectPath);
-//		}
-//		
-//		   Map<String, String> dataMap = new HashMap<>();
-//	       dataMap.put("nodeId", host);
-//	       dataMap.put("methodName", methodName);
-//	       
-//	       ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
-//	       ObjectOutputStream out = new ObjectOutputStream(byteOut);
-//	       out.writeObject(dataMap);
-//		
-//			// this updates the path and the watcher is watching for updates
-//			//TODO - pass a full map as the data where host will be a key along with the function used - ex. pushOwl, pushInsightDB
-//			 //client.setData().forPath(enginePath, host.getBytes());
-//	       client.setData().forPath(projectPath, byteOut.toByteArray());
-//		
-//	}
-//	
-	
-	
+
+	//
+	// //TODO - break this out smarter to be for all different pushes
+	// public void publishEngineChange(String engineId, String methodName) throws
+	// Exception {
+	//
+	// String enginePath = SYNC_ENGINE_PATH + "/" + engineId;
+	//
+	// //this creates the path if it doesnt exist
+	// if (client.checkExists().forPath(enginePath) == null) {
+	// client.create().creatingParentsIfNeeded().forPath(enginePath);
+	// }
+	//
+	// Map<String, String> dataMap = new HashMap<>();
+	// dataMap.put("nodeId", host);
+	// dataMap.put("methodName", methodName);
+	//
+	// ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+	// ObjectOutputStream out = new ObjectOutputStream(byteOut);
+	// out.writeObject(dataMap);
+	//
+	// // this updates the path and the watcher is watching for updates
+	// //TODO - pass a full map as the data where host will be a key along with the
+	// function used - ex. pushOwl, pushInsightDB
+	// //client.setData().forPath(enginePath, host.getBytes());
+	// client.setData().forPath(enginePath, byteOut.toByteArray());
+	//
+	// }
+	//
+	// //TODO - break this out smarter to be for all different pushes
+	// public void publishProjectChange(String projectId, String methodName) throws
+	// Exception {
+	//
+	// String projectPath = SYNC_PROJECT_PATH + "/" + projectId;
+	//
+	// //this creates the path if it doesnt exist
+	// if (client.checkExists().forPath(projectPath) == null) {
+	// client.create().creatingParentsIfNeeded().forPath(projectPath);
+	// }
+	//
+	// Map<String, String> dataMap = new HashMap<>();
+	// dataMap.put("nodeId", host);
+	// dataMap.put("methodName", methodName);
+	//
+	// ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+	// ObjectOutputStream out = new ObjectOutputStream(byteOut);
+	// out.writeObject(dataMap);
+	//
+	// // this updates the path and the watcher is watching for updates
+	// //TODO - pass a full map as the data where host will be a key along with the
+	// function used - ex. pushOwl, pushInsightDB
+	// //client.setData().forPath(enginePath, host.getBytes());
+	// client.setData().forPath(projectPath, byteOut.toByteArray());
+	//
+	// }
+	//
+
 	public static void main(String[] args) {
-		
+
 		try {
 			ClusterSynchronizer instance = ClusterSynchronizer.getInstance();
-			
-	        Thread.sleep(Integer.MAX_VALUE);
+
+			Thread.sleep(Integer.MAX_VALUE);
 
 		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			classLogger.error(Constants.STACKTRACE, e);
 		}
-		
+
 	}
 
-
 }
-	
-

--- a/src/prerna/cluster/util/ClusterSynchronizer.java
+++ b/src/prerna/cluster/util/ClusterSynchronizer.java
@@ -31,12 +31,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.reflect.MethodUtils;
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.CuratorFrameworkFactory;
 import org.apache.curator.framework.recipes.cache.CuratorCache;
@@ -163,14 +163,13 @@ public class ClusterSynchronizer {
 
 								if (pull) {
 									try {
-										List<String> params = (List<String>) dataMap.get("params");
-										Class<?>[] paramTypes = new Class[params.size()];
-										for (int i = 0; i < params.size(); i++) {
-											paramTypes[i] = params.get(i).getClass();
-										}
-										Method method = ClusterUtil.class
-												.getMethod(dataMap.get("methodName").toString(), paramTypes);
-										method.invoke(null, params.toArray());
+										
+										// actual method param types could be primitives or wrappers
+										// params are all Objects (wrappers)
+										// invoke method with utility to handle primitive lookups
+										@SuppressWarnings("unchecked")
+										List<Object> params = (List<Object>) dataMap.get("params");
+										MethodUtils.invokeStaticMethod(ClusterUtil.class, dataMap.get("methodName").toString(), params.toArray());
 									} catch (Exception e) {
 										classLogger.error(Constants.STACKTRACE, e);
 									}

--- a/src/prerna/cluster/util/ClusterSynchronizer.java
+++ b/src/prerna/cluster/util/ClusterSynchronizer.java
@@ -313,62 +313,58 @@ public class ClusterSynchronizer {
 		client.setData().forPath(projectPath, byteOut.toByteArray());
 
 	}
-
-	//
-	// //TODO - break this out smarter to be for all different pushes
-	// public void publishEngineChange(String engineId, String methodName) throws
-	// Exception {
-	//
-	// String enginePath = SYNC_ENGINE_PATH + "/" + engineId;
-	//
-	// //this creates the path if it doesnt exist
-	// if (client.checkExists().forPath(enginePath) == null) {
-	// client.create().creatingParentsIfNeeded().forPath(enginePath);
-	// }
-	//
-	// Map<String, String> dataMap = new HashMap<>();
-	// dataMap.put("nodeId", host);
-	// dataMap.put("methodName", methodName);
-	//
-	// ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
-	// ObjectOutputStream out = new ObjectOutputStream(byteOut);
-	// out.writeObject(dataMap);
-	//
-	// // this updates the path and the watcher is watching for updates
-	// //TODO - pass a full map as the data where host will be a key along with the
-	// function used - ex. pushOwl, pushInsightDB
-	// //client.setData().forPath(enginePath, host.getBytes());
-	// client.setData().forPath(enginePath, byteOut.toByteArray());
-	//
-	// }
-	//
-	// //TODO - break this out smarter to be for all different pushes
-	// public void publishProjectChange(String projectId, String methodName) throws
-	// Exception {
-	//
-	// String projectPath = SYNC_PROJECT_PATH + "/" + projectId;
-	//
-	// //this creates the path if it doesnt exist
-	// if (client.checkExists().forPath(projectPath) == null) {
-	// client.create().creatingParentsIfNeeded().forPath(projectPath);
-	// }
-	//
-	// Map<String, String> dataMap = new HashMap<>();
-	// dataMap.put("nodeId", host);
-	// dataMap.put("methodName", methodName);
-	//
-	// ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
-	// ObjectOutputStream out = new ObjectOutputStream(byteOut);
-	// out.writeObject(dataMap);
-	//
-	// // this updates the path and the watcher is watching for updates
-	// //TODO - pass a full map as the data where host will be a key along with the
-	// function used - ex. pushOwl, pushInsightDB
-	// //client.setData().forPath(enginePath, host.getBytes());
-	// client.setData().forPath(projectPath, byteOut.toByteArray());
-	//
-	// }
-	//
+	
+//	
+//	//TODO - break this out smarter to be for all different pushes
+//	public void publishEngineChange(String engineId, String methodName) throws Exception {
+//		
+//		String enginePath = SYNC_ENGINE_PATH + "/" + engineId;
+//		
+//		//this creates the path if it doesnt exist
+//		if (client.checkExists().forPath(enginePath) == null) {
+//		    client.create().creatingParentsIfNeeded().forPath(enginePath);
+//		}
+//		
+//	   Map<String, String> dataMap = new HashMap<>();
+//       dataMap.put("nodeId", host);
+//       dataMap.put("methodName", methodName);
+//       
+//       ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+//       ObjectOutputStream out = new ObjectOutputStream(byteOut);
+//       out.writeObject(dataMap);
+//	
+//		// this updates the path and the watcher is watching for updates
+//		//TODO - pass a full map as the data where host will be a key along with the function used - ex. pushOwl, pushInsightDB
+//		 //client.setData().forPath(enginePath, host.getBytes());
+//       client.setData().forPath(enginePath, byteOut.toByteArray());
+//
+//	}
+//	
+//	//TODO - break this out smarter to be for all different pushes
+//	public void publishProjectChange(String projectId, String methodName) throws Exception {
+//		
+//		String projectPath = SYNC_PROJECT_PATH + "/" + projectId;
+//		
+//		//this creates the path if it doesnt exist
+//		if (client.checkExists().forPath(projectPath) == null) {
+//		    client.create().creatingParentsIfNeeded().forPath(projectPath);
+//		}
+//		
+//		   Map<String, String> dataMap = new HashMap<>();
+//	       dataMap.put("nodeId", host);
+//	       dataMap.put("methodName", methodName);
+//	       
+//	       ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+//	       ObjectOutputStream out = new ObjectOutputStream(byteOut);
+//	       out.writeObject(dataMap);
+//		
+//			// this updates the path and the watcher is watching for updates
+//			//TODO - pass a full map as the data where host will be a key along with the function used - ex. pushOwl, pushInsightDB
+//			 //client.setData().forPath(enginePath, host.getBytes());
+//	       client.setData().forPath(projectPath, byteOut.toByteArray());
+//		
+//	}
+//	
 
 	public static void main(String[] args) {
 

--- a/src/prerna/cluster/util/ClusterSynchronizer.java
+++ b/src/prerna/cluster/util/ClusterSynchronizer.java
@@ -163,13 +163,14 @@ public class ClusterSynchronizer {
 
 								if (pull) {
 									try {
-										
+
 										// actual method param types could be primitives or wrappers
 										// params are all Objects (wrappers)
 										// invoke method with utility to handle primitive lookups
 										@SuppressWarnings("unchecked")
 										List<Object> params = (List<Object>) dataMap.get("params");
-										MethodUtils.invokeStaticMethod(ClusterUtil.class, dataMap.get("methodName").toString(), params.toArray());
+										MethodUtils.invokeStaticMethod(ClusterUtil.class,
+												dataMap.get("methodName").toString(), params.toArray());
 									} catch (Exception e) {
 										classLogger.error(Constants.STACKTRACE, e);
 									}
@@ -312,58 +313,62 @@ public class ClusterSynchronizer {
 		client.setData().forPath(projectPath, byteOut.toByteArray());
 
 	}
-	
-//	
-//	//TODO - break this out smarter to be for all different pushes
-//	public void publishEngineChange(String engineId, String methodName) throws Exception {
-//		
-//		String enginePath = SYNC_ENGINE_PATH + "/" + engineId;
-//		
-//		//this creates the path if it doesnt exist
-//		if (client.checkExists().forPath(enginePath) == null) {
-//		    client.create().creatingParentsIfNeeded().forPath(enginePath);
-//		}
-//		
-//	   Map<String, String> dataMap = new HashMap<>();
-//       dataMap.put("nodeId", host);
-//       dataMap.put("methodName", methodName);
-//       
-//       ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
-//       ObjectOutputStream out = new ObjectOutputStream(byteOut);
-//       out.writeObject(dataMap);
-//	
-//		// this updates the path and the watcher is watching for updates
-//		//TODO - pass a full map as the data where host will be a key along with the function used - ex. pushOwl, pushInsightDB
-//		 //client.setData().forPath(enginePath, host.getBytes());
-//       client.setData().forPath(enginePath, byteOut.toByteArray());
-//
-//	}
-//	
-//	//TODO - break this out smarter to be for all different pushes
-//	public void publishProjectChange(String projectId, String methodName) throws Exception {
-//		
-//		String projectPath = SYNC_PROJECT_PATH + "/" + projectId;
-//		
-//		//this creates the path if it doesnt exist
-//		if (client.checkExists().forPath(projectPath) == null) {
-//		    client.create().creatingParentsIfNeeded().forPath(projectPath);
-//		}
-//		
-//		   Map<String, String> dataMap = new HashMap<>();
-//	       dataMap.put("nodeId", host);
-//	       dataMap.put("methodName", methodName);
-//	       
-//	       ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
-//	       ObjectOutputStream out = new ObjectOutputStream(byteOut);
-//	       out.writeObject(dataMap);
-//		
-//			// this updates the path and the watcher is watching for updates
-//			//TODO - pass a full map as the data where host will be a key along with the function used - ex. pushOwl, pushInsightDB
-//			 //client.setData().forPath(enginePath, host.getBytes());
-//	       client.setData().forPath(projectPath, byteOut.toByteArray());
-//		
-//	}
-//	
+
+	//
+	// //TODO - break this out smarter to be for all different pushes
+	// public void publishEngineChange(String engineId, String methodName) throws
+	// Exception {
+	//
+	// String enginePath = SYNC_ENGINE_PATH + "/" + engineId;
+	//
+	// //this creates the path if it doesnt exist
+	// if (client.checkExists().forPath(enginePath) == null) {
+	// client.create().creatingParentsIfNeeded().forPath(enginePath);
+	// }
+	//
+	// Map<String, String> dataMap = new HashMap<>();
+	// dataMap.put("nodeId", host);
+	// dataMap.put("methodName", methodName);
+	//
+	// ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+	// ObjectOutputStream out = new ObjectOutputStream(byteOut);
+	// out.writeObject(dataMap);
+	//
+	// // this updates the path and the watcher is watching for updates
+	// //TODO - pass a full map as the data where host will be a key along with the
+	// function used - ex. pushOwl, pushInsightDB
+	// //client.setData().forPath(enginePath, host.getBytes());
+	// client.setData().forPath(enginePath, byteOut.toByteArray());
+	//
+	// }
+	//
+	// //TODO - break this out smarter to be for all different pushes
+	// public void publishProjectChange(String projectId, String methodName) throws
+	// Exception {
+	//
+	// String projectPath = SYNC_PROJECT_PATH + "/" + projectId;
+	//
+	// //this creates the path if it doesnt exist
+	// if (client.checkExists().forPath(projectPath) == null) {
+	// client.create().creatingParentsIfNeeded().forPath(projectPath);
+	// }
+	//
+	// Map<String, String> dataMap = new HashMap<>();
+	// dataMap.put("nodeId", host);
+	// dataMap.put("methodName", methodName);
+	//
+	// ByteArrayOutputStream byteOut = new ByteArrayOutputStream();
+	// ObjectOutputStream out = new ObjectOutputStream(byteOut);
+	// out.writeObject(dataMap);
+	//
+	// // this updates the path and the watcher is watching for updates
+	// //TODO - pass a full map as the data where host will be a key along with the
+	// function used - ex. pushOwl, pushInsightDB
+	// //client.setData().forPath(enginePath, host.getBytes());
+	// client.setData().forPath(projectPath, byteOut.toByteArray());
+	//
+	// }
+	//
 
 	public static void main(String[] args) {
 

--- a/src/prerna/cluster/util/ClusterSynchronizer.java
+++ b/src/prerna/cluster/util/ClusterSynchronizer.java
@@ -163,9 +163,13 @@ public class ClusterSynchronizer {
 
 								if (pull) {
 									try {
-										List<Object> params = (List<Object>) dataMap.get("params");
-										String methodName = dataMap.get("methodName").toString();
-										Method method = findMethod(methodName, params);
+										List<String> params = (List<String>) dataMap.get("params");
+										Class<?>[] paramTypes = new Class[params.size()];
+										for (int i = 0; i < params.size(); i++) {
+											paramTypes[i] = params.get(i).getClass();
+										}
+										Method method = ClusterUtil.class
+												.getMethod(dataMap.get("methodName").toString(), paramTypes);
 										method.invoke(null, params.toArray());
 									} catch (Exception e) {
 										classLogger.error(Constants.STACKTRACE, e);
@@ -182,50 +186,6 @@ public class ClusterSynchronizer {
 		cache.start();
 
 		return cache;
-	}
-
-	/**
-	 * Finds a public static method on ClusterUtil by name and parameter
-	 * compatibility.
-	 * Handles primitive/boxed type mismatches (e.g. boolean vs Boolean).
-	 */
-	private static Method findMethod(String methodName, List<Object> params) {
-		for (Method method : ClusterUtil.class.getMethods()) {
-			if (!method.getName().equals(methodName)) {
-				continue;
-			}
-			Class<?>[] methodParamTypes = method.getParameterTypes();
-			if (methodParamTypes.length != params.size()) {
-				continue;
-			}
-			boolean match = true;
-			for (int i = 0; i < methodParamTypes.length; i++) {
-				Class<?> paramType = methodParamTypes[i];
-				Class<?> argType = params.get(i).getClass();
-				if (!paramType.isAssignableFrom(argType) && !isBoxedMatch(paramType, argType)) {
-					match = false;
-					break;
-				}
-			}
-			if (match) {
-				return method;
-			}
-		}
-		return null;
-	}
-
-	/**
-	 * Checks if a primitive type matches its boxed equivalent.
-	 */
-	private static boolean isBoxedMatch(Class<?> paramType, Class<?> argType) {
-		return (paramType == boolean.class && argType == Boolean.class)
-				|| (paramType == int.class && argType == Integer.class)
-				|| (paramType == long.class && argType == Long.class)
-				|| (paramType == double.class && argType == Double.class)
-				|| (paramType == float.class && argType == Float.class)
-				|| (paramType == short.class && argType == Short.class)
-				|| (paramType == byte.class && argType == Byte.class)
-				|| (paramType == char.class && argType == Character.class);
 	}
 
 	private static boolean projectLoaded(String projectId) {

--- a/src/prerna/cluster/util/ClusterUtil.java
+++ b/src/prerna/cluster/util/ClusterUtil.java
@@ -1091,7 +1091,8 @@ public class ClusterUtil {
 
 		if (ClusterUtil.IS_CLUSTER_ZK) {
 			try {
-				getClusterSynchronizer().publishUserChange(projectId, "pullUserWorkspace", projectId, isAsset);
+				getClusterSynchronizer().publishUserChange(projectId, "pullUserWorkspaceString", projectId,
+						String.valueOf(isAsset));
 			} catch (Exception e) {
 				classLogger.error("Failed to publish user/workspace project '{}' (isAsset: {}) change to ZK cluster",
 						projectId, isAsset, e);
@@ -1101,6 +1102,16 @@ public class ClusterUtil {
 				throw err;
 			}
 		}
+	}
+
+	/**
+	 * String-param bridge for ZK cluster listener reflection.
+	 * 
+	 * @param projectId
+	 * @param isAsset
+	 */
+	public static void pullUserWorkspaceString(String projectId, String isAsset) {
+		pullUserWorkspace(projectId, Boolean.parseBoolean(isAsset));
 	}
 
 	/**

--- a/src/prerna/cluster/util/ClusterUtil.java
+++ b/src/prerna/cluster/util/ClusterUtil.java
@@ -146,26 +146,25 @@ public class ClusterUtil {
 
 			// finally dynamic
 
-			// String hostName = System.getenv("HOSTNAME");
-			// logger.info("pod host name is " + hostName);
-			//
-			// if(hostName == null || hostName.isEmpty()) {
-			// throw new IllegalArgumentException("Hostname is null or empty along with no
-			// reference to scheduler execution in RDF_Map or env vars");
-			// }
-			// try {
-			// // TODO make this dynamic url instead of hard coded
-			// JSONObject json = readJsonFromUrl("http://localhost:4040/");
-			// String electedLeader = json.get("name").toString();
-			// logger.info("elected leader is " + electedLeader);
-			//
-			// return hostName.equals(electedLeader);
-			// } catch (JSONException e) {
-			// logger.error(STACKTRACE, e);
-			// } catch (IOException e) {
-			// logger.error(STACKTRACE, e);
-			// }
-			// return false;
+//			String hostName = System.getenv("HOSTNAME");
+//			logger.info("pod host name is " + hostName);
+//
+//			if(hostName == null || hostName.isEmpty()) {
+//				throw new IllegalArgumentException("Hostname is null or empty along with no reference to scheduler execution in RDF_Map or env vars");
+//			}
+//		    try {
+//		    	// TODO make this dynamic url instead of hard coded
+//				JSONObject json = readJsonFromUrl("http://localhost:4040/");
+//			    String electedLeader = json.get("name").toString();
+//				logger.info("elected leader is " + electedLeader);
+//
+//				return hostName.equals(electedLeader);
+//			} catch (JSONException e) {
+//				logger.error(STACKTRACE, e);
+//			} catch (IOException e) {
+//				logger.error(STACKTRACE, e);
+//			}
+//		    return false;
 		} else {
 			// if its not clustered, return true to say its a executor
 			return true;

--- a/src/prerna/cluster/util/ClusterUtil.java
+++ b/src/prerna/cluster/util/ClusterUtil.java
@@ -146,25 +146,26 @@ public class ClusterUtil {
 
 			// finally dynamic
 
-//			String hostName = System.getenv("HOSTNAME");
-//			logger.info("pod host name is " + hostName);
-//
-//			if(hostName == null || hostName.isEmpty()) {
-//				throw new IllegalArgumentException("Hostname is null or empty along with no reference to scheduler execution in RDF_Map or env vars");
-//			}
-//		    try {
-//		    	// TODO make this dynamic url instead of hard coded
-//				JSONObject json = readJsonFromUrl("http://localhost:4040/");
-//			    String electedLeader = json.get("name").toString();
-//				logger.info("elected leader is " + electedLeader);
-//
-//				return hostName.equals(electedLeader);
-//			} catch (JSONException e) {
-//				logger.error(STACKTRACE, e);
-//			} catch (IOException e) {
-//				logger.error(STACKTRACE, e);
-//			}
-//		    return false;
+			// String hostName = System.getenv("HOSTNAME");
+			// logger.info("pod host name is " + hostName);
+			//
+			// if(hostName == null || hostName.isEmpty()) {
+			// throw new IllegalArgumentException("Hostname is null or empty along with no
+			// reference to scheduler execution in RDF_Map or env vars");
+			// }
+			// try {
+			// // TODO make this dynamic url instead of hard coded
+			// JSONObject json = readJsonFromUrl("http://localhost:4040/");
+			// String electedLeader = json.get("name").toString();
+			// logger.info("elected leader is " + electedLeader);
+			//
+			// return hostName.equals(electedLeader);
+			// } catch (JSONException e) {
+			// logger.error(STACKTRACE, e);
+			// } catch (IOException e) {
+			// logger.error(STACKTRACE, e);
+			// }
+			// return false;
 		} else {
 			// if its not clustered, return true to say its a executor
 			return true;
@@ -1090,7 +1091,7 @@ public class ClusterUtil {
 
 		if (ClusterUtil.IS_CLUSTER_ZK) {
 			try {
-				getClusterSynchronizer().publishProjectChange(projectId, "pullUserWorkspace", projectId, isAsset);
+				getClusterSynchronizer().publishUserChange(projectId, "pullUserWorkspace", projectId, isAsset);
 			} catch (Exception e) {
 				classLogger.error("Failed to publish user/workspace project '{}' (isAsset: {}) change to ZK cluster",
 						projectId, isAsset, e);

--- a/src/prerna/cluster/util/ClusterUtil.java
+++ b/src/prerna/cluster/util/ClusterUtil.java
@@ -146,25 +146,26 @@ public class ClusterUtil {
 
 			// finally dynamic
 
-//			String hostName = System.getenv("HOSTNAME");
-//			logger.info("pod host name is " + hostName);
-//
-//			if(hostName == null || hostName.isEmpty()) {
-//				throw new IllegalArgumentException("Hostname is null or empty along with no reference to scheduler execution in RDF_Map or env vars");
-//			}
-//		    try {
-//		    	// TODO make this dynamic url instead of hard coded
-//				JSONObject json = readJsonFromUrl("http://localhost:4040/");
-//			    String electedLeader = json.get("name").toString();
-//				logger.info("elected leader is " + electedLeader);
-//
-//				return hostName.equals(electedLeader);
-//			} catch (JSONException e) {
-//				logger.error(STACKTRACE, e);
-//			} catch (IOException e) {
-//				logger.error(STACKTRACE, e);
-//			}
-//		    return false;
+			// String hostName = System.getenv("HOSTNAME");
+			// logger.info("pod host name is " + hostName);
+			//
+			// if(hostName == null || hostName.isEmpty()) {
+			// throw new IllegalArgumentException("Hostname is null or empty along with no
+			// reference to scheduler execution in RDF_Map or env vars");
+			// }
+			// try {
+			// // TODO make this dynamic url instead of hard coded
+			// JSONObject json = readJsonFromUrl("http://localhost:4040/");
+			// String electedLeader = json.get("name").toString();
+			// logger.info("elected leader is " + electedLeader);
+			//
+			// return hostName.equals(electedLeader);
+			// } catch (JSONException e) {
+			// logger.error(STACKTRACE, e);
+			// } catch (IOException e) {
+			// logger.error(STACKTRACE, e);
+			// }
+			// return false;
 		} else {
 			// if its not clustered, return true to say its a executor
 			return true;
@@ -1090,8 +1091,7 @@ public class ClusterUtil {
 
 		if (ClusterUtil.IS_CLUSTER_ZK) {
 			try {
-				getClusterSynchronizer().publishUserChange(projectId, "pullUserWorkspaceString", projectId,
-						String.valueOf(isAsset));
+				getClusterSynchronizer().publishUserChange(projectId, "pullUserWorkspace", projectId, isAsset);
 			} catch (Exception e) {
 				classLogger.error("Failed to publish user/workspace project '{}' (isAsset: {}) change to ZK cluster",
 						projectId, isAsset, e);
@@ -1101,16 +1101,6 @@ public class ClusterUtil {
 				throw err;
 			}
 		}
-	}
-
-	/**
-	 * String-param bridge for ZK cluster listener reflection.
-	 * 
-	 * @param projectId
-	 * @param isAsset
-	 */
-	public static void pullUserWorkspaceString(String projectId, String isAsset) {
-		pullUserWorkspace(projectId, Boolean.parseBoolean(isAsset));
 	}
 
 	/**

--- a/src/prerna/util/AssetUtility.java
+++ b/src/prerna/util/AssetUtility.java
@@ -80,14 +80,6 @@ public class AssetUtility {
 				String projectId = user.getAssetProjectId(provider);
 				String projectName = "Asset";
 				assetFolder = getUserAssetAndWorkspaceAppRootFolder(projectName, projectId);
-				// Symlink user asset folder into chroot so it persists across sessions
-				if (Boolean.parseBoolean(Utility.getDIHelperProperty(Constants.CHROOT_ENABLE))) {
-					try {
-						user.getUserSymlinkHelper().symlinkUserAsset(user);
-					} catch (Exception e) {
-						classLogger.warn("Unable to symlink user asset folder into chroot", e);
-					}
-				}
 			} else if (INSIGHT_SPACE_KEY.equalsIgnoreCase(space)) {
 				// default
 				// but need to perform check

--- a/src/prerna/util/AssetUtility.java
+++ b/src/prerna/util/AssetUtility.java
@@ -81,9 +81,9 @@ public class AssetUtility {
 				String projectName = "Asset";
 				assetFolder = getUserAssetAndWorkspaceAppRootFolder(projectName, projectId);
 				// Symlink user asset folder into chroot so it persists across sessions
-				if (Boolean.parseBoolean(Utility.getDIHelperProperty(Constants.CHROOT_ENABLE)) && user != null) {
+				if (Boolean.parseBoolean(Utility.getDIHelperProperty(Constants.CHROOT_ENABLE))) {
 					try {
-						user.getUserSymlinkHelper().symlinkFolder(assetFolder);
+						user.getUserSymlinkHelper().symlinkUserAsset(user);
 					} catch (Exception e) {
 						classLogger.warn("Unable to symlink user asset folder into chroot", e);
 					}

--- a/src/prerna/util/AssetUtility.java
+++ b/src/prerna/util/AssetUtility.java
@@ -80,6 +80,14 @@ public class AssetUtility {
 				String projectId = user.getAssetProjectId(provider);
 				String projectName = "Asset";
 				assetFolder = getUserAssetAndWorkspaceAppRootFolder(projectName, projectId);
+				// Symlink user asset folder into chroot so it persists across sessions
+				if (Boolean.parseBoolean(Utility.getDIHelperProperty(Constants.CHROOT_ENABLE)) && user != null) {
+					try {
+						user.getUserSymlinkHelper().symlinkFolder(assetFolder);
+					} catch (Exception e) {
+						classLogger.warn("Unable to symlink user asset folder into chroot", e);
+					}
+				}
 			} else if (INSIGHT_SPACE_KEY.equalsIgnoreCase(space)) {
 				// default
 				// but need to perform check

--- a/src/prerna/util/SymlinkHelper.java
+++ b/src/prerna/util/SymlinkHelper.java
@@ -44,6 +44,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import prerna.auth.AuthProvider;
 import prerna.auth.User;
 import prerna.auth.utils.SecurityProjectUtils;
 
@@ -55,6 +56,7 @@ public class SymlinkHelper {
 
 	/**
 	 * This will be username__uuid - ex. /opt/kunalppatel9__a123123
+	 * 
 	 * @param targetDirName
 	 */
 	public SymlinkHelper(String targetDirName) {
@@ -80,31 +82,31 @@ public class SymlinkHelper {
 	 * Initialization for cross-platform support
 	 */
 	private void initalizeChrootFolder() {
-	    String baseFolder = Utility.getBaseFolder();
-	    symlinkFolder(baseFolder + "/" + Constants.PY_BASE_FOLDER);
-	    symlinkFolder(Utility.getDIHelperProperty(Constants.INSIGHT_CACHE_DIR));
-	    
-	    // Read paths from DIHelper or configuration
-	    String pathsToSymlink = Utility.getDIHelperProperty("CHROOT_SYMLINK_PATHS");
-	    if (pathsToSymlink != null && !pathsToSymlink.isEmpty()) {
-	        String[] paths = pathsToSymlink.split(",");
-	        for (String path : paths) {
-	            symlinkFolder(path.trim());
-	        }
-	    } else {
-	        classLogger.warn("No paths specified for symlinking.");
-	    }
+		String baseFolder = Utility.getBaseFolder();
+		symlinkFolder(baseFolder + "/" + Constants.PY_BASE_FOLDER);
+		symlinkFolder(Utility.getDIHelperProperty(Constants.INSIGHT_CACHE_DIR));
 
-	    createChrootDirectory("/root");
-	    createChrootDirectory("/home/default");
-	    
-	    // Set proper ownership for home directories
-	    setDirectoryOwnership("/home/default", "1001", "1001");
-	    
-	    // Setup basic shell environment
-	    setupBashForChroot();
-	    // Setup Git
-	    setupGitForChroot();
+		// Read paths from DIHelper or configuration
+		String pathsToSymlink = Utility.getDIHelperProperty("CHROOT_SYMLINK_PATHS");
+		if (pathsToSymlink != null && !pathsToSymlink.isEmpty()) {
+			String[] paths = pathsToSymlink.split(",");
+			for (String path : paths) {
+				symlinkFolder(path.trim());
+			}
+		} else {
+			classLogger.warn("No paths specified for symlinking.");
+		}
+
+		createChrootDirectory("/root");
+		createChrootDirectory("/home/default");
+
+		// Set proper ownership for home directories
+		setDirectoryOwnership("/home/default", "1001", "1001");
+
+		// Setup basic shell environment
+		setupBashForChroot();
+		// Setup Git
+		setupGitForChroot();
 	}
 
 	/**
@@ -135,13 +137,13 @@ public class SymlinkHelper {
 				copySystemBinary(cmd); // copies symlink
 				copyRequiredLibraries(cmd); // mostly no-op, since all point to coreutils
 			}
-			
-	        // Add whoami and id commands
-	        String[] identityCommands = { "/usr/bin/whoami", "/usr/bin/id" };
-	        for (String cmd : identityCommands) {
-	            copySystemBinary(cmd);
-	            copyRequiredLibraries(cmd);
-	        }
+
+			// Add whoami and id commands
+			String[] identityCommands = { "/usr/bin/whoami", "/usr/bin/id" };
+			for (String cmd : identityCommands) {
+				copySystemBinary(cmd);
+				copyRequiredLibraries(cmd);
+			}
 
 			classLogger.info("Bash and essential commands setup completed for chroot: " + userChrootFolder);
 		} catch (Exception e) {
@@ -151,6 +153,7 @@ public class SymlinkHelper {
 
 	/**
 	 * Create a directory inside the chroot environment
+	 * 
 	 * @param relativePath
 	 */
 	private void createChrootDirectory(String relativePath) {
@@ -165,6 +168,7 @@ public class SymlinkHelper {
 
 	/**
 	 * Copy a system binary to the chroot environment
+	 * 
 	 * @param binaryPath
 	 */
 	private void copySystemBinary(String binaryPath) {
@@ -194,6 +198,7 @@ public class SymlinkHelper {
 
 	/**
 	 * Copy required shared libraries for bash using ldd command
+	 * 
 	 * @param binaryPath
 	 */
 	private void copyRequiredLibraries(String binaryPath) {
@@ -234,6 +239,7 @@ public class SymlinkHelper {
 
 	/**
 	 * Copy a single library to the chroot environment
+	 * 
 	 * @param libraryPath
 	 */
 	private void copyLibraryIfExists(String libraryPath) {
@@ -263,261 +269,261 @@ public class SymlinkHelper {
 	 * and required helper programs for both RHEL/UBI and Ubuntu systems.
 	 */
 	private void setupGitForChroot() {
-	    try {
-	        // Main git binary
-	        copySystemBinary("/usr/bin/git");
-	        copyRequiredLibraries("/usr/bin/git");
+		try {
+			// Main git binary
+			copySystemBinary("/usr/bin/git");
+			copyRequiredLibraries("/usr/bin/git");
 
-	        // Setup git helpers (handles both RHEL and Ubuntu)
-	        setupGitHelpersForCrossPlatform();
+			// Setup git helpers (handles both RHEL and Ubuntu)
+			setupGitHelpersForCrossPlatform();
 
-	        // Setup essential binaries for git operations
-	        setupGitEssentialBinaries();
+			// Setup essential binaries for git operations
+			setupGitEssentialBinaries();
 
-	        // Setup git templates
-	        setupGitTemplatesForCrossPlatform();
+			// Setup git templates
+			setupGitTemplatesForCrossPlatform();
 
-	        // Setup SSL certificates (handles both RHEL and Ubuntu)
-	        setupSSLCertsForCrossPlatform();
+			// Setup SSL certificates (handles both RHEL and Ubuntu)
+			setupSSLCertsForCrossPlatform();
 
-	        // Create necessary directories
-	        createChrootDirectory("/tmp");
-	        createChrootDirectory("/var/tmp");
-	        createChrootDirectory("/etc/git");
+			// Create necessary directories
+			createChrootDirectory("/tmp");
+			createChrootDirectory("/var/tmp");
+			createChrootDirectory("/etc/git");
 
-	        classLogger.info("Git setup completed for chroot: " + userChrootFolder);
+			classLogger.info("Git setup completed for chroot: " + userChrootFolder);
 
-	    } catch (Exception e) {
-	        classLogger.error("Error setting up git for chroot: " + e.getMessage(), e);
-	    }
+		} catch (Exception e) {
+			classLogger.error("Error setting up git for chroot: " + e.getMessage(), e);
+		}
 	}
 
 	/**
 	 * Setup git helper programs for both RHEL/UBI and Ubuntu systems
 	 */
 	private void setupGitHelpersForCrossPlatform() {
-	    try {
-	        // Try RHEL/UBI path first
-	        Path gitHelpersHost = Paths.get("/usr/libexec/git-core");
-	        Path gitHelpersChroot = Paths.get(userChrootFolder).resolve("usr/libexec/git-core");
-	        
-	        if (Files.exists(gitHelpersHost)) {
-	            copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
-	            classLogger.info("Copied git helpers from RHEL/UBI location: " + gitHelpersHost);
-	        } else {
-	            // Fallback to Ubuntu path
-	            gitHelpersHost = Paths.get("/usr/lib/git-core");
-	            gitHelpersChroot = Paths.get(userChrootFolder).resolve("usr/lib/git-core");
-	            
-	            if (Files.exists(gitHelpersHost)) {
-	                copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
-	                classLogger.info("Copied git helpers from Ubuntu location: " + gitHelpersHost);
-	            } else {
-	                classLogger.warn("Git helpers directory not found at expected locations");
-	                // Try to find git helpers using git itself
-	                findAndCopyGitHelpers();
-	            }
-	        }
-	    } catch (IOException e) {
-	        classLogger.error("Error setting up git helpers: " + e.getMessage(), e);
-	    }
+		try {
+			// Try RHEL/UBI path first
+			Path gitHelpersHost = Paths.get("/usr/libexec/git-core");
+			Path gitHelpersChroot = Paths.get(userChrootFolder).resolve("usr/libexec/git-core");
+
+			if (Files.exists(gitHelpersHost)) {
+				copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
+				classLogger.info("Copied git helpers from RHEL/UBI location: " + gitHelpersHost);
+			} else {
+				// Fallback to Ubuntu path
+				gitHelpersHost = Paths.get("/usr/lib/git-core");
+				gitHelpersChroot = Paths.get(userChrootFolder).resolve("usr/lib/git-core");
+
+				if (Files.exists(gitHelpersHost)) {
+					copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
+					classLogger.info("Copied git helpers from Ubuntu location: " + gitHelpersHost);
+				} else {
+					classLogger.warn("Git helpers directory not found at expected locations");
+					// Try to find git helpers using git itself
+					findAndCopyGitHelpers();
+				}
+			}
+		} catch (IOException e) {
+			classLogger.error("Error setting up git helpers: " + e.getMessage(), e);
+		}
 	}
 
 	/**
 	 * Find git helpers using git --exec-path command
 	 */
 	private void findAndCopyGitHelpers() {
-	    try {
-	        ProcessBuilder pb = new ProcessBuilder("git", "--exec-path");
-	        Process process = pb.start();
-	        
-	        try (java.io.BufferedReader reader = new java.io.BufferedReader(
-	                new java.io.InputStreamReader(process.getInputStream()))) {
-	            
-	            String gitExecPath = reader.readLine();
-	            if (gitExecPath != null && !gitExecPath.trim().isEmpty()) {
-	                Path gitHelpersHost = Paths.get(gitExecPath.trim());
-	                Path gitHelpersChroot = Paths.get(userChrootFolder).resolve(gitExecPath.substring(1));
-	                
-	                if (Files.exists(gitHelpersHost)) {
-	                    copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
-	                    classLogger.info("Found and copied git helpers from: " + gitExecPath);
-	                }
-	            }
-	        }
-	        
-	        process.waitFor();
-	    } catch (Exception e) {
-	        classLogger.warn("Could not find git helpers using git --exec-path: " + e.getMessage());
-	    }
+		try {
+			ProcessBuilder pb = new ProcessBuilder("git", "--exec-path");
+			Process process = pb.start();
+
+			try (java.io.BufferedReader reader = new java.io.BufferedReader(
+					new java.io.InputStreamReader(process.getInputStream()))) {
+
+				String gitExecPath = reader.readLine();
+				if (gitExecPath != null && !gitExecPath.trim().isEmpty()) {
+					Path gitHelpersHost = Paths.get(gitExecPath.trim());
+					Path gitHelpersChroot = Paths.get(userChrootFolder).resolve(gitExecPath.substring(1));
+
+					if (Files.exists(gitHelpersHost)) {
+						copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
+						classLogger.info("Found and copied git helpers from: " + gitExecPath);
+					}
+				}
+			}
+
+			process.waitFor();
+		} catch (Exception e) {
+			classLogger.warn("Could not find git helpers using git --exec-path: " + e.getMessage());
+		}
 	}
 
 	/**
 	 * Setup essential binaries for git operations on both platforms
 	 */
 	private void setupGitEssentialBinaries() {
-	    String[] essentialBinaries = {
-	        "/usr/bin/curl",      // Required for git-remote-https
-	        "/usr/bin/ssh",       // For git@... URLs  
-	        "/bin/tar",           // Archive operations
-	        "/bin/gzip",          // Compression
-	        "/usr/bin/openssl",   // SSL/TLS operations
-	        "/usr/bin/wget"       // Alternative HTTP client
-	    };
+		String[] essentialBinaries = {
+				"/usr/bin/curl", // Required for git-remote-https
+				"/usr/bin/ssh", // For git@... URLs
+				"/bin/tar", // Archive operations
+				"/bin/gzip", // Compression
+				"/usr/bin/openssl", // SSL/TLS operations
+				"/usr/bin/wget" // Alternative HTTP client
+		};
 
-	    for (String bin : essentialBinaries) {
-	        if (Files.exists(Paths.get(bin))) {
-	            copySystemBinary(bin);
-	            copyRequiredLibraries(bin);
-	            classLogger.debug("Copied git dependency: " + bin);
-	        } else {
-	            classLogger.debug("Optional git dependency not found: " + bin);
-	        }
-	    }
-	    
-	    // Copy git-specific libraries that might be needed
-	    copyGitSpecificLibraries();
+		for (String bin : essentialBinaries) {
+			if (Files.exists(Paths.get(bin))) {
+				copySystemBinary(bin);
+				copyRequiredLibraries(bin);
+				classLogger.debug("Copied git dependency: " + bin);
+			} else {
+				classLogger.debug("Optional git dependency not found: " + bin);
+			}
+		}
+
+		// Copy git-specific libraries that might be needed
+		copyGitSpecificLibraries();
 	}
 
 	/**
 	 * Copy git-specific libraries for both RHEL and Ubuntu
 	 */
 	private void copyGitSpecificLibraries() {
-	    // RHEL/UBI library paths
-	    String[] rhelLibs = {
-	        "/usr/lib64/libcurl.so.4",
-	        "/usr/lib64/libssl.so.3",
-	        "/usr/lib64/libcrypto.so.3",
-	        "/usr/lib64/libz.so.1",
-	        "/usr/lib64/libgssapi_krb5.so.2"
-	    };
-	    
-	    // Ubuntu library paths
-	    String[] ubuntuLibs = {
-	        "/usr/lib/x86_64-linux-gnu/libcurl.so.4",
-	        "/usr/lib/x86_64-linux-gnu/libssl.so.3",
-	        "/usr/lib/x86_64-linux-gnu/libcrypto.so.3",
-	        "/usr/lib/x86_64-linux-gnu/libz.so.1"
-	    };
-	    
-	    // Try RHEL paths first
-	    boolean foundRhelLibs = false;
-	    for (String lib : rhelLibs) {
-	        if (Files.exists(Paths.get(lib))) {
-	            copyLibraryIfExists(lib);
-	            foundRhelLibs = true;
-	        }
-	    }
-	    
-	    // If no RHEL libs found, try Ubuntu paths
-	    if (!foundRhelLibs) {
-	        for (String lib : ubuntuLibs) {
-	            copyLibraryIfExists(lib);
-	        }
-	    }
+		// RHEL/UBI library paths
+		String[] rhelLibs = {
+				"/usr/lib64/libcurl.so.4",
+				"/usr/lib64/libssl.so.3",
+				"/usr/lib64/libcrypto.so.3",
+				"/usr/lib64/libz.so.1",
+				"/usr/lib64/libgssapi_krb5.so.2"
+		};
+
+		// Ubuntu library paths
+		String[] ubuntuLibs = {
+				"/usr/lib/x86_64-linux-gnu/libcurl.so.4",
+				"/usr/lib/x86_64-linux-gnu/libssl.so.3",
+				"/usr/lib/x86_64-linux-gnu/libcrypto.so.3",
+				"/usr/lib/x86_64-linux-gnu/libz.so.1"
+		};
+
+		// Try RHEL paths first
+		boolean foundRhelLibs = false;
+		for (String lib : rhelLibs) {
+			if (Files.exists(Paths.get(lib))) {
+				copyLibraryIfExists(lib);
+				foundRhelLibs = true;
+			}
+		}
+
+		// If no RHEL libs found, try Ubuntu paths
+		if (!foundRhelLibs) {
+			for (String lib : ubuntuLibs) {
+				copyLibraryIfExists(lib);
+			}
+		}
 	}
 
 	/**
 	 * Setup git templates for cross-platform compatibility
 	 */
 	private void setupGitTemplatesForCrossPlatform() {
-	    String[] templatePaths = {
-	        "/usr/share/git-core/templates",  // Common location
-	        "/usr/local/share/git-core/templates"  // Alternative location
-	    };
-	    
-	    for (String templatePath : templatePaths) {
-	        Path templatesSource = Paths.get(templatePath);
-	        if (Files.exists(templatesSource)) {
-	            Path templatesTarget = Paths.get(userChrootFolder).resolve(templatePath.substring(1));
-	            try {
-	                copyDirectoryRecursively(templatesSource, templatesTarget);
-	                classLogger.info("Copied git templates from: " + templatePath);
-	                break; // Only copy the first one found
-	            } catch (IOException e) {
-	                classLogger.debug("Could not copy git templates from: " + templatePath);
-	            }
-	        }
-	    }
+		String[] templatePaths = {
+				"/usr/share/git-core/templates", // Common location
+				"/usr/local/share/git-core/templates" // Alternative location
+		};
+
+		for (String templatePath : templatePaths) {
+			Path templatesSource = Paths.get(templatePath);
+			if (Files.exists(templatesSource)) {
+				Path templatesTarget = Paths.get(userChrootFolder).resolve(templatePath.substring(1));
+				try {
+					copyDirectoryRecursively(templatesSource, templatesTarget);
+					classLogger.info("Copied git templates from: " + templatePath);
+					break; // Only copy the first one found
+				} catch (IOException e) {
+					classLogger.debug("Could not copy git templates from: " + templatePath);
+				}
+			}
+		}
 	}
 
 	/**
 	 * Setup SSL certificates for both RHEL/UBI and Ubuntu systems
 	 */
 	private void setupSSLCertsForCrossPlatform() {
-	    try {
-	        // Detect OS type and setup accordingly
-	    	boolean isRHELBased = isRHELBasedSystem();
-	        if (isRHELBased) {
-	        	classLogger.info("Predicted OS as RHEL");
-	            setupSSLCertsForRHEL();
-	        } else {
-	        	classLogger.info("Predicted OS as Ubuntu");
-	            setupSSLCertsForUbuntu();
-	        }
-	    } catch (Exception e) {
-	        classLogger.warn("Could not setup SSL certificates: " + e.getMessage());
-	        // Try both approaches as fallback
-	        setupSSLCertsForRHEL();
-	        setupSSLCertsForUbuntu();
-	    }
+		try {
+			// Detect OS type and setup accordingly
+			boolean isRHELBased = isRHELBasedSystem();
+			if (isRHELBased) {
+				classLogger.info("Predicted OS as RHEL");
+				setupSSLCertsForRHEL();
+			} else {
+				classLogger.info("Predicted OS as Ubuntu");
+				setupSSLCertsForUbuntu();
+			}
+		} catch (Exception e) {
+			classLogger.warn("Could not setup SSL certificates: " + e.getMessage());
+			// Try both approaches as fallback
+			setupSSLCertsForRHEL();
+			setupSSLCertsForUbuntu();
+		}
 	}
 
 	/**
 	 * Detect if the system is RHEL-based
 	 */
 	private boolean isRHELBasedSystem() {
-	    // Check for RHEL-specific files/directories
-	    return Files.exists(Paths.get("/etc/redhat-release")) ||
-	           Files.exists(Paths.get("/etc/rhel-release")) ||
-	           Files.exists(Paths.get("/etc/pki"));
+		// Check for RHEL-specific files/directories
+		return Files.exists(Paths.get("/etc/redhat-release")) ||
+				Files.exists(Paths.get("/etc/rhel-release")) ||
+				Files.exists(Paths.get("/etc/pki"));
 	}
 
 	/**
 	 * Setup SSL certificates for RHEL/UBI systems
 	 */
 	private void setupSSLCertsForRHEL() {
-	    try {
-	        String[] caCertFiles = {
-	            "/etc/pki/tls/certs/ca-bundle.crt",
-	            "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
-	            "/etc/pki/tls/cert.pem"
-	        };
+		try {
+			String[] caCertFiles = {
+					"/etc/pki/tls/certs/ca-bundle.crt",
+					"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+					"/etc/pki/tls/cert.pem"
+			};
 
-	        // Copy CA certificate files
-	        for (String certPath : caCertFiles) {
-	            Path sourceCerts = Paths.get(certPath);
-	            if (Files.exists(sourceCerts)) {
-	                Path targetCerts = Paths.get(userChrootFolder).resolve(certPath.substring(1));
-	                Files.createDirectories(targetCerts.getParent());
-	                Files.copy(sourceCerts, targetCerts, StandardCopyOption.REPLACE_EXISTING);
-	                classLogger.info("Copied RHEL CA certificates from: " + certPath);
-	            } else {
+			// Copy CA certificate files
+			for (String certPath : caCertFiles) {
+				Path sourceCerts = Paths.get(certPath);
+				if (Files.exists(sourceCerts)) {
+					Path targetCerts = Paths.get(userChrootFolder).resolve(certPath.substring(1));
+					Files.createDirectories(targetCerts.getParent());
+					Files.copy(sourceCerts, targetCerts, StandardCopyOption.REPLACE_EXISTING);
+					classLogger.info("Copied RHEL CA certificates from: " + certPath);
+				} else {
 					classLogger.warn("Could not find file at " + certPath);
 				}
-	        }
+			}
 
-	        // Copy certificate directories
-	        String[] certDirs = {
-	            "/etc/pki/tls/certs",
-	            "/etc/pki/ca-trust/extracted",
-	            "/etc/pki/tls"
-	        };
+			// Copy certificate directories
+			String[] certDirs = {
+					"/etc/pki/tls/certs",
+					"/etc/pki/ca-trust/extracted",
+					"/etc/pki/tls"
+			};
 
-	        for (String certDir : certDirs) {
-	            Path sourceCertDir = Paths.get(certDir);
-	            if (Files.exists(sourceCertDir)) {
-	                Path targetCertDir = Paths.get(userChrootFolder).resolve(certDir.substring(1));
-	                copyDirectoryRecursively(sourceCertDir, targetCertDir);
-	                classLogger.debug("Copied RHEL certificate directory: " + certDir);
-	            } else {
+			for (String certDir : certDirs) {
+				Path sourceCertDir = Paths.get(certDir);
+				if (Files.exists(sourceCertDir)) {
+					Path targetCertDir = Paths.get(userChrootFolder).resolve(certDir.substring(1));
+					copyDirectoryRecursively(sourceCertDir, targetCertDir);
+					classLogger.debug("Copied RHEL certificate directory: " + certDir);
+				} else {
 					classLogger.warn("Could not find directory at " + certDir);
-	            }
-	        }
+				}
+			}
 
-	    } catch (IOException e) {
-	        classLogger.debug("Could not setup RHEL SSL certificates: " + e.getMessage());
-	    }
+		} catch (IOException e) {
+			classLogger.debug("Could not setup RHEL SSL certificates: " + e.getMessage());
+		}
 	}
 
 	/**
@@ -533,7 +539,8 @@ public class SymlinkHelper {
 				if (Files.exists(sourceCerts)) {
 					Path targetCerts = Paths.get(userChrootFolder).resolve(certPath.substring(1));
 					Files.createDirectories(targetCerts.getParent());
-					Files.copy(sourceCerts, targetCerts, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+					Files.copy(sourceCerts, targetCerts, StandardCopyOption.REPLACE_EXISTING,
+							StandardCopyOption.COPY_ATTRIBUTES);
 					classLogger.info("Copied Ubuntu CA certificates from: " + certPath);
 				} else {
 					classLogger.warn("Could not find file at " + certPath);
@@ -543,46 +550,46 @@ public class SymlinkHelper {
 			// Copy certificate directories with symlink preservation
 			String[] certDirs = { "/etc/ssl/certs", "/usr/share/ca-certificates" };
 			for (String certDir : certDirs) {
-	            Path sourceCertDir = Paths.get(certDir);
-	            if (Files.exists(sourceCertDir)) {
-	                Path targetCertDir = Paths.get(userChrootFolder).resolve(certDir.substring(1));
-	                copyDirectoryRecursively(sourceCertDir, targetCertDir);
+				Path sourceCertDir = Paths.get(certDir);
+				if (Files.exists(sourceCertDir)) {
+					Path targetCertDir = Paths.get(userChrootFolder).resolve(certDir.substring(1));
+					copyDirectoryRecursively(sourceCertDir, targetCertDir);
 					classLogger.debug("Copied Ubuntu certificate directory (with symlinks): " + certDir);
-	            } else {
+				} else {
 					classLogger.warn("Could not find directory at " + certDir);
-	            }
-	        }
+				}
+			}
 		} catch (IOException e) {
 			classLogger.debug("Could not setup Ubuntu SSL certificates: " + e.getMessage());
 		}
 	}
-	
+
 	/**
 	 * Set ownership of a directory in chroot (works on both platforms)
 	 */
 	private void setDirectoryOwnership(String relativePath, String uid, String gid) {
-	    try {
-	        Path chrootDir = Paths.get(userChrootFolder, relativePath);
-	        if (Files.exists(chrootDir)) {
-	            ProcessBuilder pb = new ProcessBuilder("chown", uid + ":" + gid, chrootDir.toString());
-	            Process process = pb.start();
-	            int exitCode = process.waitFor();
-	            if (exitCode == 0) {
-	                classLogger.debug("Set ownership " + uid + ":" + gid + " for: " + relativePath);
-	            } else {
-	                classLogger.warn("Could not set ownership for: " + relativePath + " (exit code: " + exitCode + ")");
-	            }
-	        }
-	    } catch (Exception e) {
-	        classLogger.warn("Could not set ownership for: " + relativePath, e);
-	    }
+		try {
+			Path chrootDir = Paths.get(userChrootFolder, relativePath);
+			if (Files.exists(chrootDir)) {
+				ProcessBuilder pb = new ProcessBuilder("chown", uid + ":" + gid, chrootDir.toString());
+				Process process = pb.start();
+				int exitCode = process.waitFor();
+				if (exitCode == 0) {
+					classLogger.debug("Set ownership " + uid + ":" + gid + " for: " + relativePath);
+				} else {
+					classLogger.warn("Could not set ownership for: " + relativePath + " (exit code: " + exitCode + ")");
+				}
+			}
+		} catch (Exception e) {
+			classLogger.warn("Could not set ownership for: " + relativePath, e);
+		}
 	}
 
 	/**
 	 * Copy an entire directory recursively into the chroot, preserving structure.
 	 */
 	private void copyDirectoryRecursively(Path source, Path target) throws IOException {
-		if(source.toFile().exists()) {
+		if (source.toFile().exists()) {
 			Files.walk(source).forEach(src -> {
 				try {
 					Path dest = target.resolve(source.relativize(src));
@@ -597,7 +604,6 @@ public class SymlinkHelper {
 			});
 		}
 	}
-
 
 	/**
 	 * 
@@ -664,151 +670,155 @@ public class SymlinkHelper {
 		}
 	}
 
-	
-	public void symlinkProject(User user, String projectId) {
-	    classLogger.info("Symlinking project for projectId=" + projectId);
-
-	    String projectAppRootFolder = AssetUtility.getProjectAppRootFolder(projectId);
-
-	    if (SecurityProjectUtils.userCanEditProject(user, projectId)) {
-	        symlinkFolder(projectAppRootFolder);
-	        return;
-	    }
-
-	    boolean readOnlyCopyEnabled = Boolean.parseBoolean(
-	        Utility.getDIHelperProperty(Constants.CHROOT_READ_ONLY_COPY)
-	    );
-
-	    if (readOnlyCopyEnabled) {
-	        Path projectTarget = Paths.get(userChrootFolder).resolve(Utility.normalizePath(projectAppRootFolder).substring(1));
-	        if (Files.exists(projectTarget)) {
-	            classLogger.info("Chrooted project already copied for projectId=" + projectId +
-	                             " at: " + projectTarget + ", skipping copy and permission patch.");
-	            return;
-	        }
-	        
-	        classLogger.info("Symlinking read-only copy for projectId=" + projectId);
-	        setupCopiedProject(projectId);
-	        setAllReadExecuteForProject(projectId);
-	        // below does not work - commenting out for now
-			//setExecuteOnlyOnAssetCodeFolders(projectId);
-	    } else {
-	        classLogger.info("Symlinking full folder for read-only user, projectId=" + projectId);
-	        symlinkFolder(projectAppRootFolder);
-	    }
+	public void symlinkUserAsset(User user) {
+		AuthProvider provider = user.getPrimaryLogin();
+		String projectId = user.getAssetProjectId(provider);
+		String assetFolder = AssetUtility.getUserAssetAndWorkspaceAppRootFolder("Asset", projectId);
+		classLogger.info("Symlinking user asset folder for projectId=" + projectId);
+		symlinkFolder(assetFolder);
 	}
-	
+
+	public void symlinkProject(User user, String projectId) {
+		classLogger.info("Symlinking project for projectId=" + projectId);
+
+		String projectAppRootFolder = AssetUtility.getProjectAppRootFolder(projectId);
+
+		if (SecurityProjectUtils.userCanEditProject(user, projectId)) {
+			symlinkFolder(projectAppRootFolder);
+			return;
+		}
+
+		boolean readOnlyCopyEnabled = Boolean.parseBoolean(
+				Utility.getDIHelperProperty(Constants.CHROOT_READ_ONLY_COPY));
+
+		if (readOnlyCopyEnabled) {
+			Path projectTarget = Paths.get(userChrootFolder)
+					.resolve(Utility.normalizePath(projectAppRootFolder).substring(1));
+			if (Files.exists(projectTarget)) {
+				classLogger.info("Chrooted project already copied for projectId=" + projectId +
+						" at: " + projectTarget + ", skipping copy and permission patch.");
+				return;
+			}
+
+			classLogger.info("Symlinking read-only copy for projectId=" + projectId);
+			setupCopiedProject(projectId);
+			setAllReadExecuteForProject(projectId);
+			// below does not work - commenting out for now
+			// setExecuteOnlyOnAssetCodeFolders(projectId);
+		} else {
+			classLogger.info("Symlinking full folder for read-only user, projectId=" + projectId);
+			symlinkFolder(projectAppRootFolder);
+		}
+	}
+
 	private void setOwnerRWX(Path dir) throws IOException {
-	    Files.setPosixFilePermissions(dir, EnumSet.of(
-	        PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
-	        PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
-	        PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
-	    ));
+		Files.setPosixFilePermissions(dir, EnumSet.of(
+				PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
+				PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
+				PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE));
 	}
 
 	private void setOwnerRX(Path dir) throws IOException {
-	    Files.setPosixFilePermissions(dir, EnumSet.of(
-	        PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE,
-	        PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
-	        PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
-	    ));
+		Files.setPosixFilePermissions(dir, EnumSet.of(
+				PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE,
+				PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
+				PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE));
 	}
-	
+
 	private void setupCopiedProject(String projectId) {
-	    String sourceDirToCopy = AssetUtility.getProjectAppRootFolder(projectId);
-	    sourceDirToCopy = Utility.normalizePath(sourceDirToCopy);
-	    Path projectSource = Paths.get(sourceDirToCopy);
-	    if (!Files.exists(projectSource)) {
-	        classLogger.warn("Project app root does not exist for readOnlyCopyProject: " + sourceDirToCopy);
-	        return;
-	    }
-        Path projectTarget = Paths.get(userChrootFolder).resolve(sourceDirToCopy.substring(1));
-        if (Files.exists(projectTarget)) {
-            classLogger.info("Chrooted project already copied, skipping copy for: " + projectTarget);
-            return;
-        }
-        try {
-            copyDirectoryRecursively(projectSource, projectTarget);
-            classLogger.info("Copied project from: " + projectSource);
-        } catch (IOException e) {
-            classLogger.debug("Could not copy project from: " + projectSource);
-        }
+		String sourceDirToCopy = AssetUtility.getProjectAppRootFolder(projectId);
+		sourceDirToCopy = Utility.normalizePath(sourceDirToCopy);
+		Path projectSource = Paths.get(sourceDirToCopy);
+		if (!Files.exists(projectSource)) {
+			classLogger.warn("Project app root does not exist for readOnlyCopyProject: " + sourceDirToCopy);
+			return;
+		}
+		Path projectTarget = Paths.get(userChrootFolder).resolve(sourceDirToCopy.substring(1));
+		if (Files.exists(projectTarget)) {
+			classLogger.info("Chrooted project already copied, skipping copy for: " + projectTarget);
+			return;
+		}
+		try {
+			copyDirectoryRecursively(projectSource, projectTarget);
+			classLogger.info("Copied project from: " + projectSource);
+		} catch (IOException e) {
+			classLogger.debug("Could not copy project from: " + projectSource);
+		}
 	}
-	
+
 	public void setAllReadExecuteForProject(String projectId) {
-	    String projectAppRootFolder = AssetUtility.getProjectAppRootFolder(projectId);
-	    projectAppRootFolder = Utility.normalizePath(projectAppRootFolder);
-	    Path chrootAppRoot = Paths.get(userChrootFolder, projectAppRootFolder.startsWith("/")
-	            ? projectAppRootFolder.substring(1) : projectAppRootFolder);
+		String projectAppRootFolder = AssetUtility.getProjectAppRootFolder(projectId);
+		projectAppRootFolder = Utility.normalizePath(projectAppRootFolder);
+		Path chrootAppRoot = Paths.get(userChrootFolder, projectAppRootFolder.startsWith("/")
+				? projectAppRootFolder.substring(1)
+				: projectAppRootFolder);
 
-	    if (!Files.exists(chrootAppRoot)) {
-	        classLogger.warn("Chrooted app root does not exist for project: " + chrootAppRoot);
-	        return;
-	    }
+		if (!Files.exists(chrootAppRoot)) {
+			classLogger.warn("Chrooted app root does not exist for project: " + chrootAppRoot);
+			return;
+		}
 
-	    try {
-	        Files.walkFileTree(chrootAppRoot, new SimpleFileVisitor<Path>() {
-	            @Override
-	            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-	                setOwnerRX(dir);
-	                return FileVisitResult.CONTINUE;
-	            }
-	            @Override
-	            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-	                setOwnerRX(file);
-	                return FileVisitResult.CONTINUE;
-	            }
-	        });
-	    } catch (IOException e) {
-	        classLogger.error("Failed to set r-x permissions on project: " + chrootAppRoot, e);
-	    }
+		try {
+			Files.walkFileTree(chrootAppRoot, new SimpleFileVisitor<Path>() {
+				@Override
+				public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+					setOwnerRX(dir);
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+					setOwnerRX(file);
+					return FileVisitResult.CONTINUE;
+				}
+			});
+		} catch (IOException e) {
+			classLogger.error("Failed to set r-x permissions on project: " + chrootAppRoot, e);
+		}
 	}
-	
 
-
-        
 	public void setExecuteOnlyOnAssetCodeFolders(String projectId) {
-	    String assetsFolderPath = AssetUtility.getProjectAssetsFolder(projectId);
-	    assetsFolderPath = Utility.normalizePath(assetsFolderPath);
-	    Path chrootAssetsFolder = Paths.get(userChrootFolder, assetsFolderPath.startsWith("/")
-	            ? assetsFolderPath.substring(1) : assetsFolderPath);
+		String assetsFolderPath = AssetUtility.getProjectAssetsFolder(projectId);
+		assetsFolderPath = Utility.normalizePath(assetsFolderPath);
+		Path chrootAssetsFolder = Paths.get(userChrootFolder, assetsFolderPath.startsWith("/")
+				? assetsFolderPath.substring(1)
+				: assetsFolderPath);
 
-	    if (!Files.exists(chrootAssetsFolder)) {
-	        classLogger.warn("Chroot assets folder does not exist: " + chrootAssetsFolder);
-	        return;
-	    }
+		if (!Files.exists(chrootAssetsFolder)) {
+			classLogger.warn("Chroot assets folder does not exist: " + chrootAssetsFolder);
+			return;
+		}
 
-	    String[] codeDirs = { "java", "classes", "py" };
-	    for (String dirName : codeDirs) {
-	        Path subDir = chrootAssetsFolder.resolve(dirName);
-	        if (Files.exists(subDir)) {
-	            try {
-	                Files.walkFileTree(subDir, new SimpleFileVisitor<Path>() {
-	                    @Override
-	                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-	                        Files.setPosixFilePermissions(dir, EnumSet.of(
-	                            PosixFilePermission.OWNER_EXECUTE,
-	                            PosixFilePermission.GROUP_EXECUTE,
-	                            PosixFilePermission.OTHERS_EXECUTE
-	                        ));
-	                        return FileVisitResult.CONTINUE;
-	                    }
-	                    @Override
-	                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-	                        Files.setPosixFilePermissions(file, EnumSet.of(
-	                            PosixFilePermission.OWNER_EXECUTE,
-	                            PosixFilePermission.GROUP_EXECUTE,
-	                            PosixFilePermission.OTHERS_EXECUTE
-	                        ));
-	                        return FileVisitResult.CONTINUE;
-	                    }
-	                });
-	            } catch (IOException e) {
-	                classLogger.warn("Failed to set execute-only on: " + subDir, e);
-	            }
-	        }
-	    }
+		String[] codeDirs = { "java", "classes", "py" };
+		for (String dirName : codeDirs) {
+			Path subDir = chrootAssetsFolder.resolve(dirName);
+			if (Files.exists(subDir)) {
+				try {
+					Files.walkFileTree(subDir, new SimpleFileVisitor<Path>() {
+						@Override
+						public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+								throws IOException {
+							Files.setPosixFilePermissions(dir, EnumSet.of(
+									PosixFilePermission.OWNER_EXECUTE,
+									PosixFilePermission.GROUP_EXECUTE,
+									PosixFilePermission.OTHERS_EXECUTE));
+							return FileVisitResult.CONTINUE;
+						}
+
+						@Override
+						public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+							Files.setPosixFilePermissions(file, EnumSet.of(
+									PosixFilePermission.OWNER_EXECUTE,
+									PosixFilePermission.GROUP_EXECUTE,
+									PosixFilePermission.OTHERS_EXECUTE));
+							return FileVisitResult.CONTINUE;
+						}
+					});
+				} catch (IOException e) {
+					classLogger.warn("Failed to set execute-only on: " + subDir, e);
+				}
+			}
+		}
 	}
-
 
 }

--- a/src/prerna/util/SymlinkHelper.java
+++ b/src/prerna/util/SymlinkHelper.java
@@ -56,6 +56,7 @@ public class SymlinkHelper {
 
 	/**
 	 * This will be username__uuid - ex. /opt/kunalppatel9__a123123
+	 * 
 	 * @param targetDirName
 	 */
 	public SymlinkHelper(String targetDirName) {
@@ -81,31 +82,31 @@ public class SymlinkHelper {
 	 * Initialization for cross-platform support
 	 */
 	private void initalizeChrootFolder() {
-	    String baseFolder = Utility.getBaseFolder();
-	    symlinkFolder(baseFolder + "/" + Constants.PY_BASE_FOLDER);
-	    symlinkFolder(Utility.getDIHelperProperty(Constants.INSIGHT_CACHE_DIR));
-	    
-	    // Read paths from DIHelper or configuration
-	    String pathsToSymlink = Utility.getDIHelperProperty("CHROOT_SYMLINK_PATHS");
-	    if (pathsToSymlink != null && !pathsToSymlink.isEmpty()) {
-	        String[] paths = pathsToSymlink.split(",");
-	        for (String path : paths) {
-	            symlinkFolder(path.trim());
-	        }
-	    } else {
-	        classLogger.warn("No paths specified for symlinking.");
-	    }
+		String baseFolder = Utility.getBaseFolder();
+		symlinkFolder(baseFolder + "/" + Constants.PY_BASE_FOLDER);
+		symlinkFolder(Utility.getDIHelperProperty(Constants.INSIGHT_CACHE_DIR));
 
-	    createChrootDirectory("/root");
-	    createChrootDirectory("/home/default");
-	    
-	    // Set proper ownership for home directories
-	    setDirectoryOwnership("/home/default", "1001", "1001");
-	    
-	    // Setup basic shell environment
-	    setupBashForChroot();
-	    // Setup Git
-	    setupGitForChroot();
+		// Read paths from DIHelper or configuration
+		String pathsToSymlink = Utility.getDIHelperProperty("CHROOT_SYMLINK_PATHS");
+		if (pathsToSymlink != null && !pathsToSymlink.isEmpty()) {
+			String[] paths = pathsToSymlink.split(",");
+			for (String path : paths) {
+				symlinkFolder(path.trim());
+			}
+		} else {
+			classLogger.warn("No paths specified for symlinking.");
+		}
+
+		createChrootDirectory("/root");
+		createChrootDirectory("/home/default");
+
+		// Set proper ownership for home directories
+		setDirectoryOwnership("/home/default", "1001", "1001");
+
+		// Setup basic shell environment
+		setupBashForChroot();
+		// Setup Git
+		setupGitForChroot();
 	}
 
 	/**
@@ -136,13 +137,13 @@ public class SymlinkHelper {
 				copySystemBinary(cmd); // copies symlink
 				copyRequiredLibraries(cmd); // mostly no-op, since all point to coreutils
 			}
-			
-	        // Add whoami and id commands
-	        String[] identityCommands = { "/usr/bin/whoami", "/usr/bin/id" };
-	        for (String cmd : identityCommands) {
-	            copySystemBinary(cmd);
-	            copyRequiredLibraries(cmd);
-	        }
+
+			// Add whoami and id commands
+			String[] identityCommands = { "/usr/bin/whoami", "/usr/bin/id" };
+			for (String cmd : identityCommands) {
+				copySystemBinary(cmd);
+				copyRequiredLibraries(cmd);
+			}
 
 			classLogger.info("Bash and essential commands setup completed for chroot: " + userChrootFolder);
 		} catch (Exception e) {
@@ -152,6 +153,7 @@ public class SymlinkHelper {
 
 	/**
 	 * Create a directory inside the chroot environment
+	 * 
 	 * @param relativePath
 	 */
 	private void createChrootDirectory(String relativePath) {
@@ -166,6 +168,7 @@ public class SymlinkHelper {
 
 	/**
 	 * Copy a system binary to the chroot environment
+	 * 
 	 * @param binaryPath
 	 */
 	private void copySystemBinary(String binaryPath) {
@@ -195,6 +198,7 @@ public class SymlinkHelper {
 
 	/**
 	 * Copy required shared libraries for bash using ldd command
+	 * 
 	 * @param binaryPath
 	 */
 	private void copyRequiredLibraries(String binaryPath) {
@@ -235,6 +239,7 @@ public class SymlinkHelper {
 
 	/**
 	 * Copy a single library to the chroot environment
+	 * 
 	 * @param libraryPath
 	 */
 	private void copyLibraryIfExists(String libraryPath) {
@@ -264,261 +269,261 @@ public class SymlinkHelper {
 	 * and required helper programs for both RHEL/UBI and Ubuntu systems.
 	 */
 	private void setupGitForChroot() {
-	    try {
-	        // Main git binary
-	        copySystemBinary("/usr/bin/git");
-	        copyRequiredLibraries("/usr/bin/git");
+		try {
+			// Main git binary
+			copySystemBinary("/usr/bin/git");
+			copyRequiredLibraries("/usr/bin/git");
 
-	        // Setup git helpers (handles both RHEL and Ubuntu)
-	        setupGitHelpersForCrossPlatform();
+			// Setup git helpers (handles both RHEL and Ubuntu)
+			setupGitHelpersForCrossPlatform();
 
-	        // Setup essential binaries for git operations
-	        setupGitEssentialBinaries();
+			// Setup essential binaries for git operations
+			setupGitEssentialBinaries();
 
-	        // Setup git templates
-	        setupGitTemplatesForCrossPlatform();
+			// Setup git templates
+			setupGitTemplatesForCrossPlatform();
 
-	        // Setup SSL certificates (handles both RHEL and Ubuntu)
-	        setupSSLCertsForCrossPlatform();
+			// Setup SSL certificates (handles both RHEL and Ubuntu)
+			setupSSLCertsForCrossPlatform();
 
-	        // Create necessary directories
-	        createChrootDirectory("/tmp");
-	        createChrootDirectory("/var/tmp");
-	        createChrootDirectory("/etc/git");
+			// Create necessary directories
+			createChrootDirectory("/tmp");
+			createChrootDirectory("/var/tmp");
+			createChrootDirectory("/etc/git");
 
-	        classLogger.info("Git setup completed for chroot: " + userChrootFolder);
+			classLogger.info("Git setup completed for chroot: " + userChrootFolder);
 
-	    } catch (Exception e) {
-	        classLogger.error("Error setting up git for chroot: " + e.getMessage(), e);
-	    }
+		} catch (Exception e) {
+			classLogger.error("Error setting up git for chroot: " + e.getMessage(), e);
+		}
 	}
 
 	/**
 	 * Setup git helper programs for both RHEL/UBI and Ubuntu systems
 	 */
 	private void setupGitHelpersForCrossPlatform() {
-	    try {
-	        // Try RHEL/UBI path first
-	        Path gitHelpersHost = Paths.get("/usr/libexec/git-core");
-	        Path gitHelpersChroot = Paths.get(userChrootFolder).resolve("usr/libexec/git-core");
-	        
-	        if (Files.exists(gitHelpersHost)) {
-	            copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
-	            classLogger.info("Copied git helpers from RHEL/UBI location: " + gitHelpersHost);
-	        } else {
-	            // Fallback to Ubuntu path
-	            gitHelpersHost = Paths.get("/usr/lib/git-core");
-	            gitHelpersChroot = Paths.get(userChrootFolder).resolve("usr/lib/git-core");
-	            
-	            if (Files.exists(gitHelpersHost)) {
-	                copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
-	                classLogger.info("Copied git helpers from Ubuntu location: " + gitHelpersHost);
-	            } else {
-	                classLogger.warn("Git helpers directory not found at expected locations");
-	                // Try to find git helpers using git itself
-	                findAndCopyGitHelpers();
-	            }
-	        }
-	    } catch (IOException e) {
-	        classLogger.error("Error setting up git helpers: " + e.getMessage(), e);
-	    }
+		try {
+			// Try RHEL/UBI path first
+			Path gitHelpersHost = Paths.get("/usr/libexec/git-core");
+			Path gitHelpersChroot = Paths.get(userChrootFolder).resolve("usr/libexec/git-core");
+
+			if (Files.exists(gitHelpersHost)) {
+				copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
+				classLogger.info("Copied git helpers from RHEL/UBI location: " + gitHelpersHost);
+			} else {
+				// Fallback to Ubuntu path
+				gitHelpersHost = Paths.get("/usr/lib/git-core");
+				gitHelpersChroot = Paths.get(userChrootFolder).resolve("usr/lib/git-core");
+
+				if (Files.exists(gitHelpersHost)) {
+					copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
+					classLogger.info("Copied git helpers from Ubuntu location: " + gitHelpersHost);
+				} else {
+					classLogger.warn("Git helpers directory not found at expected locations");
+					// Try to find git helpers using git itself
+					findAndCopyGitHelpers();
+				}
+			}
+		} catch (IOException e) {
+			classLogger.error("Error setting up git helpers: " + e.getMessage(), e);
+		}
 	}
 
 	/**
 	 * Find git helpers using git --exec-path command
 	 */
 	private void findAndCopyGitHelpers() {
-	    try {
-	        ProcessBuilder pb = new ProcessBuilder("git", "--exec-path");
-	        Process process = pb.start();
-	        
-	        try (java.io.BufferedReader reader = new java.io.BufferedReader(
-	                new java.io.InputStreamReader(process.getInputStream()))) {
-	            
-	            String gitExecPath = reader.readLine();
-	            if (gitExecPath != null && !gitExecPath.trim().isEmpty()) {
-	                Path gitHelpersHost = Paths.get(gitExecPath.trim());
-	                Path gitHelpersChroot = Paths.get(userChrootFolder).resolve(gitExecPath.substring(1));
-	                
-	                if (Files.exists(gitHelpersHost)) {
-	                    copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
-	                    classLogger.info("Found and copied git helpers from: " + gitExecPath);
-	                }
-	            }
-	        }
-	        
-	        process.waitFor();
-	    } catch (Exception e) {
-	        classLogger.warn("Could not find git helpers using git --exec-path: " + e.getMessage());
-	    }
+		try {
+			ProcessBuilder pb = new ProcessBuilder("git", "--exec-path");
+			Process process = pb.start();
+
+			try (java.io.BufferedReader reader = new java.io.BufferedReader(
+					new java.io.InputStreamReader(process.getInputStream()))) {
+
+				String gitExecPath = reader.readLine();
+				if (gitExecPath != null && !gitExecPath.trim().isEmpty()) {
+					Path gitHelpersHost = Paths.get(gitExecPath.trim());
+					Path gitHelpersChroot = Paths.get(userChrootFolder).resolve(gitExecPath.substring(1));
+
+					if (Files.exists(gitHelpersHost)) {
+						copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
+						classLogger.info("Found and copied git helpers from: " + gitExecPath);
+					}
+				}
+			}
+
+			process.waitFor();
+		} catch (Exception e) {
+			classLogger.warn("Could not find git helpers using git --exec-path: " + e.getMessage());
+		}
 	}
 
 	/**
 	 * Setup essential binaries for git operations on both platforms
 	 */
 	private void setupGitEssentialBinaries() {
-	    String[] essentialBinaries = {
-	        "/usr/bin/curl",      // Required for git-remote-https
-	        "/usr/bin/ssh",       // For git@... URLs  
-	        "/bin/tar",           // Archive operations
-	        "/bin/gzip",          // Compression
-	        "/usr/bin/openssl",   // SSL/TLS operations
-	        "/usr/bin/wget"       // Alternative HTTP client
-	    };
+		String[] essentialBinaries = {
+				"/usr/bin/curl", // Required for git-remote-https
+				"/usr/bin/ssh", // For git@... URLs
+				"/bin/tar", // Archive operations
+				"/bin/gzip", // Compression
+				"/usr/bin/openssl", // SSL/TLS operations
+				"/usr/bin/wget" // Alternative HTTP client
+		};
 
-	    for (String bin : essentialBinaries) {
-	        if (Files.exists(Paths.get(bin))) {
-	            copySystemBinary(bin);
-	            copyRequiredLibraries(bin);
-	            classLogger.debug("Copied git dependency: " + bin);
-	        } else {
-	            classLogger.debug("Optional git dependency not found: " + bin);
-	        }
-	    }
-	    
-	    // Copy git-specific libraries that might be needed
-	    copyGitSpecificLibraries();
+		for (String bin : essentialBinaries) {
+			if (Files.exists(Paths.get(bin))) {
+				copySystemBinary(bin);
+				copyRequiredLibraries(bin);
+				classLogger.debug("Copied git dependency: " + bin);
+			} else {
+				classLogger.debug("Optional git dependency not found: " + bin);
+			}
+		}
+
+		// Copy git-specific libraries that might be needed
+		copyGitSpecificLibraries();
 	}
 
 	/**
 	 * Copy git-specific libraries for both RHEL and Ubuntu
 	 */
 	private void copyGitSpecificLibraries() {
-	    // RHEL/UBI library paths
-	    String[] rhelLibs = {
-	        "/usr/lib64/libcurl.so.4",
-	        "/usr/lib64/libssl.so.3",
-	        "/usr/lib64/libcrypto.so.3",
-	        "/usr/lib64/libz.so.1",
-	        "/usr/lib64/libgssapi_krb5.so.2"
-	    };
-	    
-	    // Ubuntu library paths
-	    String[] ubuntuLibs = {
-	        "/usr/lib/x86_64-linux-gnu/libcurl.so.4",
-	        "/usr/lib/x86_64-linux-gnu/libssl.so.3",
-	        "/usr/lib/x86_64-linux-gnu/libcrypto.so.3",
-	        "/usr/lib/x86_64-linux-gnu/libz.so.1"
-	    };
-	    
-	    // Try RHEL paths first
-	    boolean foundRhelLibs = false;
-	    for (String lib : rhelLibs) {
-	        if (Files.exists(Paths.get(lib))) {
-	            copyLibraryIfExists(lib);
-	            foundRhelLibs = true;
-	        }
-	    }
-	    
-	    // If no RHEL libs found, try Ubuntu paths
-	    if (!foundRhelLibs) {
-	        for (String lib : ubuntuLibs) {
-	            copyLibraryIfExists(lib);
-	        }
-	    }
+		// RHEL/UBI library paths
+		String[] rhelLibs = {
+				"/usr/lib64/libcurl.so.4",
+				"/usr/lib64/libssl.so.3",
+				"/usr/lib64/libcrypto.so.3",
+				"/usr/lib64/libz.so.1",
+				"/usr/lib64/libgssapi_krb5.so.2"
+		};
+
+		// Ubuntu library paths
+		String[] ubuntuLibs = {
+				"/usr/lib/x86_64-linux-gnu/libcurl.so.4",
+				"/usr/lib/x86_64-linux-gnu/libssl.so.3",
+				"/usr/lib/x86_64-linux-gnu/libcrypto.so.3",
+				"/usr/lib/x86_64-linux-gnu/libz.so.1"
+		};
+
+		// Try RHEL paths first
+		boolean foundRhelLibs = false;
+		for (String lib : rhelLibs) {
+			if (Files.exists(Paths.get(lib))) {
+				copyLibraryIfExists(lib);
+				foundRhelLibs = true;
+			}
+		}
+
+		// If no RHEL libs found, try Ubuntu paths
+		if (!foundRhelLibs) {
+			for (String lib : ubuntuLibs) {
+				copyLibraryIfExists(lib);
+			}
+		}
 	}
 
 	/**
 	 * Setup git templates for cross-platform compatibility
 	 */
 	private void setupGitTemplatesForCrossPlatform() {
-	    String[] templatePaths = {
-	        "/usr/share/git-core/templates",  // Common location
-	        "/usr/local/share/git-core/templates"  // Alternative location
-	    };
-	    
-	    for (String templatePath : templatePaths) {
-	        Path templatesSource = Paths.get(templatePath);
-	        if (Files.exists(templatesSource)) {
-	            Path templatesTarget = Paths.get(userChrootFolder).resolve(templatePath.substring(1));
-	            try {
-	                copyDirectoryRecursively(templatesSource, templatesTarget);
-	                classLogger.info("Copied git templates from: " + templatePath);
-	                break; // Only copy the first one found
-	            } catch (IOException e) {
-	                classLogger.debug("Could not copy git templates from: " + templatePath);
-	            }
-	        }
-	    }
+		String[] templatePaths = {
+				"/usr/share/git-core/templates", // Common location
+				"/usr/local/share/git-core/templates" // Alternative location
+		};
+
+		for (String templatePath : templatePaths) {
+			Path templatesSource = Paths.get(templatePath);
+			if (Files.exists(templatesSource)) {
+				Path templatesTarget = Paths.get(userChrootFolder).resolve(templatePath.substring(1));
+				try {
+					copyDirectoryRecursively(templatesSource, templatesTarget);
+					classLogger.info("Copied git templates from: " + templatePath);
+					break; // Only copy the first one found
+				} catch (IOException e) {
+					classLogger.debug("Could not copy git templates from: " + templatePath);
+				}
+			}
+		}
 	}
 
 	/**
 	 * Setup SSL certificates for both RHEL/UBI and Ubuntu systems
 	 */
 	private void setupSSLCertsForCrossPlatform() {
-	    try {
-	        // Detect OS type and setup accordingly
-	    	boolean isRHELBased = isRHELBasedSystem();
-	        if (isRHELBased) {
-	        	classLogger.info("Predicted OS as RHEL");
-	            setupSSLCertsForRHEL();
-	        } else {
-	        	classLogger.info("Predicted OS as Ubuntu");
-	            setupSSLCertsForUbuntu();
-	        }
-	    } catch (Exception e) {
-	        classLogger.warn("Could not setup SSL certificates: " + e.getMessage());
-	        // Try both approaches as fallback
-	        setupSSLCertsForRHEL();
-	        setupSSLCertsForUbuntu();
-	    }
+		try {
+			// Detect OS type and setup accordingly
+			boolean isRHELBased = isRHELBasedSystem();
+			if (isRHELBased) {
+				classLogger.info("Predicted OS as RHEL");
+				setupSSLCertsForRHEL();
+			} else {
+				classLogger.info("Predicted OS as Ubuntu");
+				setupSSLCertsForUbuntu();
+			}
+		} catch (Exception e) {
+			classLogger.warn("Could not setup SSL certificates: " + e.getMessage());
+			// Try both approaches as fallback
+			setupSSLCertsForRHEL();
+			setupSSLCertsForUbuntu();
+		}
 	}
 
 	/**
 	 * Detect if the system is RHEL-based
 	 */
 	private boolean isRHELBasedSystem() {
-	    // Check for RHEL-specific files/directories
-	    return Files.exists(Paths.get("/etc/redhat-release")) ||
-	           Files.exists(Paths.get("/etc/rhel-release")) ||
-	           Files.exists(Paths.get("/etc/pki"));
+		// Check for RHEL-specific files/directories
+		return Files.exists(Paths.get("/etc/redhat-release")) ||
+				Files.exists(Paths.get("/etc/rhel-release")) ||
+				Files.exists(Paths.get("/etc/pki"));
 	}
 
 	/**
 	 * Setup SSL certificates for RHEL/UBI systems
 	 */
 	private void setupSSLCertsForRHEL() {
-	    try {
-	        String[] caCertFiles = {
-	            "/etc/pki/tls/certs/ca-bundle.crt",
-	            "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
-	            "/etc/pki/tls/cert.pem"
-	        };
+		try {
+			String[] caCertFiles = {
+					"/etc/pki/tls/certs/ca-bundle.crt",
+					"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+					"/etc/pki/tls/cert.pem"
+			};
 
-	        // Copy CA certificate files
-	        for (String certPath : caCertFiles) {
-	            Path sourceCerts = Paths.get(certPath);
-	            if (Files.exists(sourceCerts)) {
-	                Path targetCerts = Paths.get(userChrootFolder).resolve(certPath.substring(1));
-	                Files.createDirectories(targetCerts.getParent());
-	                Files.copy(sourceCerts, targetCerts, StandardCopyOption.REPLACE_EXISTING);
-	                classLogger.info("Copied RHEL CA certificates from: " + certPath);
-	            } else {
+			// Copy CA certificate files
+			for (String certPath : caCertFiles) {
+				Path sourceCerts = Paths.get(certPath);
+				if (Files.exists(sourceCerts)) {
+					Path targetCerts = Paths.get(userChrootFolder).resolve(certPath.substring(1));
+					Files.createDirectories(targetCerts.getParent());
+					Files.copy(sourceCerts, targetCerts, StandardCopyOption.REPLACE_EXISTING);
+					classLogger.info("Copied RHEL CA certificates from: " + certPath);
+				} else {
 					classLogger.warn("Could not find file at " + certPath);
 				}
-	        }
+			}
 
-	        // Copy certificate directories
-	        String[] certDirs = {
-	            "/etc/pki/tls/certs",
-	            "/etc/pki/ca-trust/extracted",
-	            "/etc/pki/tls"
-	        };
+			// Copy certificate directories
+			String[] certDirs = {
+					"/etc/pki/tls/certs",
+					"/etc/pki/ca-trust/extracted",
+					"/etc/pki/tls"
+			};
 
-	        for (String certDir : certDirs) {
-	            Path sourceCertDir = Paths.get(certDir);
-	            if (Files.exists(sourceCertDir)) {
-	                Path targetCertDir = Paths.get(userChrootFolder).resolve(certDir.substring(1));
-	                copyDirectoryRecursively(sourceCertDir, targetCertDir);
-	                classLogger.debug("Copied RHEL certificate directory: " + certDir);
-	            } else {
+			for (String certDir : certDirs) {
+				Path sourceCertDir = Paths.get(certDir);
+				if (Files.exists(sourceCertDir)) {
+					Path targetCertDir = Paths.get(userChrootFolder).resolve(certDir.substring(1));
+					copyDirectoryRecursively(sourceCertDir, targetCertDir);
+					classLogger.debug("Copied RHEL certificate directory: " + certDir);
+				} else {
 					classLogger.warn("Could not find directory at " + certDir);
-	            }
-	        }
+				}
+			}
 
-	    } catch (IOException e) {
-	        classLogger.debug("Could not setup RHEL SSL certificates: " + e.getMessage());
-	    }
+		} catch (IOException e) {
+			classLogger.debug("Could not setup RHEL SSL certificates: " + e.getMessage());
+		}
 	}
 
 	/**
@@ -534,7 +539,8 @@ public class SymlinkHelper {
 				if (Files.exists(sourceCerts)) {
 					Path targetCerts = Paths.get(userChrootFolder).resolve(certPath.substring(1));
 					Files.createDirectories(targetCerts.getParent());
-					Files.copy(sourceCerts, targetCerts, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
+					Files.copy(sourceCerts, targetCerts, StandardCopyOption.REPLACE_EXISTING,
+							StandardCopyOption.COPY_ATTRIBUTES);
 					classLogger.info("Copied Ubuntu CA certificates from: " + certPath);
 				} else {
 					classLogger.warn("Could not find file at " + certPath);
@@ -544,46 +550,46 @@ public class SymlinkHelper {
 			// Copy certificate directories with symlink preservation
 			String[] certDirs = { "/etc/ssl/certs", "/usr/share/ca-certificates" };
 			for (String certDir : certDirs) {
-	            Path sourceCertDir = Paths.get(certDir);
-	            if (Files.exists(sourceCertDir)) {
-	                Path targetCertDir = Paths.get(userChrootFolder).resolve(certDir.substring(1));
-	                copyDirectoryRecursively(sourceCertDir, targetCertDir);
+				Path sourceCertDir = Paths.get(certDir);
+				if (Files.exists(sourceCertDir)) {
+					Path targetCertDir = Paths.get(userChrootFolder).resolve(certDir.substring(1));
+					copyDirectoryRecursively(sourceCertDir, targetCertDir);
 					classLogger.debug("Copied Ubuntu certificate directory (with symlinks): " + certDir);
-	            } else {
+				} else {
 					classLogger.warn("Could not find directory at " + certDir);
-	            }
-	        }
+				}
+			}
 		} catch (IOException e) {
 			classLogger.debug("Could not setup Ubuntu SSL certificates: " + e.getMessage());
 		}
 	}
-	
+
 	/**
 	 * Set ownership of a directory in chroot (works on both platforms)
 	 */
 	private void setDirectoryOwnership(String relativePath, String uid, String gid) {
-	    try {
-	        Path chrootDir = Paths.get(userChrootFolder, relativePath);
-	        if (Files.exists(chrootDir)) {
-	            ProcessBuilder pb = new ProcessBuilder("chown", uid + ":" + gid, chrootDir.toString());
-	            Process process = pb.start();
-	            int exitCode = process.waitFor();
-	            if (exitCode == 0) {
-	                classLogger.debug("Set ownership " + uid + ":" + gid + " for: " + relativePath);
-	            } else {
-	                classLogger.warn("Could not set ownership for: " + relativePath + " (exit code: " + exitCode + ")");
-	            }
-	        }
-	    } catch (Exception e) {
-	        classLogger.warn("Could not set ownership for: " + relativePath, e);
-	    }
+		try {
+			Path chrootDir = Paths.get(userChrootFolder, relativePath);
+			if (Files.exists(chrootDir)) {
+				ProcessBuilder pb = new ProcessBuilder("chown", uid + ":" + gid, chrootDir.toString());
+				Process process = pb.start();
+				int exitCode = process.waitFor();
+				if (exitCode == 0) {
+					classLogger.debug("Set ownership " + uid + ":" + gid + " for: " + relativePath);
+				} else {
+					classLogger.warn("Could not set ownership for: " + relativePath + " (exit code: " + exitCode + ")");
+				}
+			}
+		} catch (Exception e) {
+			classLogger.warn("Could not set ownership for: " + relativePath, e);
+		}
 	}
 
 	/**
 	 * Copy an entire directory recursively into the chroot, preserving structure.
 	 */
 	private void copyDirectoryRecursively(Path source, Path target) throws IOException {
-		if(source.toFile().exists()) {
+		if (source.toFile().exists()) {
 			Files.walk(source).forEach(src -> {
 				try {
 					Path dest = target.resolve(source.relativize(src));
@@ -598,7 +604,6 @@ public class SymlinkHelper {
 			});
 		}
 	}
-
 
 	/**
 	 * 
@@ -665,159 +670,155 @@ public class SymlinkHelper {
 		}
 	}
 
-	
 	public void symlinkUserAsset(User user) {
-	    AuthProvider provider = user.getPrimaryLogin();
-	    String projectId = user.getAssetProjectId(provider);
-	    String assetFolder = AssetUtility.getUserAssetAndWorkspaceAppRootFolder("Asset", projectId);
-	    classLogger.info("Symlinking user asset folder for projectId=" + projectId);
-	    symlinkFolder(assetFolder);
+		AuthProvider provider = user.getPrimaryLogin();
+		String projectId = user.getAssetProjectId(provider);
+		String assetFolder = AssetUtility.getUserAssetAndWorkspaceAppRootFolder("Asset", projectId);
+		classLogger.info("Symlinking user asset folder for projectId=" + projectId);
+		symlinkFolder(assetFolder);
 	}
 
 	public void symlinkProject(User user, String projectId) {
-	    classLogger.info("Symlinking project for projectId=" + projectId);
+		classLogger.info("Symlinking project for projectId=" + projectId);
 
-	    String projectAppRootFolder = AssetUtility.getProjectAppRootFolder(projectId);
+		String projectAppRootFolder = AssetUtility.getProjectAppRootFolder(projectId);
 
-	    if (SecurityProjectUtils.userCanEditProject(user, projectId)) {
-	        symlinkFolder(projectAppRootFolder);
-	        return;
-	    }
+		if (SecurityProjectUtils.userCanEditProject(user, projectId)) {
+			symlinkFolder(projectAppRootFolder);
+			return;
+		}
 
-	    boolean readOnlyCopyEnabled = Boolean.parseBoolean(
-	        Utility.getDIHelperProperty(Constants.CHROOT_READ_ONLY_COPY)
-	    );
+		boolean readOnlyCopyEnabled = Boolean.parseBoolean(
+				Utility.getDIHelperProperty(Constants.CHROOT_READ_ONLY_COPY));
 
-	    if (readOnlyCopyEnabled) {
-	        Path projectTarget = Paths.get(userChrootFolder).resolve(Utility.normalizePath(projectAppRootFolder).substring(1));
-	        if (Files.exists(projectTarget)) {
-	            classLogger.info("Chrooted project already copied for projectId=" + projectId +
-	                             " at: " + projectTarget + ", skipping copy and permission patch.");
-	            return;
-	        }
-	        
-	        classLogger.info("Symlinking read-only copy for projectId=" + projectId);
-	        setupCopiedProject(projectId);
-	        setAllReadExecuteForProject(projectId);
-	        // below does not work - commenting out for now
-			//setExecuteOnlyOnAssetCodeFolders(projectId);
-	    } else {
-	        classLogger.info("Symlinking full folder for read-only user, projectId=" + projectId);
-	        symlinkFolder(projectAppRootFolder);
-	    }
+		if (readOnlyCopyEnabled) {
+			Path projectTarget = Paths.get(userChrootFolder)
+					.resolve(Utility.normalizePath(projectAppRootFolder).substring(1));
+			if (Files.exists(projectTarget)) {
+				classLogger.info("Chrooted project already copied for projectId=" + projectId +
+						" at: " + projectTarget + ", skipping copy and permission patch.");
+				return;
+			}
+
+			classLogger.info("Symlinking read-only copy for projectId=" + projectId);
+			setupCopiedProject(projectId);
+			setAllReadExecuteForProject(projectId);
+			// below does not work - commenting out for now
+			// setExecuteOnlyOnAssetCodeFolders(projectId);
+		} else {
+			classLogger.info("Symlinking full folder for read-only user, projectId=" + projectId);
+			symlinkFolder(projectAppRootFolder);
+		}
 	}
-	
+
 	private void setOwnerRWX(Path dir) throws IOException {
-	    Files.setPosixFilePermissions(dir, EnumSet.of(
-	        PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
-	        PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
-	        PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
-	    ));
+		Files.setPosixFilePermissions(dir, EnumSet.of(
+				PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
+				PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
+				PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE));
 	}
 
 	private void setOwnerRX(Path dir) throws IOException {
-	    Files.setPosixFilePermissions(dir, EnumSet.of(
-	        PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE,
-	        PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
-	        PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
-	    ));
+		Files.setPosixFilePermissions(dir, EnumSet.of(
+				PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE,
+				PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
+				PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE));
 	}
-	
+
 	private void setupCopiedProject(String projectId) {
-	    String sourceDirToCopy = AssetUtility.getProjectAppRootFolder(projectId);
-	    sourceDirToCopy = Utility.normalizePath(sourceDirToCopy);
-	    Path projectSource = Paths.get(sourceDirToCopy);
-	    if (!Files.exists(projectSource)) {
-	        classLogger.warn("Project app root does not exist for readOnlyCopyProject: " + sourceDirToCopy);
-	        return;
-	    }
-        Path projectTarget = Paths.get(userChrootFolder).resolve(sourceDirToCopy.substring(1));
-        if (Files.exists(projectTarget)) {
-            classLogger.info("Chrooted project already copied, skipping copy for: " + projectTarget);
-            return;
-        }
-        try {
-            copyDirectoryRecursively(projectSource, projectTarget);
-            classLogger.info("Copied project from: " + projectSource);
-        } catch (IOException e) {
-            classLogger.debug("Could not copy project from: " + projectSource);
-        }
+		String sourceDirToCopy = AssetUtility.getProjectAppRootFolder(projectId);
+		sourceDirToCopy = Utility.normalizePath(sourceDirToCopy);
+		Path projectSource = Paths.get(sourceDirToCopy);
+		if (!Files.exists(projectSource)) {
+			classLogger.warn("Project app root does not exist for readOnlyCopyProject: " + sourceDirToCopy);
+			return;
+		}
+		Path projectTarget = Paths.get(userChrootFolder).resolve(sourceDirToCopy.substring(1));
+		if (Files.exists(projectTarget)) {
+			classLogger.info("Chrooted project already copied, skipping copy for: " + projectTarget);
+			return;
+		}
+		try {
+			copyDirectoryRecursively(projectSource, projectTarget);
+			classLogger.info("Copied project from: " + projectSource);
+		} catch (IOException e) {
+			classLogger.debug("Could not copy project from: " + projectSource);
+		}
 	}
-	
+
 	public void setAllReadExecuteForProject(String projectId) {
-	    String projectAppRootFolder = AssetUtility.getProjectAppRootFolder(projectId);
-	    projectAppRootFolder = Utility.normalizePath(projectAppRootFolder);
-	    Path chrootAppRoot = Paths.get(userChrootFolder, projectAppRootFolder.startsWith("/")
-	            ? projectAppRootFolder.substring(1) : projectAppRootFolder);
+		String projectAppRootFolder = AssetUtility.getProjectAppRootFolder(projectId);
+		projectAppRootFolder = Utility.normalizePath(projectAppRootFolder);
+		Path chrootAppRoot = Paths.get(userChrootFolder, projectAppRootFolder.startsWith("/")
+				? projectAppRootFolder.substring(1)
+				: projectAppRootFolder);
 
-	    if (!Files.exists(chrootAppRoot)) {
-	        classLogger.warn("Chrooted app root does not exist for project: " + chrootAppRoot);
-	        return;
-	    }
+		if (!Files.exists(chrootAppRoot)) {
+			classLogger.warn("Chrooted app root does not exist for project: " + chrootAppRoot);
+			return;
+		}
 
-	    try {
-	        Files.walkFileTree(chrootAppRoot, new SimpleFileVisitor<Path>() {
-	            @Override
-	            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-	                setOwnerRX(dir);
-	                return FileVisitResult.CONTINUE;
-	            }
-	            @Override
-	            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-	                setOwnerRX(file);
-	                return FileVisitResult.CONTINUE;
-	            }
-	        });
-	    } catch (IOException e) {
-	        classLogger.error("Failed to set r-x permissions on project: " + chrootAppRoot, e);
-	    }
+		try {
+			Files.walkFileTree(chrootAppRoot, new SimpleFileVisitor<Path>() {
+				@Override
+				public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+					setOwnerRX(dir);
+					return FileVisitResult.CONTINUE;
+				}
+
+				@Override
+				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+					setOwnerRX(file);
+					return FileVisitResult.CONTINUE;
+				}
+			});
+		} catch (IOException e) {
+			classLogger.error("Failed to set r-x permissions on project: " + chrootAppRoot, e);
+		}
 	}
-	
 
-
-        
 	public void setExecuteOnlyOnAssetCodeFolders(String projectId) {
-	    String assetsFolderPath = AssetUtility.getProjectAssetsFolder(projectId);
-	    assetsFolderPath = Utility.normalizePath(assetsFolderPath);
-	    Path chrootAssetsFolder = Paths.get(userChrootFolder, assetsFolderPath.startsWith("/")
-	            ? assetsFolderPath.substring(1) : assetsFolderPath);
+		String assetsFolderPath = AssetUtility.getProjectAssetsFolder(projectId);
+		assetsFolderPath = Utility.normalizePath(assetsFolderPath);
+		Path chrootAssetsFolder = Paths.get(userChrootFolder, assetsFolderPath.startsWith("/")
+				? assetsFolderPath.substring(1)
+				: assetsFolderPath);
 
-	    if (!Files.exists(chrootAssetsFolder)) {
-	        classLogger.warn("Chroot assets folder does not exist: " + chrootAssetsFolder);
-	        return;
-	    }
+		if (!Files.exists(chrootAssetsFolder)) {
+			classLogger.warn("Chroot assets folder does not exist: " + chrootAssetsFolder);
+			return;
+		}
 
-	    String[] codeDirs = { "java", "classes", "py" };
-	    for (String dirName : codeDirs) {
-	        Path subDir = chrootAssetsFolder.resolve(dirName);
-	        if (Files.exists(subDir)) {
-	            try {
-	                Files.walkFileTree(subDir, new SimpleFileVisitor<Path>() {
-	                    @Override
-	                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-	                        Files.setPosixFilePermissions(dir, EnumSet.of(
-	                            PosixFilePermission.OWNER_EXECUTE,
-	                            PosixFilePermission.GROUP_EXECUTE,
-	                            PosixFilePermission.OTHERS_EXECUTE
-	                        ));
-	                        return FileVisitResult.CONTINUE;
-	                    }
-	                    @Override
-	                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-	                        Files.setPosixFilePermissions(file, EnumSet.of(
-	                            PosixFilePermission.OWNER_EXECUTE,
-	                            PosixFilePermission.GROUP_EXECUTE,
-	                            PosixFilePermission.OTHERS_EXECUTE
-	                        ));
-	                        return FileVisitResult.CONTINUE;
-	                    }
-	                });
-	            } catch (IOException e) {
-	                classLogger.warn("Failed to set execute-only on: " + subDir, e);
-	            }
-	        }
-	    }
+		String[] codeDirs = { "java", "classes", "py" };
+		for (String dirName : codeDirs) {
+			Path subDir = chrootAssetsFolder.resolve(dirName);
+			if (Files.exists(subDir)) {
+				try {
+					Files.walkFileTree(subDir, new SimpleFileVisitor<Path>() {
+						@Override
+						public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+								throws IOException {
+							Files.setPosixFilePermissions(dir, EnumSet.of(
+									PosixFilePermission.OWNER_EXECUTE,
+									PosixFilePermission.GROUP_EXECUTE,
+									PosixFilePermission.OTHERS_EXECUTE));
+							return FileVisitResult.CONTINUE;
+						}
+
+						@Override
+						public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+							Files.setPosixFilePermissions(file, EnumSet.of(
+									PosixFilePermission.OWNER_EXECUTE,
+									PosixFilePermission.GROUP_EXECUTE,
+									PosixFilePermission.OTHERS_EXECUTE));
+							return FileVisitResult.CONTINUE;
+						}
+					});
+				} catch (IOException e) {
+					classLogger.warn("Failed to set execute-only on: " + subDir, e);
+				}
+			}
+		}
 	}
-
 
 }

--- a/src/prerna/util/SymlinkHelper.java
+++ b/src/prerna/util/SymlinkHelper.java
@@ -56,7 +56,6 @@ public class SymlinkHelper {
 
 	/**
 	 * This will be username__uuid - ex. /opt/kunalppatel9__a123123
-	 * 
 	 * @param targetDirName
 	 */
 	public SymlinkHelper(String targetDirName) {
@@ -82,31 +81,31 @@ public class SymlinkHelper {
 	 * Initialization for cross-platform support
 	 */
 	private void initalizeChrootFolder() {
-		String baseFolder = Utility.getBaseFolder();
-		symlinkFolder(baseFolder + "/" + Constants.PY_BASE_FOLDER);
-		symlinkFolder(Utility.getDIHelperProperty(Constants.INSIGHT_CACHE_DIR));
+	    String baseFolder = Utility.getBaseFolder();
+	    symlinkFolder(baseFolder + "/" + Constants.PY_BASE_FOLDER);
+	    symlinkFolder(Utility.getDIHelperProperty(Constants.INSIGHT_CACHE_DIR));
+	    
+	    // Read paths from DIHelper or configuration
+	    String pathsToSymlink = Utility.getDIHelperProperty("CHROOT_SYMLINK_PATHS");
+	    if (pathsToSymlink != null && !pathsToSymlink.isEmpty()) {
+	        String[] paths = pathsToSymlink.split(",");
+	        for (String path : paths) {
+	            symlinkFolder(path.trim());
+	        }
+	    } else {
+	        classLogger.warn("No paths specified for symlinking.");
+	    }
 
-		// Read paths from DIHelper or configuration
-		String pathsToSymlink = Utility.getDIHelperProperty("CHROOT_SYMLINK_PATHS");
-		if (pathsToSymlink != null && !pathsToSymlink.isEmpty()) {
-			String[] paths = pathsToSymlink.split(",");
-			for (String path : paths) {
-				symlinkFolder(path.trim());
-			}
-		} else {
-			classLogger.warn("No paths specified for symlinking.");
-		}
-
-		createChrootDirectory("/root");
-		createChrootDirectory("/home/default");
-
-		// Set proper ownership for home directories
-		setDirectoryOwnership("/home/default", "1001", "1001");
-
-		// Setup basic shell environment
-		setupBashForChroot();
-		// Setup Git
-		setupGitForChroot();
+	    createChrootDirectory("/root");
+	    createChrootDirectory("/home/default");
+	    
+	    // Set proper ownership for home directories
+	    setDirectoryOwnership("/home/default", "1001", "1001");
+	    
+	    // Setup basic shell environment
+	    setupBashForChroot();
+	    // Setup Git
+	    setupGitForChroot();
 	}
 
 	/**
@@ -137,13 +136,13 @@ public class SymlinkHelper {
 				copySystemBinary(cmd); // copies symlink
 				copyRequiredLibraries(cmd); // mostly no-op, since all point to coreutils
 			}
-
-			// Add whoami and id commands
-			String[] identityCommands = { "/usr/bin/whoami", "/usr/bin/id" };
-			for (String cmd : identityCommands) {
-				copySystemBinary(cmd);
-				copyRequiredLibraries(cmd);
-			}
+			
+	        // Add whoami and id commands
+	        String[] identityCommands = { "/usr/bin/whoami", "/usr/bin/id" };
+	        for (String cmd : identityCommands) {
+	            copySystemBinary(cmd);
+	            copyRequiredLibraries(cmd);
+	        }
 
 			classLogger.info("Bash and essential commands setup completed for chroot: " + userChrootFolder);
 		} catch (Exception e) {
@@ -153,7 +152,6 @@ public class SymlinkHelper {
 
 	/**
 	 * Create a directory inside the chroot environment
-	 * 
 	 * @param relativePath
 	 */
 	private void createChrootDirectory(String relativePath) {
@@ -168,7 +166,6 @@ public class SymlinkHelper {
 
 	/**
 	 * Copy a system binary to the chroot environment
-	 * 
 	 * @param binaryPath
 	 */
 	private void copySystemBinary(String binaryPath) {
@@ -198,7 +195,6 @@ public class SymlinkHelper {
 
 	/**
 	 * Copy required shared libraries for bash using ldd command
-	 * 
 	 * @param binaryPath
 	 */
 	private void copyRequiredLibraries(String binaryPath) {
@@ -239,7 +235,6 @@ public class SymlinkHelper {
 
 	/**
 	 * Copy a single library to the chroot environment
-	 * 
 	 * @param libraryPath
 	 */
 	private void copyLibraryIfExists(String libraryPath) {
@@ -269,261 +264,261 @@ public class SymlinkHelper {
 	 * and required helper programs for both RHEL/UBI and Ubuntu systems.
 	 */
 	private void setupGitForChroot() {
-		try {
-			// Main git binary
-			copySystemBinary("/usr/bin/git");
-			copyRequiredLibraries("/usr/bin/git");
+	    try {
+	        // Main git binary
+	        copySystemBinary("/usr/bin/git");
+	        copyRequiredLibraries("/usr/bin/git");
 
-			// Setup git helpers (handles both RHEL and Ubuntu)
-			setupGitHelpersForCrossPlatform();
+	        // Setup git helpers (handles both RHEL and Ubuntu)
+	        setupGitHelpersForCrossPlatform();
 
-			// Setup essential binaries for git operations
-			setupGitEssentialBinaries();
+	        // Setup essential binaries for git operations
+	        setupGitEssentialBinaries();
 
-			// Setup git templates
-			setupGitTemplatesForCrossPlatform();
+	        // Setup git templates
+	        setupGitTemplatesForCrossPlatform();
 
-			// Setup SSL certificates (handles both RHEL and Ubuntu)
-			setupSSLCertsForCrossPlatform();
+	        // Setup SSL certificates (handles both RHEL and Ubuntu)
+	        setupSSLCertsForCrossPlatform();
 
-			// Create necessary directories
-			createChrootDirectory("/tmp");
-			createChrootDirectory("/var/tmp");
-			createChrootDirectory("/etc/git");
+	        // Create necessary directories
+	        createChrootDirectory("/tmp");
+	        createChrootDirectory("/var/tmp");
+	        createChrootDirectory("/etc/git");
 
-			classLogger.info("Git setup completed for chroot: " + userChrootFolder);
+	        classLogger.info("Git setup completed for chroot: " + userChrootFolder);
 
-		} catch (Exception e) {
-			classLogger.error("Error setting up git for chroot: " + e.getMessage(), e);
-		}
+	    } catch (Exception e) {
+	        classLogger.error("Error setting up git for chroot: " + e.getMessage(), e);
+	    }
 	}
 
 	/**
 	 * Setup git helper programs for both RHEL/UBI and Ubuntu systems
 	 */
 	private void setupGitHelpersForCrossPlatform() {
-		try {
-			// Try RHEL/UBI path first
-			Path gitHelpersHost = Paths.get("/usr/libexec/git-core");
-			Path gitHelpersChroot = Paths.get(userChrootFolder).resolve("usr/libexec/git-core");
-
-			if (Files.exists(gitHelpersHost)) {
-				copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
-				classLogger.info("Copied git helpers from RHEL/UBI location: " + gitHelpersHost);
-			} else {
-				// Fallback to Ubuntu path
-				gitHelpersHost = Paths.get("/usr/lib/git-core");
-				gitHelpersChroot = Paths.get(userChrootFolder).resolve("usr/lib/git-core");
-
-				if (Files.exists(gitHelpersHost)) {
-					copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
-					classLogger.info("Copied git helpers from Ubuntu location: " + gitHelpersHost);
-				} else {
-					classLogger.warn("Git helpers directory not found at expected locations");
-					// Try to find git helpers using git itself
-					findAndCopyGitHelpers();
-				}
-			}
-		} catch (IOException e) {
-			classLogger.error("Error setting up git helpers: " + e.getMessage(), e);
-		}
+	    try {
+	        // Try RHEL/UBI path first
+	        Path gitHelpersHost = Paths.get("/usr/libexec/git-core");
+	        Path gitHelpersChroot = Paths.get(userChrootFolder).resolve("usr/libexec/git-core");
+	        
+	        if (Files.exists(gitHelpersHost)) {
+	            copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
+	            classLogger.info("Copied git helpers from RHEL/UBI location: " + gitHelpersHost);
+	        } else {
+	            // Fallback to Ubuntu path
+	            gitHelpersHost = Paths.get("/usr/lib/git-core");
+	            gitHelpersChroot = Paths.get(userChrootFolder).resolve("usr/lib/git-core");
+	            
+	            if (Files.exists(gitHelpersHost)) {
+	                copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
+	                classLogger.info("Copied git helpers from Ubuntu location: " + gitHelpersHost);
+	            } else {
+	                classLogger.warn("Git helpers directory not found at expected locations");
+	                // Try to find git helpers using git itself
+	                findAndCopyGitHelpers();
+	            }
+	        }
+	    } catch (IOException e) {
+	        classLogger.error("Error setting up git helpers: " + e.getMessage(), e);
+	    }
 	}
 
 	/**
 	 * Find git helpers using git --exec-path command
 	 */
 	private void findAndCopyGitHelpers() {
-		try {
-			ProcessBuilder pb = new ProcessBuilder("git", "--exec-path");
-			Process process = pb.start();
-
-			try (java.io.BufferedReader reader = new java.io.BufferedReader(
-					new java.io.InputStreamReader(process.getInputStream()))) {
-
-				String gitExecPath = reader.readLine();
-				if (gitExecPath != null && !gitExecPath.trim().isEmpty()) {
-					Path gitHelpersHost = Paths.get(gitExecPath.trim());
-					Path gitHelpersChroot = Paths.get(userChrootFolder).resolve(gitExecPath.substring(1));
-
-					if (Files.exists(gitHelpersHost)) {
-						copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
-						classLogger.info("Found and copied git helpers from: " + gitExecPath);
-					}
-				}
-			}
-
-			process.waitFor();
-		} catch (Exception e) {
-			classLogger.warn("Could not find git helpers using git --exec-path: " + e.getMessage());
-		}
+	    try {
+	        ProcessBuilder pb = new ProcessBuilder("git", "--exec-path");
+	        Process process = pb.start();
+	        
+	        try (java.io.BufferedReader reader = new java.io.BufferedReader(
+	                new java.io.InputStreamReader(process.getInputStream()))) {
+	            
+	            String gitExecPath = reader.readLine();
+	            if (gitExecPath != null && !gitExecPath.trim().isEmpty()) {
+	                Path gitHelpersHost = Paths.get(gitExecPath.trim());
+	                Path gitHelpersChroot = Paths.get(userChrootFolder).resolve(gitExecPath.substring(1));
+	                
+	                if (Files.exists(gitHelpersHost)) {
+	                    copyDirectoryRecursively(gitHelpersHost, gitHelpersChroot);
+	                    classLogger.info("Found and copied git helpers from: " + gitExecPath);
+	                }
+	            }
+	        }
+	        
+	        process.waitFor();
+	    } catch (Exception e) {
+	        classLogger.warn("Could not find git helpers using git --exec-path: " + e.getMessage());
+	    }
 	}
 
 	/**
 	 * Setup essential binaries for git operations on both platforms
 	 */
 	private void setupGitEssentialBinaries() {
-		String[] essentialBinaries = {
-				"/usr/bin/curl", // Required for git-remote-https
-				"/usr/bin/ssh", // For git@... URLs
-				"/bin/tar", // Archive operations
-				"/bin/gzip", // Compression
-				"/usr/bin/openssl", // SSL/TLS operations
-				"/usr/bin/wget" // Alternative HTTP client
-		};
+	    String[] essentialBinaries = {
+	        "/usr/bin/curl",      // Required for git-remote-https
+	        "/usr/bin/ssh",       // For git@... URLs  
+	        "/bin/tar",           // Archive operations
+	        "/bin/gzip",          // Compression
+	        "/usr/bin/openssl",   // SSL/TLS operations
+	        "/usr/bin/wget"       // Alternative HTTP client
+	    };
 
-		for (String bin : essentialBinaries) {
-			if (Files.exists(Paths.get(bin))) {
-				copySystemBinary(bin);
-				copyRequiredLibraries(bin);
-				classLogger.debug("Copied git dependency: " + bin);
-			} else {
-				classLogger.debug("Optional git dependency not found: " + bin);
-			}
-		}
-
-		// Copy git-specific libraries that might be needed
-		copyGitSpecificLibraries();
+	    for (String bin : essentialBinaries) {
+	        if (Files.exists(Paths.get(bin))) {
+	            copySystemBinary(bin);
+	            copyRequiredLibraries(bin);
+	            classLogger.debug("Copied git dependency: " + bin);
+	        } else {
+	            classLogger.debug("Optional git dependency not found: " + bin);
+	        }
+	    }
+	    
+	    // Copy git-specific libraries that might be needed
+	    copyGitSpecificLibraries();
 	}
 
 	/**
 	 * Copy git-specific libraries for both RHEL and Ubuntu
 	 */
 	private void copyGitSpecificLibraries() {
-		// RHEL/UBI library paths
-		String[] rhelLibs = {
-				"/usr/lib64/libcurl.so.4",
-				"/usr/lib64/libssl.so.3",
-				"/usr/lib64/libcrypto.so.3",
-				"/usr/lib64/libz.so.1",
-				"/usr/lib64/libgssapi_krb5.so.2"
-		};
-
-		// Ubuntu library paths
-		String[] ubuntuLibs = {
-				"/usr/lib/x86_64-linux-gnu/libcurl.so.4",
-				"/usr/lib/x86_64-linux-gnu/libssl.so.3",
-				"/usr/lib/x86_64-linux-gnu/libcrypto.so.3",
-				"/usr/lib/x86_64-linux-gnu/libz.so.1"
-		};
-
-		// Try RHEL paths first
-		boolean foundRhelLibs = false;
-		for (String lib : rhelLibs) {
-			if (Files.exists(Paths.get(lib))) {
-				copyLibraryIfExists(lib);
-				foundRhelLibs = true;
-			}
-		}
-
-		// If no RHEL libs found, try Ubuntu paths
-		if (!foundRhelLibs) {
-			for (String lib : ubuntuLibs) {
-				copyLibraryIfExists(lib);
-			}
-		}
+	    // RHEL/UBI library paths
+	    String[] rhelLibs = {
+	        "/usr/lib64/libcurl.so.4",
+	        "/usr/lib64/libssl.so.3",
+	        "/usr/lib64/libcrypto.so.3",
+	        "/usr/lib64/libz.so.1",
+	        "/usr/lib64/libgssapi_krb5.so.2"
+	    };
+	    
+	    // Ubuntu library paths
+	    String[] ubuntuLibs = {
+	        "/usr/lib/x86_64-linux-gnu/libcurl.so.4",
+	        "/usr/lib/x86_64-linux-gnu/libssl.so.3",
+	        "/usr/lib/x86_64-linux-gnu/libcrypto.so.3",
+	        "/usr/lib/x86_64-linux-gnu/libz.so.1"
+	    };
+	    
+	    // Try RHEL paths first
+	    boolean foundRhelLibs = false;
+	    for (String lib : rhelLibs) {
+	        if (Files.exists(Paths.get(lib))) {
+	            copyLibraryIfExists(lib);
+	            foundRhelLibs = true;
+	        }
+	    }
+	    
+	    // If no RHEL libs found, try Ubuntu paths
+	    if (!foundRhelLibs) {
+	        for (String lib : ubuntuLibs) {
+	            copyLibraryIfExists(lib);
+	        }
+	    }
 	}
 
 	/**
 	 * Setup git templates for cross-platform compatibility
 	 */
 	private void setupGitTemplatesForCrossPlatform() {
-		String[] templatePaths = {
-				"/usr/share/git-core/templates", // Common location
-				"/usr/local/share/git-core/templates" // Alternative location
-		};
-
-		for (String templatePath : templatePaths) {
-			Path templatesSource = Paths.get(templatePath);
-			if (Files.exists(templatesSource)) {
-				Path templatesTarget = Paths.get(userChrootFolder).resolve(templatePath.substring(1));
-				try {
-					copyDirectoryRecursively(templatesSource, templatesTarget);
-					classLogger.info("Copied git templates from: " + templatePath);
-					break; // Only copy the first one found
-				} catch (IOException e) {
-					classLogger.debug("Could not copy git templates from: " + templatePath);
-				}
-			}
-		}
+	    String[] templatePaths = {
+	        "/usr/share/git-core/templates",  // Common location
+	        "/usr/local/share/git-core/templates"  // Alternative location
+	    };
+	    
+	    for (String templatePath : templatePaths) {
+	        Path templatesSource = Paths.get(templatePath);
+	        if (Files.exists(templatesSource)) {
+	            Path templatesTarget = Paths.get(userChrootFolder).resolve(templatePath.substring(1));
+	            try {
+	                copyDirectoryRecursively(templatesSource, templatesTarget);
+	                classLogger.info("Copied git templates from: " + templatePath);
+	                break; // Only copy the first one found
+	            } catch (IOException e) {
+	                classLogger.debug("Could not copy git templates from: " + templatePath);
+	            }
+	        }
+	    }
 	}
 
 	/**
 	 * Setup SSL certificates for both RHEL/UBI and Ubuntu systems
 	 */
 	private void setupSSLCertsForCrossPlatform() {
-		try {
-			// Detect OS type and setup accordingly
-			boolean isRHELBased = isRHELBasedSystem();
-			if (isRHELBased) {
-				classLogger.info("Predicted OS as RHEL");
-				setupSSLCertsForRHEL();
-			} else {
-				classLogger.info("Predicted OS as Ubuntu");
-				setupSSLCertsForUbuntu();
-			}
-		} catch (Exception e) {
-			classLogger.warn("Could not setup SSL certificates: " + e.getMessage());
-			// Try both approaches as fallback
-			setupSSLCertsForRHEL();
-			setupSSLCertsForUbuntu();
-		}
+	    try {
+	        // Detect OS type and setup accordingly
+	    	boolean isRHELBased = isRHELBasedSystem();
+	        if (isRHELBased) {
+	        	classLogger.info("Predicted OS as RHEL");
+	            setupSSLCertsForRHEL();
+	        } else {
+	        	classLogger.info("Predicted OS as Ubuntu");
+	            setupSSLCertsForUbuntu();
+	        }
+	    } catch (Exception e) {
+	        classLogger.warn("Could not setup SSL certificates: " + e.getMessage());
+	        // Try both approaches as fallback
+	        setupSSLCertsForRHEL();
+	        setupSSLCertsForUbuntu();
+	    }
 	}
 
 	/**
 	 * Detect if the system is RHEL-based
 	 */
 	private boolean isRHELBasedSystem() {
-		// Check for RHEL-specific files/directories
-		return Files.exists(Paths.get("/etc/redhat-release")) ||
-				Files.exists(Paths.get("/etc/rhel-release")) ||
-				Files.exists(Paths.get("/etc/pki"));
+	    // Check for RHEL-specific files/directories
+	    return Files.exists(Paths.get("/etc/redhat-release")) ||
+	           Files.exists(Paths.get("/etc/rhel-release")) ||
+	           Files.exists(Paths.get("/etc/pki"));
 	}
 
 	/**
 	 * Setup SSL certificates for RHEL/UBI systems
 	 */
 	private void setupSSLCertsForRHEL() {
-		try {
-			String[] caCertFiles = {
-					"/etc/pki/tls/certs/ca-bundle.crt",
-					"/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
-					"/etc/pki/tls/cert.pem"
-			};
+	    try {
+	        String[] caCertFiles = {
+	            "/etc/pki/tls/certs/ca-bundle.crt",
+	            "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+	            "/etc/pki/tls/cert.pem"
+	        };
 
-			// Copy CA certificate files
-			for (String certPath : caCertFiles) {
-				Path sourceCerts = Paths.get(certPath);
-				if (Files.exists(sourceCerts)) {
-					Path targetCerts = Paths.get(userChrootFolder).resolve(certPath.substring(1));
-					Files.createDirectories(targetCerts.getParent());
-					Files.copy(sourceCerts, targetCerts, StandardCopyOption.REPLACE_EXISTING);
-					classLogger.info("Copied RHEL CA certificates from: " + certPath);
-				} else {
+	        // Copy CA certificate files
+	        for (String certPath : caCertFiles) {
+	            Path sourceCerts = Paths.get(certPath);
+	            if (Files.exists(sourceCerts)) {
+	                Path targetCerts = Paths.get(userChrootFolder).resolve(certPath.substring(1));
+	                Files.createDirectories(targetCerts.getParent());
+	                Files.copy(sourceCerts, targetCerts, StandardCopyOption.REPLACE_EXISTING);
+	                classLogger.info("Copied RHEL CA certificates from: " + certPath);
+	            } else {
 					classLogger.warn("Could not find file at " + certPath);
 				}
-			}
+	        }
 
-			// Copy certificate directories
-			String[] certDirs = {
-					"/etc/pki/tls/certs",
-					"/etc/pki/ca-trust/extracted",
-					"/etc/pki/tls"
-			};
+	        // Copy certificate directories
+	        String[] certDirs = {
+	            "/etc/pki/tls/certs",
+	            "/etc/pki/ca-trust/extracted",
+	            "/etc/pki/tls"
+	        };
 
-			for (String certDir : certDirs) {
-				Path sourceCertDir = Paths.get(certDir);
-				if (Files.exists(sourceCertDir)) {
-					Path targetCertDir = Paths.get(userChrootFolder).resolve(certDir.substring(1));
-					copyDirectoryRecursively(sourceCertDir, targetCertDir);
-					classLogger.debug("Copied RHEL certificate directory: " + certDir);
-				} else {
+	        for (String certDir : certDirs) {
+	            Path sourceCertDir = Paths.get(certDir);
+	            if (Files.exists(sourceCertDir)) {
+	                Path targetCertDir = Paths.get(userChrootFolder).resolve(certDir.substring(1));
+	                copyDirectoryRecursively(sourceCertDir, targetCertDir);
+	                classLogger.debug("Copied RHEL certificate directory: " + certDir);
+	            } else {
 					classLogger.warn("Could not find directory at " + certDir);
-				}
-			}
+	            }
+	        }
 
-		} catch (IOException e) {
-			classLogger.debug("Could not setup RHEL SSL certificates: " + e.getMessage());
-		}
+	    } catch (IOException e) {
+	        classLogger.debug("Could not setup RHEL SSL certificates: " + e.getMessage());
+	    }
 	}
 
 	/**
@@ -539,8 +534,7 @@ public class SymlinkHelper {
 				if (Files.exists(sourceCerts)) {
 					Path targetCerts = Paths.get(userChrootFolder).resolve(certPath.substring(1));
 					Files.createDirectories(targetCerts.getParent());
-					Files.copy(sourceCerts, targetCerts, StandardCopyOption.REPLACE_EXISTING,
-							StandardCopyOption.COPY_ATTRIBUTES);
+					Files.copy(sourceCerts, targetCerts, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.COPY_ATTRIBUTES);
 					classLogger.info("Copied Ubuntu CA certificates from: " + certPath);
 				} else {
 					classLogger.warn("Could not find file at " + certPath);
@@ -550,46 +544,46 @@ public class SymlinkHelper {
 			// Copy certificate directories with symlink preservation
 			String[] certDirs = { "/etc/ssl/certs", "/usr/share/ca-certificates" };
 			for (String certDir : certDirs) {
-				Path sourceCertDir = Paths.get(certDir);
-				if (Files.exists(sourceCertDir)) {
-					Path targetCertDir = Paths.get(userChrootFolder).resolve(certDir.substring(1));
-					copyDirectoryRecursively(sourceCertDir, targetCertDir);
+	            Path sourceCertDir = Paths.get(certDir);
+	            if (Files.exists(sourceCertDir)) {
+	                Path targetCertDir = Paths.get(userChrootFolder).resolve(certDir.substring(1));
+	                copyDirectoryRecursively(sourceCertDir, targetCertDir);
 					classLogger.debug("Copied Ubuntu certificate directory (with symlinks): " + certDir);
-				} else {
+	            } else {
 					classLogger.warn("Could not find directory at " + certDir);
-				}
-			}
+	            }
+	        }
 		} catch (IOException e) {
 			classLogger.debug("Could not setup Ubuntu SSL certificates: " + e.getMessage());
 		}
 	}
-
+	
 	/**
 	 * Set ownership of a directory in chroot (works on both platforms)
 	 */
 	private void setDirectoryOwnership(String relativePath, String uid, String gid) {
-		try {
-			Path chrootDir = Paths.get(userChrootFolder, relativePath);
-			if (Files.exists(chrootDir)) {
-				ProcessBuilder pb = new ProcessBuilder("chown", uid + ":" + gid, chrootDir.toString());
-				Process process = pb.start();
-				int exitCode = process.waitFor();
-				if (exitCode == 0) {
-					classLogger.debug("Set ownership " + uid + ":" + gid + " for: " + relativePath);
-				} else {
-					classLogger.warn("Could not set ownership for: " + relativePath + " (exit code: " + exitCode + ")");
-				}
-			}
-		} catch (Exception e) {
-			classLogger.warn("Could not set ownership for: " + relativePath, e);
-		}
+	    try {
+	        Path chrootDir = Paths.get(userChrootFolder, relativePath);
+	        if (Files.exists(chrootDir)) {
+	            ProcessBuilder pb = new ProcessBuilder("chown", uid + ":" + gid, chrootDir.toString());
+	            Process process = pb.start();
+	            int exitCode = process.waitFor();
+	            if (exitCode == 0) {
+	                classLogger.debug("Set ownership " + uid + ":" + gid + " for: " + relativePath);
+	            } else {
+	                classLogger.warn("Could not set ownership for: " + relativePath + " (exit code: " + exitCode + ")");
+	            }
+	        }
+	    } catch (Exception e) {
+	        classLogger.warn("Could not set ownership for: " + relativePath, e);
+	    }
 	}
 
 	/**
 	 * Copy an entire directory recursively into the chroot, preserving structure.
 	 */
 	private void copyDirectoryRecursively(Path source, Path target) throws IOException {
-		if (source.toFile().exists()) {
+		if(source.toFile().exists()) {
 			Files.walk(source).forEach(src -> {
 				try {
 					Path dest = target.resolve(source.relativize(src));
@@ -604,6 +598,7 @@ public class SymlinkHelper {
 			});
 		}
 	}
+
 
 	/**
 	 * 
@@ -670,155 +665,159 @@ public class SymlinkHelper {
 		}
 	}
 
+	
 	public void symlinkUserAsset(User user) {
-		AuthProvider provider = user.getPrimaryLogin();
-		String projectId = user.getAssetProjectId(provider);
-		String assetFolder = AssetUtility.getUserAssetAndWorkspaceAppRootFolder("Asset", projectId);
-		classLogger.info("Symlinking user asset folder for projectId=" + projectId);
-		symlinkFolder(assetFolder);
+	    AuthProvider provider = user.getPrimaryLogin();
+	    String projectId = user.getAssetProjectId(provider);
+	    String assetFolder = AssetUtility.getUserAssetAndWorkspaceAppRootFolder("Asset", projectId);
+	    classLogger.info("Symlinking user asset folder for projectId=" + projectId);
+	    symlinkFolder(assetFolder);
 	}
 
 	public void symlinkProject(User user, String projectId) {
-		classLogger.info("Symlinking project for projectId=" + projectId);
+	    classLogger.info("Symlinking project for projectId=" + projectId);
 
-		String projectAppRootFolder = AssetUtility.getProjectAppRootFolder(projectId);
+	    String projectAppRootFolder = AssetUtility.getProjectAppRootFolder(projectId);
 
-		if (SecurityProjectUtils.userCanEditProject(user, projectId)) {
-			symlinkFolder(projectAppRootFolder);
-			return;
-		}
+	    if (SecurityProjectUtils.userCanEditProject(user, projectId)) {
+	        symlinkFolder(projectAppRootFolder);
+	        return;
+	    }
 
-		boolean readOnlyCopyEnabled = Boolean.parseBoolean(
-				Utility.getDIHelperProperty(Constants.CHROOT_READ_ONLY_COPY));
+	    boolean readOnlyCopyEnabled = Boolean.parseBoolean(
+	        Utility.getDIHelperProperty(Constants.CHROOT_READ_ONLY_COPY)
+	    );
 
-		if (readOnlyCopyEnabled) {
-			Path projectTarget = Paths.get(userChrootFolder)
-					.resolve(Utility.normalizePath(projectAppRootFolder).substring(1));
-			if (Files.exists(projectTarget)) {
-				classLogger.info("Chrooted project already copied for projectId=" + projectId +
-						" at: " + projectTarget + ", skipping copy and permission patch.");
-				return;
-			}
-
-			classLogger.info("Symlinking read-only copy for projectId=" + projectId);
-			setupCopiedProject(projectId);
-			setAllReadExecuteForProject(projectId);
-			// below does not work - commenting out for now
-			// setExecuteOnlyOnAssetCodeFolders(projectId);
-		} else {
-			classLogger.info("Symlinking full folder for read-only user, projectId=" + projectId);
-			symlinkFolder(projectAppRootFolder);
-		}
+	    if (readOnlyCopyEnabled) {
+	        Path projectTarget = Paths.get(userChrootFolder).resolve(Utility.normalizePath(projectAppRootFolder).substring(1));
+	        if (Files.exists(projectTarget)) {
+	            classLogger.info("Chrooted project already copied for projectId=" + projectId +
+	                             " at: " + projectTarget + ", skipping copy and permission patch.");
+	            return;
+	        }
+	        
+	        classLogger.info("Symlinking read-only copy for projectId=" + projectId);
+	        setupCopiedProject(projectId);
+	        setAllReadExecuteForProject(projectId);
+	        // below does not work - commenting out for now
+			//setExecuteOnlyOnAssetCodeFolders(projectId);
+	    } else {
+	        classLogger.info("Symlinking full folder for read-only user, projectId=" + projectId);
+	        symlinkFolder(projectAppRootFolder);
+	    }
 	}
-
+	
 	private void setOwnerRWX(Path dir) throws IOException {
-		Files.setPosixFilePermissions(dir, EnumSet.of(
-				PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
-				PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
-				PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE));
+	    Files.setPosixFilePermissions(dir, EnumSet.of(
+	        PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE,
+	        PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
+	        PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
+	    ));
 	}
 
 	private void setOwnerRX(Path dir) throws IOException {
-		Files.setPosixFilePermissions(dir, EnumSet.of(
-				PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE,
-				PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
-				PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE));
+	    Files.setPosixFilePermissions(dir, EnumSet.of(
+	        PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE,
+	        PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
+	        PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE
+	    ));
 	}
-
+	
 	private void setupCopiedProject(String projectId) {
-		String sourceDirToCopy = AssetUtility.getProjectAppRootFolder(projectId);
-		sourceDirToCopy = Utility.normalizePath(sourceDirToCopy);
-		Path projectSource = Paths.get(sourceDirToCopy);
-		if (!Files.exists(projectSource)) {
-			classLogger.warn("Project app root does not exist for readOnlyCopyProject: " + sourceDirToCopy);
-			return;
-		}
-		Path projectTarget = Paths.get(userChrootFolder).resolve(sourceDirToCopy.substring(1));
-		if (Files.exists(projectTarget)) {
-			classLogger.info("Chrooted project already copied, skipping copy for: " + projectTarget);
-			return;
-		}
-		try {
-			copyDirectoryRecursively(projectSource, projectTarget);
-			classLogger.info("Copied project from: " + projectSource);
-		} catch (IOException e) {
-			classLogger.debug("Could not copy project from: " + projectSource);
-		}
+	    String sourceDirToCopy = AssetUtility.getProjectAppRootFolder(projectId);
+	    sourceDirToCopy = Utility.normalizePath(sourceDirToCopy);
+	    Path projectSource = Paths.get(sourceDirToCopy);
+	    if (!Files.exists(projectSource)) {
+	        classLogger.warn("Project app root does not exist for readOnlyCopyProject: " + sourceDirToCopy);
+	        return;
+	    }
+        Path projectTarget = Paths.get(userChrootFolder).resolve(sourceDirToCopy.substring(1));
+        if (Files.exists(projectTarget)) {
+            classLogger.info("Chrooted project already copied, skipping copy for: " + projectTarget);
+            return;
+        }
+        try {
+            copyDirectoryRecursively(projectSource, projectTarget);
+            classLogger.info("Copied project from: " + projectSource);
+        } catch (IOException e) {
+            classLogger.debug("Could not copy project from: " + projectSource);
+        }
 	}
-
+	
 	public void setAllReadExecuteForProject(String projectId) {
-		String projectAppRootFolder = AssetUtility.getProjectAppRootFolder(projectId);
-		projectAppRootFolder = Utility.normalizePath(projectAppRootFolder);
-		Path chrootAppRoot = Paths.get(userChrootFolder, projectAppRootFolder.startsWith("/")
-				? projectAppRootFolder.substring(1)
-				: projectAppRootFolder);
+	    String projectAppRootFolder = AssetUtility.getProjectAppRootFolder(projectId);
+	    projectAppRootFolder = Utility.normalizePath(projectAppRootFolder);
+	    Path chrootAppRoot = Paths.get(userChrootFolder, projectAppRootFolder.startsWith("/")
+	            ? projectAppRootFolder.substring(1) : projectAppRootFolder);
 
-		if (!Files.exists(chrootAppRoot)) {
-			classLogger.warn("Chrooted app root does not exist for project: " + chrootAppRoot);
-			return;
-		}
+	    if (!Files.exists(chrootAppRoot)) {
+	        classLogger.warn("Chrooted app root does not exist for project: " + chrootAppRoot);
+	        return;
+	    }
 
-		try {
-			Files.walkFileTree(chrootAppRoot, new SimpleFileVisitor<Path>() {
-				@Override
-				public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-					setOwnerRX(dir);
-					return FileVisitResult.CONTINUE;
-				}
-
-				@Override
-				public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-					setOwnerRX(file);
-					return FileVisitResult.CONTINUE;
-				}
-			});
-		} catch (IOException e) {
-			classLogger.error("Failed to set r-x permissions on project: " + chrootAppRoot, e);
-		}
+	    try {
+	        Files.walkFileTree(chrootAppRoot, new SimpleFileVisitor<Path>() {
+	            @Override
+	            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+	                setOwnerRX(dir);
+	                return FileVisitResult.CONTINUE;
+	            }
+	            @Override
+	            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+	                setOwnerRX(file);
+	                return FileVisitResult.CONTINUE;
+	            }
+	        });
+	    } catch (IOException e) {
+	        classLogger.error("Failed to set r-x permissions on project: " + chrootAppRoot, e);
+	    }
 	}
+	
 
+
+        
 	public void setExecuteOnlyOnAssetCodeFolders(String projectId) {
-		String assetsFolderPath = AssetUtility.getProjectAssetsFolder(projectId);
-		assetsFolderPath = Utility.normalizePath(assetsFolderPath);
-		Path chrootAssetsFolder = Paths.get(userChrootFolder, assetsFolderPath.startsWith("/")
-				? assetsFolderPath.substring(1)
-				: assetsFolderPath);
+	    String assetsFolderPath = AssetUtility.getProjectAssetsFolder(projectId);
+	    assetsFolderPath = Utility.normalizePath(assetsFolderPath);
+	    Path chrootAssetsFolder = Paths.get(userChrootFolder, assetsFolderPath.startsWith("/")
+	            ? assetsFolderPath.substring(1) : assetsFolderPath);
 
-		if (!Files.exists(chrootAssetsFolder)) {
-			classLogger.warn("Chroot assets folder does not exist: " + chrootAssetsFolder);
-			return;
-		}
+	    if (!Files.exists(chrootAssetsFolder)) {
+	        classLogger.warn("Chroot assets folder does not exist: " + chrootAssetsFolder);
+	        return;
+	    }
 
-		String[] codeDirs = { "java", "classes", "py" };
-		for (String dirName : codeDirs) {
-			Path subDir = chrootAssetsFolder.resolve(dirName);
-			if (Files.exists(subDir)) {
-				try {
-					Files.walkFileTree(subDir, new SimpleFileVisitor<Path>() {
-						@Override
-						public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
-								throws IOException {
-							Files.setPosixFilePermissions(dir, EnumSet.of(
-									PosixFilePermission.OWNER_EXECUTE,
-									PosixFilePermission.GROUP_EXECUTE,
-									PosixFilePermission.OTHERS_EXECUTE));
-							return FileVisitResult.CONTINUE;
-						}
-
-						@Override
-						public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-							Files.setPosixFilePermissions(file, EnumSet.of(
-									PosixFilePermission.OWNER_EXECUTE,
-									PosixFilePermission.GROUP_EXECUTE,
-									PosixFilePermission.OTHERS_EXECUTE));
-							return FileVisitResult.CONTINUE;
-						}
-					});
-				} catch (IOException e) {
-					classLogger.warn("Failed to set execute-only on: " + subDir, e);
-				}
-			}
-		}
+	    String[] codeDirs = { "java", "classes", "py" };
+	    for (String dirName : codeDirs) {
+	        Path subDir = chrootAssetsFolder.resolve(dirName);
+	        if (Files.exists(subDir)) {
+	            try {
+	                Files.walkFileTree(subDir, new SimpleFileVisitor<Path>() {
+	                    @Override
+	                    public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
+	                        Files.setPosixFilePermissions(dir, EnumSet.of(
+	                            PosixFilePermission.OWNER_EXECUTE,
+	                            PosixFilePermission.GROUP_EXECUTE,
+	                            PosixFilePermission.OTHERS_EXECUTE
+	                        ));
+	                        return FileVisitResult.CONTINUE;
+	                    }
+	                    @Override
+	                    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+	                        Files.setPosixFilePermissions(file, EnumSet.of(
+	                            PosixFilePermission.OWNER_EXECUTE,
+	                            PosixFilePermission.GROUP_EXECUTE,
+	                            PosixFilePermission.OTHERS_EXECUTE
+	                        ));
+	                        return FileVisitResult.CONTINUE;
+	                    }
+	                });
+	            } catch (IOException e) {
+	                classLogger.warn("Failed to set execute-only on: " + subDir, e);
+	            }
+	        }
+	    }
 	}
+
 
 }


### PR DESCRIPTION
This pr symlinks the user folder to chroot on boot, and also sets up a zk listener on that folder. Also slightly modifies the listener child event method to handle lookup for methods with primitive arguments (previously, since all of the methods had string args it was fine, but if you pass a method and primitive args they get autoboxed, and the old class.getMethod call doesn't handle that)