### PR TITLE
fix(security): correct StackWalker caller filter for access checks

### DIFF
--- a/src/prerna/util/SystemEngineRegistry.java
+++ b/src/prerna/util/SystemEngineRegistry.java
@@ -485,14 +485,16 @@ public final class SystemEngineRegistry {
 	 * @param context
 	 */
 	private static void checkAccess(Set<String> allowedPackages, String context) {
-		final String registryName = prerna.util.SystemEngineRegistry.class.getName();
+		final String registryName = SystemEngineRegistry.class.getName();
 
 		Class<?> caller = WALKER
 				.walk(frames -> frames.skip(2).map(StackWalker.StackFrame::getDeclaringClass).filter(c -> {
 					String n = c.getName();
+					// ignore inner classes classes properly with $
+					// do not use startsWith due to matching unintended files
 					return !(n.equals(registryName) || n.startsWith(registryName + "$"));
 				}).findFirst().orElse(null));
-		
+
 		if (caller == null) {
 			throw new SecurityException("Unable to determine caller for " + context);
 		}

--- a/src/prerna/util/SystemEngineRegistry.java
+++ b/src/prerna/util/SystemEngineRegistry.java
@@ -485,9 +485,14 @@ public final class SystemEngineRegistry {
 	 * @param context
 	 */
 	private static void checkAccess(Set<String> allowedPackages, String context) {
-		Class<?> caller = WALKER.walk(frames -> frames.skip(2).map(StackWalker.StackFrame::getDeclaringClass)
-				.filter(c -> !c.getName().startsWith("prerna.util.SystemEngineRegistry")).findFirst().orElse(null));
+		final String registryName = prerna.util.SystemEngineRegistry.class.getName();
 
+		Class<?> caller = WALKER
+				.walk(frames -> frames.skip(2).map(StackWalker.StackFrame::getDeclaringClass).filter(c -> {
+					String n = c.getName();
+					return !(n.equals(registryName) || n.startsWith(registryName + "$"));
+				}).findFirst().orElse(null));
+		
 		if (caller == null) {
 			throw new SecurityException("Unable to determine caller for " + context);
 		}


### PR DESCRIPTION
## Description
Exclude only SystemEngineRegistry and its nested $ classes (not SystemEngineRegistryTestExtension) when resolving the first non-registry caller. This prevents test code from being misidentified as the unauthorized caller during LocalMasterDatabase registration.