### PR TITLE
feat: Implement SqlQueryBase64Reactor for Base64-encoded SQL queries

### DIFF
--- a/src/prerna/reactor/agent/mcp/MakeEngineMCPReactor.java
+++ b/src/prerna/reactor/agent/mcp/MakeEngineMCPReactor.java
@@ -59,7 +59,6 @@ import prerna.reactor.function.ExecuteFunctionEngineReactor;
 import prerna.reactor.masterdatabase.GetDatabaseTableStructureReactor;
 import prerna.reactor.model.LLMReactor;
 import prerna.reactor.qs.SqlQueryBase64Reactor;
-import prerna.reactor.qs.SqlQueryReactor;
 import prerna.reactor.storage.DeleteFromStorageReactor;
 import prerna.reactor.storage.ListStoragePathDetailsReactor;
 import prerna.reactor.storage.ListStoragePathReactor;
@@ -102,17 +101,13 @@ public class MakeEngineMCPReactor extends AbstractReactor {
             	RemoveDocumentFromVectorDatabaseReactor.class,
             	VectorFileDownloadReactor.class
             )));
-        
         put(IEngine.CATALOG_TYPE.DATABASE, new ArrayList<>(Arrays.asList(
             	GetDatabaseTableStructureReactor.class,
-            	SqlQueryReactor.class,
             	SqlQueryBase64Reactor.class
             )));
-        
         put(IEngine.CATALOG_TYPE.MODEL, new ArrayList<>(Arrays.asList(
             	LLMReactor.class
             )));
-		
 		}
 	};
     // @formatter:on 

--- a/src/prerna/reactor/agent/mcp/MakeEngineMCPReactor.java
+++ b/src/prerna/reactor/agent/mcp/MakeEngineMCPReactor.java
@@ -56,6 +56,10 @@ import prerna.reactor.ReactorFactory;
 import prerna.reactor.agent.mcp.MCPUtility.MCPDisplayOption;
 import prerna.reactor.agent.mcp.MCPUtility.MCPExecution;
 import prerna.reactor.function.ExecuteFunctionEngineReactor;
+import prerna.reactor.masterdatabase.GetDatabaseTableStructureReactor;
+import prerna.reactor.model.LLMReactor;
+import prerna.reactor.qs.SqlQueryBase64Reactor;
+import prerna.reactor.qs.SqlQueryReactor;
 import prerna.reactor.storage.DeleteFromStorageReactor;
 import prerna.reactor.storage.ListStoragePathDetailsReactor;
 import prerna.reactor.storage.ListStoragePathReactor;
@@ -98,6 +102,17 @@ public class MakeEngineMCPReactor extends AbstractReactor {
             	RemoveDocumentFromVectorDatabaseReactor.class,
             	VectorFileDownloadReactor.class
             )));
+        
+        put(IEngine.CATALOG_TYPE.DATABASE, new ArrayList<>(Arrays.asList(
+            	GetDatabaseTableStructureReactor.class,
+            	SqlQueryReactor.class,
+            	SqlQueryBase64Reactor.class
+            )));
+        
+        put(IEngine.CATALOG_TYPE.MODEL, new ArrayList<>(Arrays.asList(
+            	LLMReactor.class
+            )));
+		
 		}
 	};
     // @formatter:on 

