### PR TITLE
feat: use lazy tokenizer to defer import of heavy modules in faiss

### DIFF
--- a/py/genai_client/__init__.py
+++ b/py/genai_client/__init__.py
@@ -79,6 +79,10 @@ def __getattr__(name: str) -> Any:
         from .tokenizers.huggingface_tokenizer import HuggingfaceTokenizer
 
         return HuggingfaceTokenizer
+    elif name == "LazyTokenizer":
+        from .tokenizers.lazy_tokenizer import LazyTokenizer
+
+        return LazyTokenizer
 
     elif name == "BedrockEmbedder":
         from .embedders.bedrock_embedder import BedrockEmbedder
@@ -161,23 +165,16 @@ def get_embedder(embedder_type, **kwargs):
 
 def get_tokenizer(tokenizer_type: str, tokenizer_name, max_tokens):
     """
-    Utility method to  get the appropriate tokenizer based on the Model Engine
+    Utility method to get the appropriate tokenizer based on the Model Engine.
+    Returns a LazyTokenizer that defers the expensive construction until first use.
     """
-    if (tokenizer_type == "EMBEDDED") or (tokenizer_type == "TEXT_GENERATION"):
-        from .tokenizers.huggingface_tokenizer import HuggingfaceTokenizer
+    from .tokenizers.lazy_tokenizer import LazyTokenizer
 
