### PR TITLE
Add grounding support none checks to citation logic in Python Google GenAI client

### DIFF
--- a/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
+++ b/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
@@ -219,7 +219,7 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
             hasattr(response, "candidates")
             and response.candidates
             and hasattr(response.candidates[0], "content")
-            and hasattr(response.candidates[0].content, "parts")
+            and getattr(response.candidates[0].content, "parts", None)
         ):
             parts_with_fc = [
                 p
@@ -283,8 +283,8 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
                 candidate = event.candidates[0]
                 if getattr(candidate, "grounding_metadata", None):
                     latest_grounding_metadata = candidate.grounding_metadata
-                if hasattr(candidate, "content") and hasattr(
-                    candidate.content, "parts"
+                if hasattr(candidate, "content") and getattr(
+                    candidate.content, "parts", None
                 ):
                     for part in candidate.content.parts:
                         if (
@@ -601,6 +601,9 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
             chunks = response.candidates[0].grounding_metadata.grounding_chunks
         except Exception:
             return getattr(response, "text", "") or ""
+
+        if not supports or not chunks:
+            return text or ""
 
         # Sort supports by end_index in descending order to avoid shifting issues when inserting.
         sorted_supports = sorted(


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Add grounding support none checks to citation logic in Python Google GenAI client. Fixes bug with Gemini 3.1 Pro with web search enabled. 

## Changes Made
<!-- List the key changes made in this PR -->

Updating a few None checks in `GoogleGenAiTextClient`.

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->