### PR TITLE
feat(model): add admin per-user token usage report

### DIFF
--- a/RDF_Map.prop
+++ b/RDF_Map.prop
@@ -72,7 +72,7 @@ NETTY_PYTHON true
 NATIVE_PY_SERVER true
 
 USE_PYTHON true
-PYTHONHOME C:\\workspace\\Semoss\\py\\install_config\\.venv
+PYTHONHOME C:\\workspace\\Semoss\\py\\install_config\\.venv\\Scripts
 
 USE_R false
 R_CONNECTION_JRI	false

--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -2910,4 +2910,85 @@ public class ModelInferenceLogsUtils {
 		return QueryExecutionUtility.flushRsToMap(modelInferenceLogsDb, qs);
 	}
 
+	/**
+	 * Get model inference token usage report for specified users on a specific
+	 * model engine
+	 * 
+	 * @param modelId   The model engine ID
+	 * @param userIds   List of user IDs to report on
+	 * @param startDate Optional start date (format: YYYY-MM-DD HH:MM:SS.SSS)
+	 * @param endDate   Optional end date (format: YYYY-MM-DD HH:MM:SS.SSS)
+	 * @return List of maps with token usage per user
+	 */
+	public static List<Map<String, Object>> getModelInferenceUserTokenReport(String modelId, List<String> userIds,
+			String startDate, String endDate) {
+		IRDBMSEngine modelInferenceLogsDb = SystemEngineRegistry.getModelInferenceLogsDb();
+		SelectQueryStruct qs = new SelectQueryStruct();
+
+		// Select user info
+		qs.addSelector(new QueryColumnSelector(MESSAGE_TABLE_NAME + "USER_ID", "user_id"));
+		qs.addSelector(new QueryColumnSelector(MESSAGE_TABLE_NAME + "USER_NAME", "user_name"));
+
+		// SUM(CASE WHEN MESSAGE_TYPE='INPUT' THEN MESSAGE_TOKENS ELSE 0 END) AS
+		// INPUT_TOKENS
+		QueryIfSelector inputIf = QueryIfSelector.makeQueryIfSelector(
+				SimpleQueryFilter.makeColToValFilter(MESSAGE_TABLE_NAME + "MESSAGE_TYPE", "==", "INPUT"),
+				new QueryColumnSelector(MESSAGE_TABLE_NAME + "MESSAGE_TOKENS"), new QueryConstantSelector(0),
+				"INPUT_IF");
+		QueryFunctionSelector inputTokenSelector = new QueryFunctionSelector();
+		inputTokenSelector.setAlias("input_tokens");
+		inputTokenSelector.setFunction(QueryFunctionHelper.SUM);
+		inputTokenSelector.addInnerSelector(inputIf);
+		qs.addSelector(inputTokenSelector);
+
+		// SUM(CASE WHEN MESSAGE_TYPE='RESPONSE' THEN MESSAGE_TOKENS ELSE 0 END) AS
+		// RESPONSE_TOKENS
+		QueryIfSelector responseIf = QueryIfSelector.makeQueryIfSelector(
+				SimpleQueryFilter.makeColToValFilter(MESSAGE_TABLE_NAME + "MESSAGE_TYPE", "==", "RESPONSE"),
+				new QueryColumnSelector(MESSAGE_TABLE_NAME + "MESSAGE_TOKENS"), new QueryConstantSelector(0),
+				"RESPONSE_IF");
+		QueryFunctionSelector responseTokenSelector = new QueryFunctionSelector();
+		responseTokenSelector.setAlias("response_tokens");
+		responseTokenSelector.setFunction(QueryFunctionHelper.SUM);
+		responseTokenSelector.addInnerSelector(responseIf);
+		qs.addSelector(responseTokenSelector);
+
+		// SUM(MESSAGE_TOKENS) AS TOTAL_TOKENS
+		QueryFunctionSelector totalTokenSelector = new QueryFunctionSelector();
+		totalTokenSelector.setAlias("total_tokens");
+		totalTokenSelector.setFunction(QueryFunctionHelper.SUM);
+		totalTokenSelector.addInnerSelector(new QueryColumnSelector(MESSAGE_TABLE_NAME + "MESSAGE_TOKENS"));
+		qs.addSelector(totalTokenSelector);
+
+		// COUNT(DISTINCT MESSAGE_ID) for total messages
+		QueryFunctionSelector msgCountSelector = new QueryFunctionSelector();
+		msgCountSelector.setAlias("total_messages");
+		msgCountSelector.setFunction(QueryFunctionHelper.COUNT);
+		msgCountSelector.addInnerSelector(new QueryColumnSelector(MESSAGE_TABLE_NAME + "MESSAGE_ID"));
+		qs.addSelector(msgCountSelector);
+
+		// Filter by model engine ID
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(MESSAGE_TABLE_NAME + "AGENT_ID", "==", modelId));
+
+		// Filter by user IDs
+		if (userIds != null && !userIds.isEmpty()) {
+			qs.addExplicitFilter(
+					SimpleQueryFilter.makeColToValFilter(MESSAGE_TABLE_NAME + "USER_ID", "==", userIds));
+		}
+
+		// Filter by date range if provided
+		if (startDate != null && endDate != null) {
+			addStartDateEndDateFitler(qs, startDate, endDate);
+		}
+
+		// Group by user
+		qs.addGroupBy(new QueryColumnSelector(MESSAGE_TABLE_NAME + "USER_ID"));
+		qs.addGroupBy(new QueryColumnSelector(MESSAGE_TABLE_NAME + "USER_NAME"));
+
+		// Order by total tokens descending
+		qs.addOrderBy("total_tokens", "DESC");
+
+		return QueryExecutionUtility.flushRsToMap(modelInferenceLogsDb, qs);
+	}
+
 }

