### PR TITLE
Simplify messages flag

### DIFF
--- a/py/genai_client/message_builders/openai/openai_message_builder.py
+++ b/py/genai_client/message_builders/openai/openai_message_builder.py
@@ -34,10 +34,16 @@ from ..semoss_base.semoss_models import (
 
 class OpenAIMessageBuilder:
 
-    def __init__(self, model_settings: ModelSettings, chat_type: str):
+    def __init__(
+        self,
+        model_settings: ModelSettings,
+        chat_type: str,
+        simplify_messages: bool = False,
+    ):
         """Initialize the OpenAI message builder with a specific model name."""
         self.model_settings = model_settings
         self.chat_type = chat_type
+        self.simplify_messages = simplify_messages
 
     def build_request(self, semoss_messages: List[SEMOSSMessage]) -> Dict[str, Any]:
         """Build complete OpenAI request with messages and parameters. This is a dictionary that can be sent directly to OpenAI"""
@@ -375,6 +381,15 @@ class OpenAIMessageBuilder:
                 # this message might be a tool result with no other content
                 # in that case we don't want to add an additional message with empty content
                 elif content_parts:
+                    if (
+                        len(content_parts) == 1
+                        and isinstance(content_parts[0], OpenAITextContentPart)
+                        and self.simplify_messages
+                    ):
+                        content = content_parts[0].text
+                    else:
+                        content = content_parts
+
                     openai_messages.append(
                         OpenAIMessage(
                             role=(
@@ -382,7 +397,7 @@ class OpenAIMessageBuilder:
                                 if message.io == "INPUT"
                                 else OpenAIRoles.ASSISTANT.value
                             ),
-                            content=content_parts,
+                            content=content,
                         )
                     )
 

--- a/py/genai_client/text_generation/openai_clients/openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_client.py
@@ -21,6 +21,7 @@ from ...tokenizers.tgi_tokenizer import TGITokenizer
 from ...tokenizers.openai_tokenizer import OpenAiTokenizer
 from ...tokenizers.huggingface_tokenizer import HuggingfaceTokenizer
 from ..model_engine_exception import ModelEngineException, ErrorDetails
+from ...utils import string_to_bool
 
 
 class OpenAiClient(AbstractTextGenerationClient):
@@ -41,6 +42,7 @@ class OpenAiClient(AbstractTextGenerationClient):
         "thinking",
         "thinking_budget",
         "global_param_override",
+        "simplify_messages",
     }
 
     def __init__(
@@ -64,8 +66,13 @@ class OpenAiClient(AbstractTextGenerationClient):
         self.chat_type = self.model_settings.chat_type
         self.tokenizer = self._get_tokenizer(kwargs)
         self.client = self._get_client(api_key, is_azure, **client_kwargs)
+        self.simplify_messages = string_to_bool(
+            parent_kwargs.get("simplify_messages", False)
+        )
 
-        self.message_builder = OpenAIMessageBuilder(self.model_settings, self.chat_type)
+        self.message_builder = OpenAIMessageBuilder(
+            self.model_settings, self.chat_type, self.simplify_messages
+        )
         self.image_client = OpenAiImageClient(client=self)
         self.audio_client = OpenAiAudioClient(client=self)
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Adding a simpify_messages flag that is honor'ed in the openai client through the init script. This simplifies the content to always be a string message. Some API's like GenAI.mil require this format. 

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->