--- a/src/prerna/reactor/qs/AbstractSqlQueryReactor.java
+++ b/src/prerna/reactor/qs/AbstractSqlQueryReactor.java
@@ -1,0 +1,265 @@
+package prerna.reactor.qs;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.delete.Delete;
+import net.sf.jsqlparser.statement.insert.Insert;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.update.Update;
+import prerna.auth.User;
+import prerna.auth.utils.SecurityEngineUtils;
+import prerna.engine.api.IDatabaseEngine;
+import prerna.query.querystruct.AbstractQueryStruct.QUERY_STRUCT_TYPE;
+import prerna.query.querystruct.HardSelectQueryStruct;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.NounStore;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.execptions.SemossPixelException;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.sablecc2.om.task.BasicIteratorTask;
+import prerna.util.Constants;
+import prerna.util.Utility;
+
+public abstract class AbstractSqlQueryReactor extends AbstractReactor {
+	private static final Logger classLogger = LogManager.getLogger(SqlQueryReactor.class);
+
+	private static final int DEFAULT_LIMIT = 50;
+	private static final int MAX_LIMIT = 5_000;
+
+	private enum QueryType {
+		SELECT, INSERT, UPDATE, DELETE, OTHER
+	}
+
+	public AbstractSqlQueryReactor() {
+		this.keysToGet = new String[] { ReactorKeysEnum.QUERY_KEY.getKey(), ReactorKeysEnum.DATABASE.getKey(),
+				ReactorKeysEnum.LIMIT.getKey(), "commit" };
+		this.keyRequired = new int[] { 1, 1, 0, 0, 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		User user = this.insight.getUser();
+		if (user == null) {
+			NounMetadata noun = new NounMetadata("User must be signed into an account in order to run this operation",
+					PixelDataType.CONST_STRING, PixelOperationType.ERROR, PixelOperationType.LOGGIN_REQUIRED_ERROR);
+			SemossPixelException err = new SemossPixelException(noun);
+			err.setContinueThreadOfExecution(false);
+			throw err;
+		}
+
+		organizeKeys();
+		String sqlQuery = getDecodedQuery();
+		String databaseId = this.keyValue.get(this.keysToGet[1]);
+		String limitStr = this.keyValue.get(this.keysToGet[2]);
+		String commitStr = this.keyValue.get(this.keysToGet[3]);
+
+		if (sqlQuery == null || sqlQuery.trim().isEmpty()) {
+			throw new SemossPixelException("SQL query cannot be empty");
+		}
+
+		if (databaseId == null || databaseId.trim().isEmpty()) {
+			throw new SemossPixelException("Database id is required");
+		}
+
+		try {
+			// determine query type
+			QueryType queryType = detectQueryType(sqlQuery);
+			classLogger.info("Detected query type: {}", queryType);
+			validateUserPermissions(user, databaseId, queryType);
+
+			// create query structure and delegate
+			return delegateToAppropriateReactor(sqlQuery, databaseId, queryType, limitStr, commitStr);
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new SemossPixelException("Error executing SQL query: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * 
+	 * @return Decoded SQL query string ready for execution
+	 * @throws IllegalArgumentException if decoding fails or input is invalid
+	 */
+	protected abstract String getDecodedQuery();
+
+	/**
+	 * Detect SQL statement type using JSQLParser
+	 */
+	private QueryType detectQueryType(String sql) {
+		try {
+			Statement statement = CCJSqlParserUtil.parse(sql);
+
+			if (statement instanceof Select) {
+				return QueryType.SELECT;
+			} else if (statement instanceof Insert) {
+				return QueryType.INSERT;
+			} else if (statement instanceof Update) {
+				return QueryType.UPDATE;
+			} else if (statement instanceof Delete) {
+				return QueryType.DELETE;
+			} else {
+				// For CREATE, ALTER, DROP, etc.
+				return QueryType.OTHER;
+			}
+		} catch (Exception e) {
+			classLogger.warn("Could not parse SQL statement, defaulting to OTHER type: " + e.getMessage());
+			return QueryType.OTHER;
+		}
+	}
+
+	/**
+	 * 
+	 * @param user
+	 * @param databaseId
+	 * @param queryType
+	 */
+	private void validateUserPermissions(User user, String databaseId, QueryType queryType) {
+		switch (queryType) {
+		case SELECT:
+			// view permission
+			if (!SecurityEngineUtils.userCanViewEngine(user, databaseId)) {
+				throw new SemossPixelException("User does not have permission to query this database");
+			}
+			break;
+		default:
+			// any other modification queries need edit permission
+			if (!SecurityEngineUtils.userCanEditEngine(user, databaseId)) {
+				throw new SemossPixelException("User does not have permission to modify this database");
+			}
+			break;
+		}
+	}
+
+	/**
+	 * 
+	 * @param sqlQuery
+	 * @param databaseId
+	 * @param queryType
+	 * @param limitStr
+	 * @param commitStr
+	 * @return
+	 */
+	private NounMetadata delegateToAppropriateReactor(String sqlQuery, String databaseId, QueryType queryType,
+			String limitStr, String commitStr) {
+
+		if (queryType == QueryType.SELECT) {
+			return executeSelectQuery(sqlQuery, databaseId, limitStr);
+		} else {
+			return executeModificationQuery(sqlQuery, databaseId, commitStr);
+		}
+	}
+
+	/**
+	 * For select, create task and return it directly, much like the collect reactor
+	 * 
+	 * @param sqlQuery
+	 * @param databaseId
+	 * @param limitStr
+	 * @return
+	 */
+	private NounMetadata executeSelectQuery(String sqlQuery, String databaseId, String limitStr) {
+		try {
+			HardSelectQueryStruct qs = getQs(sqlQuery, databaseId);
+			// set limit if provided
+			int limit = parseLimit(limitStr);
+			BasicIteratorTask task = new BasicIteratorTask(qs);
+			task.setNumCollect(limit);
+			task.setCollectLimit(limit);
+			this.insight.addQueriedDatabasesese(databaseId);
+			return new NounMetadata(task, PixelDataType.FORMATTED_DATA_SET);
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new SemossPixelException("Error executing SELECT query: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * 
+	 * @param sqlQuery
+	 * @param databaseId
+	 * @param commitStr
+	 * @return
+	 */
+	private NounMetadata executeModificationQuery(String sqlQuery, String databaseId, String commitStr) {
+		try {
+			HardSelectQueryStruct qs = getQs(sqlQuery, databaseId);
+			// default to false if not provided
+			boolean commit = commitStr != null && !commitStr.trim().isEmpty() && Boolean.parseBoolean(commitStr.trim());
+
+			NounStore execQueryNounStore = new NounStore("ExecQuery");
+			execQueryNounStore.makeGenRowStruct(PixelDataType.QUERY_STRUCT.getKey())
+					.add(new NounMetadata(qs, PixelDataType.QUERY_STRUCT));
+			execQueryNounStore.makeGenRowStruct("commit").add(new NounMetadata(commit, PixelDataType.BOOLEAN));
+
+			ExecQueryReactor execReactor = new ExecQueryReactor();
+			execReactor.setInsight(this.insight);
+			execReactor.setNounStore(execQueryNounStore);
+
+			return execReactor.execute();
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new SemossPixelException("Error executing modification query: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * 
+	 * @param sqlQuery
+	 * @param databaseId
+	 * @return
+	 */
+	private HardSelectQueryStruct getQs(String sqlQuery, String databaseId) {
+		IDatabaseEngine engine = Utility.getDatabase(databaseId);
+		if (engine == null) {
+			throw new SemossPixelException("Database with ID '" + databaseId + "' not found or could not be loaded");
+		}
+
+		// Create HardSelectQueryStruct for raw SQL
+		HardSelectQueryStruct qs = new HardSelectQueryStruct();
+		qs.setEngineId(databaseId);
+		qs.setEngine(engine);
+		qs.setQuery(sqlQuery);
+		qs.setQsType(QUERY_STRUCT_TYPE.RAW_ENGINE_QUERY);
+		return qs;
+	}
+
+	/**
+	 * Parse and validate limit parameter
+	 * 
+	 * @param limitStr
+	 * @return
+	 */
+	private int parseLimit(String limitStr) {
+		int limit = DEFAULT_LIMIT; // default
+
+		if (limitStr != null && !limitStr.trim().isEmpty()) {
+			try {
+				limit = Integer.parseInt(limitStr.trim());
+
+				if (limit <= 0) {
+					classLogger.warn("Non-positive limit value: " + limit + ", using default " + DEFAULT_LIMIT);
+					limit = DEFAULT_LIMIT;
+				} else if (limit > MAX_LIMIT) {
+					classLogger.warn("Limit value " + limit + " exceeds maximum " + MAX_LIMIT + ", using maximum");
+					limit = MAX_LIMIT;
+				}
+
+			} catch (NumberFormatException e) {
+				classLogger.warn("Invalid limit value: " + limitStr + ", using default " + DEFAULT_LIMIT);
+			}
+		}
+
+		return limit;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Abstract base class for SQL query execution. Subclasses implement specific decoding mechanisms.";
+	}
+
+}

--- a/src/prerna/reactor/qs/AbstractSqlQueryReactor.java
+++ b/src/prerna/reactor/qs/AbstractSqlQueryReactor.java
@@ -26,7 +26,8 @@ import prerna.util.Constants;
 import prerna.util.Utility;
 
 public abstract class AbstractSqlQueryReactor extends AbstractReactor {
-	private static final Logger classLogger = LogManager.getLogger(SqlQueryReactor.class);
+
+	private static final Logger classLogger = LogManager.getLogger(AbstractSqlQueryReactor.class);
 
 	private static final int DEFAULT_LIMIT = 50;
 	private static final int MAX_LIMIT = 5_000;
@@ -259,7 +260,18 @@ public abstract class AbstractSqlQueryReactor extends AbstractReactor {
 
 	@Override
 	public String getReactorDescription() {
-		return "Abstract base class for SQL query execution. Subclasses implement specific decoding mechanisms.";
+		return "Execute a sql query against a database";
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (key.equals(ReactorKeysEnum.DATABASE.getKey())) {
+			return "The database id";
+		} else if (key.equals(ReactorKeysEnum.LIMIT.getKey())) {
+			return "Limits the number of rows retrieved by a select query";
+		} else {
+			return super.getDescriptionForKey(key);
+		}
 	}
 
 }

--- a/src/prerna/reactor/qs/SqlQueryBase64Reactor.java
+++ b/src/prerna/reactor/qs/SqlQueryBase64Reactor.java
@@ -1,0 +1,298 @@
+package prerna.reactor.qs;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
+import net.sf.jsqlparser.statement.Statement;
+import net.sf.jsqlparser.statement.delete.Delete;
+import net.sf.jsqlparser.statement.insert.Insert;
+import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.update.Update;
+import prerna.auth.User;
+import prerna.auth.utils.SecurityEngineUtils;
+import prerna.engine.api.IDatabaseEngine;
+import prerna.query.querystruct.AbstractQueryStruct.QUERY_STRUCT_TYPE;
+import prerna.query.querystruct.HardSelectQueryStruct;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.NounStore;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.execptions.SemossPixelException;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.sablecc2.om.task.BasicIteratorTask;
+import prerna.util.Constants;
+import prerna.util.Utility;
+
+/**
+ * Unified SQL Query Reactor that accepts Base64-encoded SQL queries:
+ * 1. Decodes Base64-encoded SQL query 2. Parses SQL to detect query type (SELECT vs modification)
+ * 3. Validates user permissions based on query type 4. Delegates to appropriate existing reactors
+ * 
+ * Usage: SqlQueryBase64(database=["myDb"], query=[base64_encoded_sql], limit=[100], commit=[true])
+ */
+public class SqlQueryBase64Reactor extends AbstractReactor {
+
+	private static final Logger classLogger = LogManager.getLogger(SqlQueryBase64Reactor.class);
+
+	private static final int DEFAULT_LIMIT = 50;
+	private static final int MAX_LIMIT = 5_000;
+
+	private enum QueryType {
+		SELECT, INSERT, UPDATE, DELETE, OTHER
+	}
+
+	public SqlQueryBase64Reactor() {
+		this.keysToGet = new String[] { ReactorKeysEnum.QUERY_KEY.getKey(), ReactorKeysEnum.DATABASE.getKey(),
+				ReactorKeysEnum.LIMIT.getKey(), "commit" };
+		this.keyRequired = new int[] { 1, 1, 0, 0, 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		User user = this.insight.getUser();
+		if (user == null) {
+			NounMetadata noun = new NounMetadata("User must be signed into an account in order to run this operation",
+					PixelDataType.CONST_STRING, PixelOperationType.ERROR, PixelOperationType.LOGGIN_REQUIRED_ERROR);
+			SemossPixelException err = new SemossPixelException(noun);
+			err.setContinueThreadOfExecution(false);
+			throw err;
+		}
+
+		organizeKeys();
+		// Decode Base64-encoded SQL query
+		String sqlQuery = decodeBase64Query(this.keyValue.get(this.keysToGet[0]));
+		String databaseId = this.keyValue.get(this.keysToGet[1]);
+		String limitStr = this.keyValue.get(this.keysToGet[2]);
+		String commitStr = this.keyValue.get(this.keysToGet[3]);
+
+		if (sqlQuery == null || sqlQuery.trim().isEmpty()) {
+			throw new SemossPixelException("SQL query cannot be empty");
+		}
+
+		if (databaseId == null || databaseId.trim().isEmpty()) {
+			throw new SemossPixelException("Database id is required");
+		}
+
+		try {
+			// determine query type
+			QueryType queryType = detectQueryType(sqlQuery);
+			classLogger.info("Detected query type: {}", queryType);
+			validateUserPermissions(user, databaseId, queryType);
+
+			// create query structure and delegate
+			return delegateToAppropriateReactor(sqlQuery, databaseId, queryType, limitStr, commitStr);
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new SemossPixelException("Error executing SQL query: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * Decode Base64-encoded SQL query
+	 * 
+	 * @param encodedQuery Base64-encoded SQL string
+	 * @return Decoded SQL string
+	 */
+	private String decodeBase64Query(String encodedQuery) {
+		if (encodedQuery == null || encodedQuery.trim().isEmpty()) {
+			throw new SemossPixelException("Encoded SQL query cannot be empty");
+		}
+		
+		try {
+			return new String(Base64.getDecoder().decode(encodedQuery), StandardCharsets.UTF_8);
+		} catch (IllegalArgumentException e) {
+			throw new SemossPixelException(
+					"Failed to decode SQL query: input is not a valid Base64-encoded UTF-8 string", e);
+		} catch (Exception e) {
+			throw new SemossPixelException("Failed to decode SQL query: " + e.getMessage(), e);
+		}
+	}
+
+	/**
+	 * Detect SQL statement type using JSQLParser
+	 */
+	private QueryType detectQueryType(String sql) {
+		try {
+			Statement statement = CCJSqlParserUtil.parse(sql);
+
+			if (statement instanceof Select) {
+				return QueryType.SELECT;
+			} else if (statement instanceof Insert) {
+				return QueryType.INSERT;
+			} else if (statement instanceof Update) {
+				return QueryType.UPDATE;
+			} else if (statement instanceof Delete) {
+				return QueryType.DELETE;
+			} else {
+				// For CREATE, ALTER, DROP, etc.
+				return QueryType.OTHER;
+			}
+		} catch (Exception e) {
+			classLogger.warn("Could not parse SQL statement, defaulting to OTHER type: " + e.getMessage());
+			return QueryType.OTHER;
+		}
+	}
+
+	/**
+	 * 
+	 * @param user
+	 * @param databaseId
+	 * @param queryType
+	 */
+	private void validateUserPermissions(User user, String databaseId, QueryType queryType) {
+		switch (queryType) {
+		case SELECT:
+			// view permission
+			if (!SecurityEngineUtils.userCanViewEngine(user, databaseId)) {
+				throw new SemossPixelException("User does not have permission to query this database");
+			}
+			break;
+		default:
+			// any other modification queries need edit permission
+			if (!SecurityEngineUtils.userCanEditEngine(user, databaseId)) {
+				throw new SemossPixelException("User does not have permission to modify this database");
+			}
+			break;
+		}
+	}
+
+	/**
+	 * 
+	 * @param sqlQuery
+	 * @param databaseId
+	 * @param queryType
+	 * @param limitStr
+	 * @param commitStr
+	 * @return
+	 */
+	private NounMetadata delegateToAppropriateReactor(String sqlQuery, String databaseId, QueryType queryType,
+			String limitStr, String commitStr) {
+
+		if (queryType == QueryType.SELECT) {
+			return executeSelectQuery(sqlQuery, databaseId, limitStr);
+		} else {
+			return executeModificationQuery(sqlQuery, databaseId, commitStr);
+		}
+	}
+
+	/**
+	 * For select, create task and return it directly, much like the collect reactor
+	 * 
+	 * @param sqlQuery
+	 * @param databaseId
+	 * @param limitStr
+	 * @return
+	 */
+	private NounMetadata executeSelectQuery(String sqlQuery, String databaseId, String limitStr) {
+		try {
+			HardSelectQueryStruct qs = getQs(sqlQuery, databaseId);
+			// set limit if provided
+			int limit = parseLimit(limitStr);
+			BasicIteratorTask task = new BasicIteratorTask(qs);
+			task.setNumCollect(limit);
+			task.setCollectLimit(limit);
+			this.insight.addQueriedDatabasesese(databaseId);
+			return new NounMetadata(task, PixelDataType.FORMATTED_DATA_SET);
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new SemossPixelException("Error executing SELECT query: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * 
+	 * @param sqlQuery
+	 * @param databaseId
+	 * @param commitStr
+	 * @return
+	 */
+	private NounMetadata executeModificationQuery(String sqlQuery, String databaseId, String commitStr) {
+		try {
+			HardSelectQueryStruct qs = getQs(sqlQuery, databaseId);
+			// default to false if not provided
+			boolean commit = commitStr != null && !commitStr.trim().isEmpty() && Boolean.parseBoolean(commitStr.trim());
+
+			NounStore execQueryNounStore = new NounStore("ExecQuery");
+			execQueryNounStore.makeGenRowStruct(PixelDataType.QUERY_STRUCT.getKey())
+					.add(new NounMetadata(qs, PixelDataType.QUERY_STRUCT));
+			execQueryNounStore.makeGenRowStruct("commit").add(new NounMetadata(commit, PixelDataType.BOOLEAN));
+
+			ExecQueryReactor execReactor = new ExecQueryReactor();
+			execReactor.setInsight(this.insight);
+			execReactor.setNounStore(execQueryNounStore);
+
+			return execReactor.execute();
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new SemossPixelException("Error executing modification query: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * 
+	 * @param sqlQuery
+	 * @param databaseId
+	 * @return
+	 */
+	private HardSelectQueryStruct getQs(String sqlQuery, String databaseId) {
+		IDatabaseEngine engine = Utility.getDatabase(databaseId);
+		if (engine == null) {
+			throw new SemossPixelException("Database with ID '" + databaseId + "' not found or could not be loaded");
+		}
+
+		// Create HardSelectQueryStruct for raw SQL
+		HardSelectQueryStruct qs = new HardSelectQueryStruct();
+		qs.setEngineId(databaseId);
+		qs.setEngine(engine);
+		qs.setQuery(sqlQuery);
+		qs.setQsType(QUERY_STRUCT_TYPE.RAW_ENGINE_QUERY);
+		return qs;
+	}
+
+	/**
+	 * Parse and validate limit parameter
+	 * 
+	 * @param limitStr
+	 * @return
+	 */
+	private int parseLimit(String limitStr) {
+		int limit = DEFAULT_LIMIT; // default
+
+		if (limitStr != null && !limitStr.trim().isEmpty()) {
+			try {
+				limit = Integer.parseInt(limitStr.trim());
+
+				if (limit <= 0) {
+					classLogger.warn("Non-positive limit value: " + limit + ", using default " + DEFAULT_LIMIT);
+					limit = DEFAULT_LIMIT;
+				} else if (limit > MAX_LIMIT) {
+					classLogger.warn("Limit value " + limit + " exceeds maximum " + MAX_LIMIT + ", using maximum");
+					limit = MAX_LIMIT;
+				}
+
+			} catch (NumberFormatException e) {
+				classLogger.warn("Invalid limit value: " + limitStr + ", using default " + DEFAULT_LIMIT);
+			}
+		}
+
+		return limit;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Execute a Base64-encoded SQL query against a database with pagination support (limit and offset). The SQL query must be provided as a Base64-encoded UTF-8 string.";
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (key.equals(ReactorKeysEnum.QUERY_KEY.getKey())) {
+			return "The SQL query to execute, provided as a Base64-encoded UTF-8 string";
+		}
+		return super.getDescriptionForKey(key);
+	}
+
+}
+

--- a/src/prerna/reactor/qs/SqlQueryBase64Reactor.java
+++ b/src/prerna/reactor/qs/SqlQueryBase64Reactor.java
@@ -2,297 +2,48 @@ package prerna.reactor.qs;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import net.sf.jsqlparser.parser.CCJSqlParserUtil;
-import net.sf.jsqlparser.statement.Statement;
-import net.sf.jsqlparser.statement.delete.Delete;
-import net.sf.jsqlparser.statement.insert.Insert;
-import net.sf.jsqlparser.statement.select.Select;
-import net.sf.jsqlparser.statement.update.Update;
-import prerna.auth.User;
-import prerna.auth.utils.SecurityEngineUtils;
-import prerna.engine.api.IDatabaseEngine;
-import prerna.query.querystruct.AbstractQueryStruct.QUERY_STRUCT_TYPE;
-import prerna.query.querystruct.HardSelectQueryStruct;
-import prerna.reactor.AbstractReactor;
-import prerna.sablecc2.om.NounStore;
-import prerna.sablecc2.om.PixelDataType;
-import prerna.sablecc2.om.PixelOperationType;
+
 import prerna.sablecc2.om.ReactorKeysEnum;
-import prerna.sablecc2.om.execptions.SemossPixelException;
-import prerna.sablecc2.om.nounmeta.NounMetadata;
-import prerna.sablecc2.om.task.BasicIteratorTask;
-import prerna.util.Constants;
-import prerna.util.Utility;
 
 /**
- * Unified SQL Query Reactor that accepts Base64-encoded SQL queries:
- * 1. Decodes Base64-encoded SQL query 2. Parses SQL to detect query type (SELECT vs modification)
- * 3. Validates user permissions based on query type 4. Delegates to appropriate existing reactors
+ * Unified SQL Query Reactor that accepts Base64-encoded SQL queries: 1. Decodes
+ * Base64-encoded SQL query 2. Parses SQL to detect query type (SELECT vs
+ * modification) 3. Validates user permissions based on query type 4. Delegates
+ * to appropriate existing reactors
  * 
- * Usage: SqlQueryBase64(database=["myDb"], query=[base64_encoded_sql], limit=[100], commit=[true])
+ * Usage: SqlQueryBase64(database=["myDb"], query=[base64_encoded_sql],
+ * limit=[100], commit=[true])
  */
-public class SqlQueryBase64Reactor extends AbstractReactor {
-
-	private static final Logger classLogger = LogManager.getLogger(SqlQueryBase64Reactor.class);
-
-	private static final int DEFAULT_LIMIT = 50;
-	private static final int MAX_LIMIT = 5_000;
-
-	private enum QueryType {
-		SELECT, INSERT, UPDATE, DELETE, OTHER
-	}
+public class SqlQueryBase64Reactor extends AbstractSqlQueryReactor {
 
 	public SqlQueryBase64Reactor() {
-		this.keysToGet = new String[] { ReactorKeysEnum.QUERY_KEY.getKey(), ReactorKeysEnum.DATABASE.getKey(),
-				ReactorKeysEnum.LIMIT.getKey(), "commit" };
-		this.keyRequired = new int[] { 1, 1, 0, 0, 0 };
 	}
 
 	@Override
-	public NounMetadata execute() {
-		User user = this.insight.getUser();
-		if (user == null) {
-			NounMetadata noun = new NounMetadata("User must be signed into an account in order to run this operation",
-					PixelDataType.CONST_STRING, PixelOperationType.ERROR, PixelOperationType.LOGGIN_REQUIRED_ERROR);
-			SemossPixelException err = new SemossPixelException(noun);
-			err.setContinueThreadOfExecution(false);
-			throw err;
-		}
-
-		organizeKeys();
-		// Decode Base64-encoded SQL query
-		String sqlQuery = decodeBase64Query(this.keyValue.get(this.keysToGet[0]));
-		String databaseId = this.keyValue.get(this.keysToGet[1]);
-		String limitStr = this.keyValue.get(this.keysToGet[2]);
-		String commitStr = this.keyValue.get(this.keysToGet[3]);
-
-		if (sqlQuery == null || sqlQuery.trim().isEmpty()) {
-			throw new SemossPixelException("SQL query cannot be empty");
-		}
-
-		if (databaseId == null || databaseId.trim().isEmpty()) {
-			throw new SemossPixelException("Database id is required");
-		}
-
+	protected String getDecodedQuery() {
 		try {
-			// determine query type
-			QueryType queryType = detectQueryType(sqlQuery);
-			classLogger.info("Detected query type: {}", queryType);
-			validateUserPermissions(user, databaseId, queryType);
-
-			// create query structure and delegate
-			return delegateToAppropriateReactor(sqlQuery, databaseId, queryType, limitStr, commitStr);
+			return new String(Base64.getDecoder().decode(this.keyValue.get(ReactorKeysEnum.QUERY_KEY.getKey())),
+					StandardCharsets.UTF_8);
 		} catch (Exception e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			throw new SemossPixelException("Error executing SQL query: " + e.getMessage());
+			throw new IllegalArgumentException("Failed to decode SQL query: not valid Base64", e);
 		}
-	}
-
-	/**
-	 * Decode Base64-encoded SQL query
-	 * 
-	 * @param encodedQuery Base64-encoded SQL string
-	 * @return Decoded SQL string
-	 */
-	private String decodeBase64Query(String encodedQuery) {
-		if (encodedQuery == null || encodedQuery.trim().isEmpty()) {
-			throw new SemossPixelException("Encoded SQL query cannot be empty");
-		}
-		
-		try {
-			return new String(Base64.getDecoder().decode(encodedQuery), StandardCharsets.UTF_8);
-		} catch (IllegalArgumentException e) {
-			throw new SemossPixelException(
-					"Failed to decode SQL query: input is not a valid Base64-encoded UTF-8 string", e);
-		} catch (Exception e) {
-			throw new SemossPixelException("Failed to decode SQL query: " + e.getMessage(), e);
-		}
-	}
-
-	/**
-	 * Detect SQL statement type using JSQLParser
-	 */
-	private QueryType detectQueryType(String sql) {
-		try {
-			Statement statement = CCJSqlParserUtil.parse(sql);
-
-			if (statement instanceof Select) {
-				return QueryType.SELECT;
-			} else if (statement instanceof Insert) {
-				return QueryType.INSERT;
-			} else if (statement instanceof Update) {
-				return QueryType.UPDATE;
-			} else if (statement instanceof Delete) {
-				return QueryType.DELETE;
-			} else {
-				// For CREATE, ALTER, DROP, etc.
-				return QueryType.OTHER;
-			}
-		} catch (Exception e) {
-			classLogger.warn("Could not parse SQL statement, defaulting to OTHER type: " + e.getMessage());
-			return QueryType.OTHER;
-		}
-	}
-
-	/**
-	 * 
-	 * @param user
-	 * @param databaseId
-	 * @param queryType
-	 */
-	private void validateUserPermissions(User user, String databaseId, QueryType queryType) {
-		switch (queryType) {
-		case SELECT:
-			// view permission
-			if (!SecurityEngineUtils.userCanViewEngine(user, databaseId)) {
-				throw new SemossPixelException("User does not have permission to query this database");
-			}
-			break;
-		default:
-			// any other modification queries need edit permission
-			if (!SecurityEngineUtils.userCanEditEngine(user, databaseId)) {
-				throw new SemossPixelException("User does not have permission to modify this database");
-			}
-			break;
-		}
-	}
-
-	/**
-	 * 
-	 * @param sqlQuery
-	 * @param databaseId
-	 * @param queryType
-	 * @param limitStr
-	 * @param commitStr
-	 * @return
-	 */
-	private NounMetadata delegateToAppropriateReactor(String sqlQuery, String databaseId, QueryType queryType,
-			String limitStr, String commitStr) {
-
-		if (queryType == QueryType.SELECT) {
-			return executeSelectQuery(sqlQuery, databaseId, limitStr);
-		} else {
-			return executeModificationQuery(sqlQuery, databaseId, commitStr);
-		}
-	}
-
-	/**
-	 * For select, create task and return it directly, much like the collect reactor
-	 * 
-	 * @param sqlQuery
-	 * @param databaseId
-	 * @param limitStr
-	 * @return
-	 */
-	private NounMetadata executeSelectQuery(String sqlQuery, String databaseId, String limitStr) {
-		try {
-			HardSelectQueryStruct qs = getQs(sqlQuery, databaseId);
-			// set limit if provided
-			int limit = parseLimit(limitStr);
-			BasicIteratorTask task = new BasicIteratorTask(qs);
-			task.setNumCollect(limit);
-			task.setCollectLimit(limit);
-			this.insight.addQueriedDatabasesese(databaseId);
-			return new NounMetadata(task, PixelDataType.FORMATTED_DATA_SET);
-		} catch (Exception e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			throw new SemossPixelException("Error executing SELECT query: " + e.getMessage());
-		}
-	}
-
-	/**
-	 * 
-	 * @param sqlQuery
-	 * @param databaseId
-	 * @param commitStr
-	 * @return
-	 */
-	private NounMetadata executeModificationQuery(String sqlQuery, String databaseId, String commitStr) {
-		try {
-			HardSelectQueryStruct qs = getQs(sqlQuery, databaseId);
-			// default to false if not provided
-			boolean commit = commitStr != null && !commitStr.trim().isEmpty() && Boolean.parseBoolean(commitStr.trim());
-
-			NounStore execQueryNounStore = new NounStore("ExecQuery");
-			execQueryNounStore.makeGenRowStruct(PixelDataType.QUERY_STRUCT.getKey())
-					.add(new NounMetadata(qs, PixelDataType.QUERY_STRUCT));
-			execQueryNounStore.makeGenRowStruct("commit").add(new NounMetadata(commit, PixelDataType.BOOLEAN));
-
-			ExecQueryReactor execReactor = new ExecQueryReactor();
-			execReactor.setInsight(this.insight);
-			execReactor.setNounStore(execQueryNounStore);
-
-			return execReactor.execute();
-		} catch (Exception e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			throw new SemossPixelException("Error executing modification query: " + e.getMessage());
-		}
-	}
-
-	/**
-	 * 
-	 * @param sqlQuery
-	 * @param databaseId
-	 * @return
-	 */
-	private HardSelectQueryStruct getQs(String sqlQuery, String databaseId) {
-		IDatabaseEngine engine = Utility.getDatabase(databaseId);
-		if (engine == null) {
-			throw new SemossPixelException("Database with ID '" + databaseId + "' not found or could not be loaded");
-		}
-
-		// Create HardSelectQueryStruct for raw SQL
-		HardSelectQueryStruct qs = new HardSelectQueryStruct();
-		qs.setEngineId(databaseId);
-		qs.setEngine(engine);
-		qs.setQuery(sqlQuery);
-		qs.setQsType(QUERY_STRUCT_TYPE.RAW_ENGINE_QUERY);
-		return qs;
-	}
-
-	/**
-	 * Parse and validate limit parameter
-	 * 
-	 * @param limitStr
-	 * @return
-	 */
-	private int parseLimit(String limitStr) {
-		int limit = DEFAULT_LIMIT; // default
-
-		if (limitStr != null && !limitStr.trim().isEmpty()) {
-			try {
-				limit = Integer.parseInt(limitStr.trim());
-
-				if (limit <= 0) {
-					classLogger.warn("Non-positive limit value: " + limit + ", using default " + DEFAULT_LIMIT);
-					limit = DEFAULT_LIMIT;
-				} else if (limit > MAX_LIMIT) {
-					classLogger.warn("Limit value " + limit + " exceeds maximum " + MAX_LIMIT + ", using maximum");
-					limit = MAX_LIMIT;
-				}
-
-			} catch (NumberFormatException e) {
-				classLogger.warn("Invalid limit value: " + limitStr + ", using default " + DEFAULT_LIMIT);
-			}
-		}
-
-		return limit;
-	}
-
-	@Override
-	public String getReactorDescription() {
-		return "Execute a Base64-encoded SQL query against a database with pagination support (limit and offset). The SQL query must be provided as a Base64-encoded UTF-8 string.";
 	}
 
 	@Override
 	protected String getDescriptionForKey(String key) {
 		if (key.equals(ReactorKeysEnum.QUERY_KEY.getKey())) {
-			return "The SQL query to execute, provided as a Base64-encoded UTF-8 string";
+			return "The SQL query to execute, provided as a Base64-encoded UTF-8 string.";
+		} else if (key.equals(ReactorKeysEnum.DATABASE.getKey())) {
+			return "The database id";
+		} else if (key.equals(ReactorKeysEnum.LIMIT.getKey())) {
+			return "Limits the number of rows retrieved by the SQL query";
+		} else {
+			return super.getDescriptionForKey(key);
 		}
-		return super.getDescriptionForKey(key);
 	}
 
+	@Override
+	public String getReactorDescription() {
+		return "Execute a Base64-encoded SQL query against a database";
+	}
 }
-

--- a/src/prerna/reactor/qs/SqlQueryBase64Reactor.java
+++ b/src/prerna/reactor/qs/SqlQueryBase64Reactor.java
@@ -6,18 +6,9 @@ import java.util.Base64;
 import prerna.sablecc2.om.ReactorKeysEnum;
 
 /**
- * Unified SQL Query Reactor that accepts Base64-encoded SQL queries: 1. Decodes
- * Base64-encoded SQL query 2. Parses SQL to detect query type (SELECT vs
- * modification) 3. Validates user permissions based on query type 4. Delegates
- * to appropriate existing reactors
- * 
- * Usage: SqlQueryBase64(database=["myDb"], query=[base64_encoded_sql],
- * limit=[100], commit=[true])
+ * Executes Base64-encoded sql query against a database.
  */
 public class SqlQueryBase64Reactor extends AbstractSqlQueryReactor {
-
-	public SqlQueryBase64Reactor() {
-	}
 
 	@Override
 	protected String getDecodedQuery() {
@@ -25,25 +16,16 @@ public class SqlQueryBase64Reactor extends AbstractSqlQueryReactor {
 			return new String(Base64.getDecoder().decode(this.keyValue.get(ReactorKeysEnum.QUERY_KEY.getKey())),
 					StandardCharsets.UTF_8);
 		} catch (Exception e) {
-			throw new IllegalArgumentException("Failed to decode SQL query: not valid Base64", e);
+			throw new IllegalArgumentException("Failed to decode python code: input is not base64-encoded utf-8 string",
+					e);
 		}
 	}
 
 	@Override
 	protected String getDescriptionForKey(String key) {
 		if (key.equals(ReactorKeysEnum.QUERY_KEY.getKey())) {
-			return "The SQL query to execute, provided as a Base64-encoded UTF-8 string.";
-		} else if (key.equals(ReactorKeysEnum.DATABASE.getKey())) {
-			return "The database id";
-		} else if (key.equals(ReactorKeysEnum.LIMIT.getKey())) {
-			return "Limits the number of rows retrieved by the SQL query";
-		} else {
-			return super.getDescriptionForKey(key);
+			return "The sql query to execute. The query should be passed in as a base64-encoded utf-8 string";
 		}
-	}
-
-	@Override
-	public String getReactorDescription() {
-		return "Execute a Base64-encoded SQL query against a database";
+		return super.getDescriptionForKey(key);
 	}
 }

--- a/src/prerna/reactor/qs/SqlQueryReactor.java
+++ b/src/prerna/reactor/qs/SqlQueryReactor.java
@@ -31,19 +31,10 @@ import prerna.sablecc2.om.ReactorKeysEnum;
 import prerna.util.Utility;
 
 /**
- * Unified SQL Query Reactor that: 1. Parses SQL to detect query type (SELECT vs
- * modification) 2. Validates user permissions based on query type 3. Delegates
- * to appropriate existing reactors
- * 
- * Usage: SqlQuery(database=["myDb"], query=["SELECT * FROM table"],
- * limit=[100], commit=[true])
+ * Executes query against a database. The query to be executed is expected to be
+ * wrapped in <encode> </encode> blocks.
  */
-
 public class SqlQueryReactor extends AbstractSqlQueryReactor {
-
-	public SqlQueryReactor() {
-
-	}
 
 	@Override
 	protected String getDecodedQuery() {
@@ -53,18 +44,9 @@ public class SqlQueryReactor extends AbstractSqlQueryReactor {
 	@Override
 	protected String getDescriptionForKey(String key) {
 		if (key.equals(ReactorKeysEnum.QUERY_KEY.getKey())) {
-			return "The SQL query to execute, provided as a URL-encoded UTF-8 string.";
-		} else if (key.equals(ReactorKeysEnum.DATABASE.getKey())) {
-			return "The database id";
-		} else if (key.equals(ReactorKeysEnum.LIMIT.getKey())) {
-			return "Limits the number of rows retrieved by the SQL query";
-		} else {
-			return super.getDescriptionForKey(key);
+			return "The sql query to execute. The sql query should be passed wtihin <encode> </encode> blocks for proper encoding";
 		}
+		return super.getDescriptionForKey(key);
 	}
 
-	@Override
-	public String getReactorDescription() {
-		return "Execute a URL-encoded SQL query against a database with pagination support (limit and offset). ";
-	}
 }

--- a/src/prerna/reactor/qs/SqlQueryReactor.java
+++ b/src/prerna/reactor/qs/SqlQueryReactor.java
@@ -27,29 +27,7 @@
  *******************************************************************************/
 package prerna.reactor.qs;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import net.sf.jsqlparser.parser.CCJSqlParserUtil;
-import net.sf.jsqlparser.statement.Statement;
-import net.sf.jsqlparser.statement.delete.Delete;
-import net.sf.jsqlparser.statement.insert.Insert;
-import net.sf.jsqlparser.statement.select.Select;
-import net.sf.jsqlparser.statement.update.Update;
-import prerna.auth.User;
-import prerna.auth.utils.SecurityEngineUtils;
-import prerna.engine.api.IDatabaseEngine;
-import prerna.query.querystruct.AbstractQueryStruct.QUERY_STRUCT_TYPE;
-import prerna.query.querystruct.HardSelectQueryStruct;
-import prerna.reactor.AbstractReactor;
-import prerna.sablecc2.om.NounStore;
-import prerna.sablecc2.om.PixelDataType;
-import prerna.sablecc2.om.PixelOperationType;
 import prerna.sablecc2.om.ReactorKeysEnum;
-import prerna.sablecc2.om.execptions.SemossPixelException;
-import prerna.sablecc2.om.nounmeta.NounMetadata;
-import prerna.sablecc2.om.task.BasicIteratorTask;
-import prerna.util.Constants;
 import prerna.util.Utility;
 
 /**
@@ -60,235 +38,33 @@ import prerna.util.Utility;
  * Usage: SqlQuery(database=["myDb"], query=["SELECT * FROM table"],
  * limit=[100], commit=[true])
  */
-public class SqlQueryReactor extends AbstractReactor {
 
-	private static final Logger classLogger = LogManager.getLogger(SqlQueryReactor.class);
-
-	private static final int DEFAULT_LIMIT = 50;
-	private static final int MAX_LIMIT = 5_000;
-
-	private enum QueryType {
-		SELECT, INSERT, UPDATE, DELETE, OTHER
-	}
+public class SqlQueryReactor extends AbstractSqlQueryReactor {
 
 	public SqlQueryReactor() {
-		this.keysToGet = new String[] { ReactorKeysEnum.QUERY_KEY.getKey(), ReactorKeysEnum.DATABASE.getKey(),
-				ReactorKeysEnum.LIMIT.getKey(), "commit" };
-		this.keyRequired = new int[] { 1, 1, 0, 0, 0 };
+
 	}
 
 	@Override
-	public NounMetadata execute() {
-		User user = this.insight.getUser();
-		if (user == null) {
-			NounMetadata noun = new NounMetadata("User must be signed into an account in order to run this operation",
-					PixelDataType.CONST_STRING, PixelOperationType.ERROR, PixelOperationType.LOGGIN_REQUIRED_ERROR);
-			SemossPixelException err = new SemossPixelException(noun);
-			err.setContinueThreadOfExecution(false);
-			throw err;
-		}
-
-		organizeKeys();
-		String sqlQuery = Utility.decodeURIComponent(this.keyValue.get(this.keysToGet[0]));
-		String databaseId = this.keyValue.get(this.keysToGet[1]);
-		String limitStr = this.keyValue.get(this.keysToGet[2]);
-		String commitStr = this.keyValue.get(this.keysToGet[3]);
-
-		if (sqlQuery == null || sqlQuery.trim().isEmpty()) {
-			throw new SemossPixelException("SQL query cannot be empty");
-		}
-
-		if (databaseId == null || databaseId.trim().isEmpty()) {
-			throw new SemossPixelException("Database id is required");
-		}
-
-		try {
-			// determine query type
-			QueryType queryType = detectQueryType(sqlQuery);
-			classLogger.info("Detected query type: {}", queryType);
-			validateUserPermissions(user, databaseId, queryType);
-
-			// create query structure and delegate
-			return delegateToAppropriateReactor(sqlQuery, databaseId, queryType, limitStr, commitStr);
-		} catch (Exception e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			throw new SemossPixelException("Error executing SQL query: " + e.getMessage());
-		}
+	protected String getDecodedQuery() {
+		return Utility.decodeURIComponent(this.keyValue.get(ReactorKeysEnum.QUERY_KEY.getKey()));
 	}
 
-	/**
-	 * Detect SQL statement type using JSQLParser
-	 */
-	private QueryType detectQueryType(String sql) {
-		try {
-			Statement statement = CCJSqlParserUtil.parse(sql);
-
-			if (statement instanceof Select) {
-				return QueryType.SELECT;
-			} else if (statement instanceof Insert) {
-				return QueryType.INSERT;
-			} else if (statement instanceof Update) {
-				return QueryType.UPDATE;
-			} else if (statement instanceof Delete) {
-				return QueryType.DELETE;
-			} else {
-				// For CREATE, ALTER, DROP, etc.
-				return QueryType.OTHER;
-			}
-		} catch (Exception e) {
-			classLogger.warn("Could not parse SQL statement, defaulting to OTHER type: " + e.getMessage());
-			return QueryType.OTHER;
-		}
-	}
-
-	/**
-	 * 
-	 * @param user
-	 * @param databaseId
-	 * @param queryType
-	 */
-	private void validateUserPermissions(User user, String databaseId, QueryType queryType) {
-		switch (queryType) {
-		case SELECT:
-			// view permission
-			if (!SecurityEngineUtils.userCanViewEngine(user, databaseId)) {
-				throw new SemossPixelException("User does not have permission to query this database");
-			}
-			break;
-		default:
-			// any other modification queries need edit permission
-			if (!SecurityEngineUtils.userCanEditEngine(user, databaseId)) {
-				throw new SemossPixelException("User does not have permission to modify this database");
-			}
-			break;
-		}
-	}
-
-	/**
-	 * 
-	 * @param sqlQuery
-	 * @param databaseId
-	 * @param queryType
-	 * @param limitStr
-	 * @param commitStr
-	 * @return
-	 */
-	private NounMetadata delegateToAppropriateReactor(String sqlQuery, String databaseId, QueryType queryType,
-			String limitStr, String commitStr) {
-
-		if (queryType == QueryType.SELECT) {
-			return executeSelectQuery(sqlQuery, databaseId, limitStr);
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (key.equals(ReactorKeysEnum.QUERY_KEY.getKey())) {
+			return "The SQL query to execute, provided as a URL-encoded UTF-8 string.";
+		} else if (key.equals(ReactorKeysEnum.DATABASE.getKey())) {
+			return "The database id";
+		} else if (key.equals(ReactorKeysEnum.LIMIT.getKey())) {
+			return "Limits the number of rows retrieved by the SQL query";
 		} else {
-			return executeModificationQuery(sqlQuery, databaseId, commitStr);
+			return super.getDescriptionForKey(key);
 		}
-	}
-
-	/**
-	 * For select, create task and return it directly, much like the collect reactor
-	 * 
-	 * @param sqlQuery
-	 * @param databaseId
-	 * @param limitStr
-	 * @return
-	 */
-	private NounMetadata executeSelectQuery(String sqlQuery, String databaseId, String limitStr) {
-		try {
-			HardSelectQueryStruct qs = getQs(sqlQuery, databaseId);
-			// set limit if provided
-			int limit = parseLimit(limitStr);
-			BasicIteratorTask task = new BasicIteratorTask(qs);
-			task.setNumCollect(limit);
-			task.setCollectLimit(limit);
-			this.insight.addQueriedDatabasesese(databaseId);
-			return new NounMetadata(task, PixelDataType.FORMATTED_DATA_SET);
-		} catch (Exception e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			throw new SemossPixelException("Error executing SELECT query: " + e.getMessage());
-		}
-	}
-
-	/**
-	 * 
-	 * @param sqlQuery
-	 * @param databaseId
-	 * @param commitStr
-	 * @return
-	 */
-	private NounMetadata executeModificationQuery(String sqlQuery, String databaseId, String commitStr) {
-		try {
-			HardSelectQueryStruct qs = getQs(sqlQuery, databaseId);
-			// default to false if not provided
-			boolean commit = commitStr != null && !commitStr.trim().isEmpty() && Boolean.parseBoolean(commitStr.trim());
-
-			NounStore execQueryNounStore = new NounStore("ExecQuery");
-			execQueryNounStore.makeGenRowStruct(PixelDataType.QUERY_STRUCT.getKey())
-					.add(new NounMetadata(qs, PixelDataType.QUERY_STRUCT));
-			execQueryNounStore.makeGenRowStruct("commit").add(new NounMetadata(commit, PixelDataType.BOOLEAN));
-
-			ExecQueryReactor execReactor = new ExecQueryReactor();
-			execReactor.setInsight(this.insight);
-			execReactor.setNounStore(execQueryNounStore);
-
-			return execReactor.execute();
-		} catch (Exception e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			throw new SemossPixelException("Error executing modification query: " + e.getMessage());
-		}
-	}
-
-	/**
-	 * 
-	 * @param sqlQuery
-	 * @param databaseId
-	 * @return
-	 */
-	private HardSelectQueryStruct getQs(String sqlQuery, String databaseId) {
-		IDatabaseEngine engine = Utility.getDatabase(databaseId);
-		if (engine == null) {
-			throw new SemossPixelException("Database with ID '" + databaseId + "' not found or could not be loaded");
-		}
-
-		// Create HardSelectQueryStruct for raw SQL
-		HardSelectQueryStruct qs = new HardSelectQueryStruct();
-		qs.setEngineId(databaseId);
-		qs.setEngine(engine);
-		qs.setQuery(sqlQuery);
-		qs.setQsType(QUERY_STRUCT_TYPE.RAW_ENGINE_QUERY);
-		return qs;
-	}
-
-	/**
-	 * Parse and validate limit parameter
-	 * 
-	 * @param limitStr
-	 * @return
-	 */
-	private int parseLimit(String limitStr) {
-		int limit = DEFAULT_LIMIT; // default
-
-		if (limitStr != null && !limitStr.trim().isEmpty()) {
-			try {
-				limit = Integer.parseInt(limitStr.trim());
-
-				if (limit <= 0) {
-					classLogger.warn("Non-positive limit value: " + limit + ", using default " + DEFAULT_LIMIT);
-					limit = DEFAULT_LIMIT;
-				} else if (limit > MAX_LIMIT) {
-					classLogger.warn("Limit value " + limit + " exceeds maximum " + MAX_LIMIT + ", using maximum");
-					limit = MAX_LIMIT;
-				}
-
-			} catch (NumberFormatException e) {
-				classLogger.warn("Invalid limit value: " + limitStr + ", using default " + DEFAULT_LIMIT);
-			}
-		}
-
-		return limit;
 	}
 
 	@Override
 	public String getReactorDescription() {
-		return "Execute a SQL query against a database with pagination support (limit and offset)";
+		return "Execute a URL-encoded SQL query against a database with pagination support (limit and offset). ";
 	}
-
 }


### PR DESCRIPTION
## Description
Create SqlQueryBase64Reactor that accepts Base64-encoded SQL queries, decodes them, and delegates to the same execution logic as SqlQueryReactor.

**How to test:**
1. Go to any Base64 encoder website:
[base64encode.org](https://www.base64encode.org/)
2. Enter your SQL query and encode it
Example:
SQL: SELECT * FROM users WHERE id = 1
Encoded: U0VMRUNUICogRlJPTSB1c2VycyBXSEVSRSBpZCA9IDE=
Use this in below query:

<img width="928" height="490" alt="sqlquery" src="https://github.com/user-attachments/assets/b29c8394-efac-4780-a500-1b151f04a6ea" />