--- a/src/prerna/reactor/model/GetAdminModelUsageReactor.java
+++ b/src/prerna/reactor/model/GetAdminModelUsageReactor.java
@@ -1,0 +1,154 @@
+package prerna.reactor.model;
+
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.SecurityAdminUtils;
+import prerna.auth.utils.SecurityEngineUtils;
+import prerna.engine.api.IEngine;
+import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetAdminModelUsageReactor extends AbstractReactor {
+
+    private static final String USERS_KEY = "users";
+
+    public GetAdminModelUsageReactor() {
+        this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey(), USERS_KEY,
+                ReactorKeysEnum.START_DATE.getKey(), ReactorKeysEnum.END_DATE.getKey() };
+        this.keyRequired = new int[] { 1, 1, 0, 0 }; // engine and users required, dates optional
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        if (user == null) {
+            throw new IllegalArgumentException("You are not properly logged in");
+        }
+
+        if (!SecurityAdminUtils.userIsAdmin(user)) {
+            throwFunctionalityOnlyExposedForAdminsError();
+        }
+
+        // Get and validate model engine
+        String modelId = getModelEngineId();
+        if (modelId == null || modelId.trim().isEmpty()) {
+            throw new IllegalArgumentException("Must input a model id");
+        }
+
+        if (SecurityEngineUtils.getEngineType(modelId) != IEngine.CATALOG_TYPE.MODEL) {
+            throw new IllegalArgumentException("Input engine must be a model engine");
+        }
+
+        // Get and validate users list
+        List<String> userIds = getListString(USERS_KEY);
+        if (userIds == null || userIds.isEmpty()) {
+            throw new IllegalArgumentException("Must input at least one user id");
+        }
+
+        // Get and validate date parameters
+        String startDate = this.keyValue.get(ReactorKeysEnum.START_DATE.getKey());
+        String endDate = this.keyValue.get(ReactorKeysEnum.END_DATE.getKey());
+        validateDateParameters(startDate, endDate);
+
+        // Format dates for query (convert from YYYY-MM-DD to full datetime format if
+        // provided)
+        String formattedStartDate = startDate != null ? startDate + " 00:00:00.000" : null;
+        String formattedEndDate = endDate != null ? endDate + " 23:59:59.999" : null;
+
+        List<Map<String, Object>> usageList = ModelInferenceLogsUtils.getModelInferenceUserTokenReport(modelId,
+                userIds, formattedStartDate, formattedEndDate);
+        return new NounMetadata(usageList, PixelDataType.FORMATTED_DATA_SET);
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Admin-only report of model tokens used by a specified list of users over a specified time period. "
+                + "Requires model engine ID and list of user IDs. Date range is optional (if provided, both start and end dates must be given).";
+    }
+
+    @Override
+    protected String getDescriptionForKey(String key) {
+        if (key.equals(ReactorKeysEnum.ENGINE.getKey())) {
+            return "Required model engine ID or alias";
+        } else if (key.equals(USERS_KEY)) {
+            return "Required list of user IDs to include in the report";
+        } else if (key.equals(ReactorKeysEnum.START_DATE.getKey())) {
+            return "Optional start date (format: YYYY-MM-DD). Must be provided with endDate.";
+        } else if (key.equals(ReactorKeysEnum.END_DATE.getKey())) {
+            return "Optional end date (format: YYYY-MM-DD). Must be provided with startDate.";
+        }
+        return super.getDescriptionForKey(key);
+    }
+
+    /**
+     * Validates that if one date is provided, both must be provided,
+     * that dates are valid, and that start date is before or equal to end date
+     * 
+     * @param startDate
+     * @param endDate
+     */
+    private void validateDateParameters(String startDate, String endDate) {
+        boolean hasStartDate = startDate != null && !startDate.trim().isEmpty();
+        boolean hasEndDate = endDate != null && !endDate.trim().isEmpty();
+
+        if (hasStartDate != hasEndDate) {
+            throw new IllegalArgumentException(
+                    "Both startDate and endDate must be provided together, or neither should be provided");
+        }
+
+        // If both dates are provided, validate them
+        if (hasStartDate && hasEndDate) {
+            ZonedDateTime start;
+            ZonedDateTime end;
+
+            // Parse and validate start date
+            try {
+                start = LocalDate.parse(startDate.trim()).atStartOfDay(ZoneOffset.UTC);
+            } catch (DateTimeParseException e) {
+                throw new IllegalArgumentException(
+                        "Invalid startDate format. Expected format: YYYY-MM-DD (e.g., 2026-01-15)");
+            }
+
+            // Parse and validate end date
+            try {
+                end = LocalDate.parse(endDate.trim()).atStartOfDay(ZoneOffset.UTC);
+            } catch (DateTimeParseException e) {
+                throw new IllegalArgumentException(
+                        "Invalid endDate format. Expected format: YYYY-MM-DD (e.g., 2026-01-15)");
+            }
+
+            // Validate start date is before or equal to end date
+            if (start.isAfter(end)) {
+                throw new IllegalArgumentException(
+                        "startDate must be before or equal to endDate. Provided: startDate=" + startDate
+                                + ", endDate=" + endDate);
+            }
+        }
+    }
+
+    private String getModelEngineId() {
+        if (this.keyValue.containsKey(ReactorKeysEnum.ENGINE.getKey())) {
+            Object engineObj = this.keyValue.get(ReactorKeysEnum.ENGINE.getKey());
+            if (engineObj instanceof String) {
+                return (String) engineObj;
+            } else if (engineObj instanceof List) {
+                List<?> engineList = (List<?>) engineObj;
+                if (!engineList.isEmpty()) {
+                    return (String) engineList.get(0); // take first if somehow a list
+                }
+            }
+        }
+        return null;
+    }
+
+}


### PR DESCRIPTION
## Description
This is in relation to the request https://github.com/SEMOSS/Semoss/issues/2050

Still a work in progress
## Changes Made
Created a reactor that gets users token usage as an admin. With changes in ModelInterfaceLogsUtils and a new reactor file.
## How to Test
<!-- Explain how reviewers can test your changes -->
As admin, run GetAdminModelUsage with:
engine
users (list of user_id values)
optional startDate/endDate
Confirm response includes per-user totals:
user_id, user_name, input_tokens, response_tokens, total_tokens, total_messages

## Notes
Currently still work in progress, pushed for review of some functions.