### PR TITLE
fix: avoid npe by providing empty list

### DIFF
--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
@@ -120,7 +120,7 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 	 * @return list of MCP maps; each map represents one MCP configuration object
 	 */
 	List<Map<String, Object>> getMcpMapList() {
-		return getList(ReactorKeysEnum.MCP.getKey());
+		return getList(ReactorKeysEnum.MCP.getKey(), List.of());
 	}
 
 }


### PR DESCRIPTION
Previously, if we attempt to call this reactor without any value for the MCP key, we'd get an NPE in the reactor. This pr fixes that by returning an empty list by default if nothing is passed.