-        return HuggingfaceTokenizer(encoder_name=tokenizer_name, max_tokens=max_tokens)
-    elif tokenizer_type == "OPEN_AI":
-        from .tokenizers.openai_tokenizer import OpenAiTokenizer
-
-        return OpenAiTokenizer(encoder_name=tokenizer_name, max_tokens=max_tokens)
-    # putting this for now, need to implement vertex tokenizer. this will fall back to WordCountTokenizer
-    elif (tokenizer_type == "VERTEX") or (tokenizer_type == "BEDROCK"):
-        from .tokenizers.openai_tokenizer import OpenAiTokenizer
-
-        return OpenAiTokenizer(encoder_name=tokenizer_name, max_tokens=max_tokens)
-    else:
-        raise ValueError("Tokenizer type has not been defined.")
+    return LazyTokenizer(
+        tokenizer_type=tokenizer_type,
+        encoder_name=tokenizer_name,
+        max_tokens=max_tokens,
+    )
 
 
 __all__ = [
@@ -196,6 +193,7 @@ __all__ = [
     "VertexAiEmbedder",
     "OpenAiTokenizer",
     "HuggingfaceTokenizer",
+    "LazyTokenizer",
     "get_text_gen_client",
     "get_embedder",
     "get_tokenizer",

--- a/py/genai_client/tokenizers/huggingface_tokenizer.py
+++ b/py/genai_client/tokenizers/huggingface_tokenizer.py
@@ -1,5 +1,4 @@
 from typing import Dict, List, Union
-from transformers import AutoTokenizer
 from .abstract_tokenizer import AbstractTokenizer
 
 
@@ -27,6 +26,7 @@ class HuggingfaceTokenizer(AbstractTokenizer):
         Returns the appropriate encoding based on the given encoding type (either an encoding string or a model name).
         """
         try:
+            from transformers import AutoTokenizer
             return AutoTokenizer.from_pretrained(encoder_name)
         except:
             from .word_count_tokenizer import WordCountTokenizer

--- a/py/genai_client/tokenizers/lazy_tokenizer.py
+++ b/py/genai_client/tokenizers/lazy_tokenizer.py
@@ -1,16 +1,17 @@
-from typing import Optional
 from .abstract_tokenizer import AbstractTokenizer
 
 
 class LazyTokenizer:
     """
-    A lightweight carrier that stores tokenizer construction arguments and
-    defers the expensive import/construction until ``resolve()`` is called.
+    A transparent proxy that stores tokenizer construction arguments and
+    defers the expensive import/construction until the first attribute access
+    or ``isinstance()`` check.
 
-    Callers should replace their reference with the resolved tokenizer::
+    Consumers do not need special handling — attribute access and
+    ``isinstance`` checks resolve the real tokenizer automatically::
 
-        if isinstance(self.tokenizer, LazyTokenizer):
-            self.tokenizer = self.tokenizer.resolve()
+        tokenizer.count_tokens("hello")                      # triggers resolve
+        isinstance(tokenizer, HuggingfaceTokenizer)           # also triggers resolve
     """
 
     _TYPE_MAP = {
@@ -22,20 +23,39 @@ class LazyTokenizer:
     }
 
     def __init__(self, tokenizer_type: str, encoder_name: str, max_tokens: int, **extra_kwargs):
-        self.tokenizer_type = tokenizer_type
-        self._init_kwargs = {
+        object.__setattr__(self, '_tokenizer_type', tokenizer_type)
+        object.__setattr__(self, '_init_kwargs', {
             "encoder_name": encoder_name,
             "max_tokens": max_tokens,
             **extra_kwargs,
-        }
+        })
+        object.__setattr__(self, '_resolved', None)
 
-    def resolve(self) -> AbstractTokenizer:
-        """Construct and return the real tokenizer."""
+    def _ensure_resolved(self):
+        if self._resolved is not None:
+            return
         import importlib
-        entry = self._TYPE_MAP.get(self.tokenizer_type)
+        entry = self._TYPE_MAP.get(self._tokenizer_type)
         if entry is None:
-            raise ValueError(f"Tokenizer type has not been defined: {self.tokenizer_type}")
+            raise ValueError(f"Tokenizer type has not been defined: {self._tokenizer_type}")
         module_path, class_name = entry
         mod = importlib.import_module(module_path)
         cls = getattr(mod, class_name)
-        return cls(**self._init_kwargs)
+        object.__setattr__(self, '_resolved', cls(**self._init_kwargs))
+
+    # --- transparent proxy ------------------------------------------------
+
+    @property
+    def __class__(self):
+        """Allow ``isinstance(proxy, RealTokenizer)`` to work after resolution."""
+        self._ensure_resolved()
+        return type(self._resolved)
+
+    def __getattr__(self, name):
+        self._ensure_resolved()
+        return getattr(self._resolved, name)
+
+    def __repr__(self):
+        if self._resolved is not None:
+            return repr(self._resolved)
+        return f"LazyTokenizer(type={self._tokenizer_type!r}, unresolved)"

--- a/py/genai_client/tokenizers/lazy_tokenizer.py
+++ b/py/genai_client/tokenizers/lazy_tokenizer.py
@@ -1,0 +1,41 @@
+from typing import Optional
+from .abstract_tokenizer import AbstractTokenizer
+
+
+class LazyTokenizer:
+    """
+    A lightweight carrier that stores tokenizer construction arguments and
+    defers the expensive import/construction until ``resolve()`` is called.
+
+    Callers should replace their reference with the resolved tokenizer::
+
+        if isinstance(self.tokenizer, LazyTokenizer):
+            self.tokenizer = self.tokenizer.resolve()
+    """
+
+    _TYPE_MAP = {
+        "EMBEDDED": ("genai_client.tokenizers.huggingface_tokenizer", "HuggingfaceTokenizer"),
+        "TEXT_GENERATION": ("genai_client.tokenizers.huggingface_tokenizer", "HuggingfaceTokenizer"),
+        "OPEN_AI": ("genai_client.tokenizers.openai_tokenizer", "OpenAiTokenizer"),
+        "VERTEX": ("genai_client.tokenizers.openai_tokenizer", "OpenAiTokenizer"),
+        "BEDROCK": ("genai_client.tokenizers.openai_tokenizer", "OpenAiTokenizer"),
+    }
+
+    def __init__(self, tokenizer_type: str, encoder_name: str, max_tokens: int, **extra_kwargs):
+        self.tokenizer_type = tokenizer_type
+        self._init_kwargs = {
+            "encoder_name": encoder_name,
+            "max_tokens": max_tokens,
+            **extra_kwargs,
+        }
+
+    def resolve(self) -> AbstractTokenizer:
+        """Construct and return the real tokenizer."""
+        import importlib
+        entry = self._TYPE_MAP.get(self.tokenizer_type)
+        if entry is None:
+            raise ValueError(f"Tokenizer type has not been defined: {self.tokenizer_type}")
+        module_path, class_name = entry
+        mod = importlib.import_module(module_path)
+        cls = getattr(mod, class_name)
+        return cls(**self._init_kwargs)

--- a/py/vector_database/faiss/faiss_client.py
+++ b/py/vector_database/faiss/faiss_client.py
@@ -11,10 +11,16 @@ import glob
 import re
 
 # CFG/SEMOSS packages
-from genai_client import HuggingfaceTokenizer
 from gaas_gpt_model import ModelEngine
 from ..constants import ENCODING_OPTIONS
 from ..utils.bm25_client import BM25Searcher
+
+
+def _resolve_tokenizer(instance):
+    """If the tokenizer is a LazyTokenizer, resolve it and replace on the instance."""
+    from genai_client.tokenizers.lazy_tokenizer import LazyTokenizer
+    if isinstance(instance.tokenizer, LazyTokenizer):
+        instance.tokenizer = instance.tokenizer.resolve()
 
 
 class FAISSSearcher:
@@ -266,6 +272,8 @@ class FAISSSearcher:
         insight_id: Optional[str],
     ) -> List[Dict]:
         """Original vector-only search logic"""
+        from genai_client import HuggingfaceTokenizer
+        _resolve_tokenizer(self)
         if columns_to_return is None:
             columns_to_return = list(self.ds.features)
 
@@ -819,6 +827,8 @@ class FAISSSearcher:
         Returns:
             `Dict` A dictionary listing which documents have been successfully created
         """
+        from genai_client import HuggingfaceTokenizer
+        _resolve_tokenizer(self)
         # make sure they are all in indexed_files dir
         assert {
             os.path.basename(os.path.dirname(path)) for path in documentFileLocation

--- a/py/vector_database/faiss/faiss_client.py
+++ b/py/vector_database/faiss/faiss_client.py
@@ -16,13 +16,6 @@ from ..constants import ENCODING_OPTIONS
 from ..utils.bm25_client import BM25Searcher
 
 
-def _resolve_tokenizer(instance):
-    """If the tokenizer is a LazyTokenizer, resolve it and replace on the instance."""
-    from genai_client.tokenizers.lazy_tokenizer import LazyTokenizer
-    if isinstance(instance.tokenizer, LazyTokenizer):
-        instance.tokenizer = instance.tokenizer.resolve()
-
-
 class FAISSSearcher:
     """
     The primary class for a faiss database classes and searching document embeddings
@@ -273,7 +266,6 @@ class FAISSSearcher:
     ) -> List[Dict]:
         """Original vector-only search logic"""
         from genai_client import HuggingfaceTokenizer
-        _resolve_tokenizer(self)
         if columns_to_return is None:
             columns_to_return = list(self.ds.features)
 
@@ -828,7 +820,6 @@ class FAISSSearcher:
             `Dict` A dictionary listing which documents have been successfully created
         """
         from genai_client import HuggingfaceTokenizer
-        _resolve_tokenizer(self)
         # make sure they are all in indexed_files dir
         assert {
             os.path.basename(os.path.dirname(path)) for path in documentFileLocation


### PR DESCRIPTION
## Description
Previously, when we listed documents in a cold vector database, it would take a long time for the vector database to initialize before we could list files. Specifically, the case is that the tokenizer initialization would take time due to HuggingfaceTokenizer's usage of AutoTokenizer, which is a heavy import. This PR shifts the onus on fully resolving the tokenizer to when we need it in either the vector search or add documents methods, thereby improving execution times for other methods.

### How to test
- Compare running the list documents method on a cold vector database with and without this PR. You will find that this PR consistently improves the vector db initialization time.