### PR TITLE
feat: Added ImputeNullValuesReactor and FilterEmptyValuesReactor for Python clean routines

### DIFF
--- a/src/prerna/query/interpreters/PandasInterpreter.java
+++ b/src/prerna/query/interpreters/PandasInterpreter.java
@@ -1911,7 +1911,12 @@ public class PandasInterpreter extends AbstractQueryInterpreter {
 					retBuilder.append(" | ");
 				}
 				retBuilder.append("(").append(frameName).append("[").append(leftSelectorExpression)
-						.append("].apply(lambda x: x").append(thisComparator).append(objects.get(i)).append("))");
+						.append("].apply(lambda x: x").append(thisComparator);
+						if (objects.get(i) instanceof String && ((String)objects.get(i)).isEmpty()) {
+							retBuilder.append("\"\"").append("))");
+						} else {
+							retBuilder.append(objects.get(i)).append("))");
+						}
 			}
 		}
 

--- a/src/prerna/query/interpreters/PandasInterpreter.java
+++ b/src/prerna/query/interpreters/PandasInterpreter.java
@@ -1912,11 +1912,11 @@ public class PandasInterpreter extends AbstractQueryInterpreter {
 				}
 				retBuilder.append("(").append(frameName).append("[").append(leftSelectorExpression)
 						.append("].apply(lambda x: x").append(thisComparator);
-						if (objects.get(i) instanceof String && ((String)objects.get(i)).isEmpty()) {
-							retBuilder.append("\"\"").append("))");
-						} else {
-							retBuilder.append(objects.get(i)).append("))");
-						}
+				if (objects.get(i) instanceof String && ((String) objects.get(i)).isEmpty()) {
+					retBuilder.append("\"\"").append("))");
+				} else {
+					retBuilder.append(objects.get(i)).append("))");
+				}
 			}
 		}
 

--- a/src/prerna/reactor/frame/py/FilterEmptyValuesReactor.java
+++ b/src/prerna/reactor/frame/py/FilterEmptyValuesReactor.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.frame.py;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+
+import prerna.ds.py.PandasFrame;
+import prerna.ds.py.PyTranslator;
+import prerna.query.interpreters.PandasInterpreter;
+import prerna.query.querystruct.filters.GenRowFilters;
+import prerna.query.querystruct.filters.SimpleQueryFilter;
+import prerna.sablecc2.om.GenRowStruct;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+/*
+ * This reactor filters out rows where the value is null (NaN, None, NaT) or empty ("") in the specified 
+ * columns.
+ */
+public class FilterEmptyValuesReactor extends AbstractPyFrameReactor {
+
+	protected static final String CLASS_NAME = FilterEmptyValuesReactor.class.getName();
+	private static final String AXIS = "axis";
+	
+	public FilterEmptyValuesReactor() {
+		this.keysToGet = new String[] { ReactorKeysEnum.COLUMNS.getKey(), AXIS };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		PandasFrame frame = (PandasFrame) getFrame();
+		// get the frame name
+		String frameName = frame.getName();
+		String wrapperFrameName = frame.getWrapperName();
+		String wrapperDataIndexed = wrapperFrameName + ".cache['data']";
+		
+		GenRowFilters grf = getFilters();
+		
+		StringBuilder pyFilterBuilder = new StringBuilder();
+		PandasInterpreter pi = new PandasInterpreter();
+		pi.setDataTableName(frameName, wrapperFrameName + ".cache['data']");
+		pi.setDataTypeMap(frame.getMetaData().getHeaderToTypeMap());
+		pi.addFilters(grf.getFilters(), wrapperFrameName, pyFilterBuilder, true);
+		
+		String script = wrapperDataIndexed + " = " + wrapperDataIndexed + "[" + pyFilterBuilder.toString() + "]";
+		frame.runScript(script);
+		this.addExecutedCode(script);
+		return new NounMetadata(frame, PixelDataType.FRAME, PixelOperationType.FRAME_DATA_CHANGE);
+	}
+	
+	// to group by this list of columns
+	private List<String> getColumns() {
+		List<String> cols = new ArrayList<String>();
+
+		// try its own key
+		GenRowStruct colsGrs = this.store.getGenRowStruct(ReactorKeysEnum.COLUMNS.getKey());
+		if (colsGrs != null && !colsGrs.isEmpty()) {
+			int size = colsGrs.size();
+			for (int i = 0; i < size; i++) {
+				cols.add(colsGrs.get(i).toString());
+			}
+			return cols;
+		}
+
+		int inputSize = this.getCurRow().size();
+		if (inputSize > 0) {
+			for (int i = 0; i < inputSize; i++) {
+				cols.add(this.getCurRow().get(i).toString());
+			}
+			return cols;
+		}
+
+		throw new IllegalArgumentException("Need to define the columns to filter");
+	}
+	
+	public GenRowFilters getFilters() {
+		// generate a grf with the wanted filters
+		GenRowFilters grf = new GenRowFilters();
+		List<String> columns = getColumns();
+		List<Object> values = new ArrayList<Object>();
+		values.add("");
+		values.add(null);
+		for(String col : columns) {
+			grf.addFilters(SimpleQueryFilter.makeColToValFilter(col, "!=", values));
+		}
+		return grf;
+	}
+}

--- a/src/prerna/reactor/frame/py/FilterEmptyValuesReactor.java
+++ b/src/prerna/reactor/frame/py/FilterEmptyValuesReactor.java
@@ -29,10 +29,8 @@ package prerna.reactor.frame.py;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Vector;
 
 import prerna.ds.py.PandasFrame;
-import prerna.ds.py.PyTranslator;
 import prerna.query.interpreters.PandasInterpreter;
 import prerna.query.querystruct.filters.GenRowFilters;
 import prerna.query.querystruct.filters.SimpleQueryFilter;
@@ -49,7 +47,7 @@ import prerna.sablecc2.om.nounmeta.NounMetadata;
 public class FilterEmptyValuesReactor extends AbstractPyFrameReactor {
 
 	protected static final String CLASS_NAME = FilterEmptyValuesReactor.class.getName();
-	
+
 	public FilterEmptyValuesReactor() {
 		this.keysToGet = new String[] { ReactorKeysEnum.COLUMNS.getKey() };
 	}
@@ -62,22 +60,21 @@ public class FilterEmptyValuesReactor extends AbstractPyFrameReactor {
 		String frameName = frame.getName();
 		String wrapperFrameName = frame.getWrapperName();
 		String wrapperDataIndexed = wrapperFrameName + ".cache['data']";
-		
+
 		GenRowFilters grf = getFilters();
-		
+
 		StringBuilder pyFilterBuilder = new StringBuilder();
 		PandasInterpreter pi = new PandasInterpreter();
 		pi.setDataTableName(frameName, wrapperFrameName + ".cache['data']");
 		pi.setDataTypeMap(frame.getMetaData().getHeaderToTypeMap());
 		pi.addFilters(grf.getFilters(), wrapperFrameName, pyFilterBuilder, true);
-		
+
 		String script = wrapperDataIndexed + " = " + wrapperDataIndexed + "[" + pyFilterBuilder.toString() + "]";
 		frame.runScript(script);
 		this.addExecutedCode(script);
 		return new NounMetadata(frame, PixelDataType.FRAME, PixelOperationType.FRAME_DATA_CHANGE);
 	}
-	
-	// to group by this list of columns
+
 	private List<String> getColumns() {
 		List<String> cols = new ArrayList<String>();
 
@@ -101,15 +98,15 @@ public class FilterEmptyValuesReactor extends AbstractPyFrameReactor {
 
 		throw new IllegalArgumentException("Need to define the columns to filter");
 	}
-	
-	public GenRowFilters getFilters() {
+
+	private GenRowFilters getFilters() {
 		// generate a grf with the wanted filters
 		GenRowFilters grf = new GenRowFilters();
 		List<String> columns = getColumns();
 		List<Object> values = new ArrayList<Object>();
 		values.add("");
 		values.add(null);
-		for(String col : columns) {
+		for (String col : columns) {
 			grf.addFilters(SimpleQueryFilter.makeColToValFilter(col, "!=", values));
 		}
 		return grf;

--- a/src/prerna/reactor/frame/py/FilterEmptyValuesReactor.java
+++ b/src/prerna/reactor/frame/py/FilterEmptyValuesReactor.java
@@ -49,10 +49,9 @@ import prerna.sablecc2.om.nounmeta.NounMetadata;
 public class FilterEmptyValuesReactor extends AbstractPyFrameReactor {
 
 	protected static final String CLASS_NAME = FilterEmptyValuesReactor.class.getName();
-	private static final String AXIS = "axis";
 	
 	public FilterEmptyValuesReactor() {
-		this.keysToGet = new String[] { ReactorKeysEnum.COLUMNS.getKey(), AXIS };
+		this.keysToGet = new String[] { ReactorKeysEnum.COLUMNS.getKey() };
 	}
 
 	@Override

--- a/src/prerna/reactor/frame/py/ImputeNullValuesReactor.java
+++ b/src/prerna/reactor/frame/py/ImputeNullValuesReactor.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.frame.py;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import prerna.algorithm.api.SemossDataType;
+import prerna.ds.py.PandasFrame;
+import prerna.sablecc2.om.GenRowStruct;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+/*
+ * This reactor will impute the null values for the specified columns.
+ * 
+ * For a numeric valued column, nulls will be replaced by the column mean.
+ * 
+ * For date-times, the value will be forward filled, or replaced by the last valid observation
+ * 
+ * For Strings, null values will be replaced by the mode of the column or the string "Unknown" if no mode exists
+ * 
+ */
+public class ImputeNullValuesReactor extends AbstractPyFrameReactor {
+
+	protected static final String CLASS_NAME = ImputeNullValuesReactor.class.getName();
+	
+	public ImputeNullValuesReactor() {
+		this.keysToGet = new String[] { ReactorKeysEnum.COLUMNS.getKey() };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		// get frame
+		PandasFrame frame = (PandasFrame) getFrame();
+		String frameName = frame.getName();
+		String wrapperFrameName = frame.getWrapperName();
+		String wrapperDataIndexed = wrapperFrameName + ".cache['data']";
+
+		// get inputs
+		// first input is the column that we are updating
+		List<String> columnNames = getColumns();
+
+		List<String> scripts = new ArrayList<>();
+
+		// iterate through all passed columns
+		for (String column : columnNames) {
+			SemossDataType columnDataType = SemossDataType.convertStringToDataType(getColumnType(frame, column));
+			if (columnDataType == SemossDataType.INT || columnDataType == SemossDataType.DOUBLE) {
+				scripts.add( wrapperDataIndexed + "['" + column + "'] = " + wrapperDataIndexed + "['" + column + "'].fillna(" + wrapperDataIndexed + "['" + column + "'].mean(skipna=True))" );
+			} else if (columnDataType == SemossDataType.DATE || columnDataType == SemossDataType.TIMESTAMP) {
+				scripts.add( wrapperDataIndexed + "['" + column + "'].fillna(value=pd.to_datetime(" + wrapperDataIndexed + "['" + column + "']).ffill(),inplace=True)");
+			} else if (columnDataType == SemossDataType.STRING) {
+				String modeconditional = "'Unknown' if " + wrapperDataIndexed + "['" + column + "'].mode(dropna=True).empty else " + wrapperDataIndexed + "['" + column + "'].mode(dropna=True)";
+				scripts.add( wrapperDataIndexed + "['" + column + "'].fillna(" + modeconditional + ", inplace=True)" );
+			}
+		}
+
+		// execute all of the routines after we have done our validation
+		insight.getPyTranslator().runEmptyPy(scripts.toArray(new String[0]));
+		for (String script : scripts) {
+			this.addExecutedCode(script);
+		}
+		return new NounMetadata(frame, PixelDataType.FRAME, PixelOperationType.FRAME_DATA_CHANGE);
+	}
+	
+	// to group by this list of columns
+	private List<String> getColumns() {
+		List<String> cols = new ArrayList<String>();
+
+		// try its own key
+		GenRowStruct colsGrs = this.store.getGenRowStruct(ReactorKeysEnum.COLUMNS.getKey());
+		if (colsGrs != null && !colsGrs.isEmpty()) {
+			int size = colsGrs.size();
+			for (int i = 0; i < size; i++) {
+				cols.add(colsGrs.get(i).toString());
+			}
+			return cols;
+		}
+
+		int inputSize = this.getCurRow().size();
+		if (inputSize > 0) {
+			for (int i = 0; i < inputSize; i++) {
+				cols.add(this.getCurRow().get(i).toString());
+			}
+			return cols;
+		}
+
+		throw new IllegalArgumentException("Need to define the columns to impute");
+	}
+}

--- a/src/prerna/reactor/frame/py/ImputeNullValuesReactor.java
+++ b/src/prerna/reactor/frame/py/ImputeNullValuesReactor.java
@@ -40,18 +40,14 @@ import prerna.sablecc2.om.nounmeta.NounMetadata;
 
 /*
  * This reactor will impute the null values for the specified columns.
- * 
  * For a numeric valued column, nulls will be replaced by the column mean.
- * 
  * For date-times, the value will be forward filled, or replaced by the last valid observation
- * 
  * For Strings, null values will be replaced by the mode of the column or the string "Unknown" if no mode exists
- * 
  */
 public class ImputeNullValuesReactor extends AbstractPyFrameReactor {
 
 	protected static final String CLASS_NAME = ImputeNullValuesReactor.class.getName();
-	
+
 	public ImputeNullValuesReactor() {
 		this.keysToGet = new String[] { ReactorKeysEnum.COLUMNS.getKey() };
 	}
@@ -61,7 +57,6 @@ public class ImputeNullValuesReactor extends AbstractPyFrameReactor {
 		organizeKeys();
 		// get frame
 		PandasFrame frame = (PandasFrame) getFrame();
-		String frameName = frame.getName();
 		String wrapperFrameName = frame.getWrapperName();
 		String wrapperDataIndexed = wrapperFrameName + ".cache['data']";
 
@@ -75,12 +70,16 @@ public class ImputeNullValuesReactor extends AbstractPyFrameReactor {
 		for (String column : columnNames) {
 			SemossDataType columnDataType = SemossDataType.convertStringToDataType(getColumnType(frame, column));
 			if (columnDataType == SemossDataType.INT || columnDataType == SemossDataType.DOUBLE) {
-				scripts.add( wrapperDataIndexed + "['" + column + "'] = " + wrapperDataIndexed + "['" + column + "'].fillna(" + wrapperDataIndexed + "['" + column + "'].mean(skipna=True))" );
+				scripts.add(wrapperDataIndexed + "['" + column + "'] = " + wrapperDataIndexed + "['" + column
+						+ "'].fillna(" + wrapperDataIndexed + "['" + column + "'].mean(skipna=True))");
 			} else if (columnDataType == SemossDataType.DATE || columnDataType == SemossDataType.TIMESTAMP) {
-				scripts.add( wrapperDataIndexed + "['" + column + "'].fillna(value=pd.to_datetime(" + wrapperDataIndexed + "['" + column + "']).ffill(),inplace=True)");
+				scripts.add(wrapperDataIndexed + "['" + column + "'].fillna(value=pd.to_datetime(" + wrapperDataIndexed
+						+ "['" + column + "']).ffill(),inplace=True)");
 			} else if (columnDataType == SemossDataType.STRING) {
-				String modeconditional = "'Unknown' if " + wrapperDataIndexed + "['" + column + "'].mode(dropna=True).empty else " + wrapperDataIndexed + "['" + column + "'].mode(dropna=True)";
-				scripts.add( wrapperDataIndexed + "['" + column + "'].fillna(" + modeconditional + ", inplace=True)" );
+				String modeconditional = "'Unknown' if " + wrapperDataIndexed + "['" + column
+						+ "'].mode(dropna=True).empty else " + wrapperDataIndexed + "['" + column
+						+ "'].mode(dropna=True)";
+				scripts.add(wrapperDataIndexed + "['" + column + "'].fillna(" + modeconditional + ", inplace=True)");
 			}
 		}
 
@@ -91,8 +90,7 @@ public class ImputeNullValuesReactor extends AbstractPyFrameReactor {
 		}
 		return new NounMetadata(frame, PixelDataType.FRAME, PixelOperationType.FRAME_DATA_CHANGE);
 	}
-	
-	// to group by this list of columns
+
 	private List<String> getColumns() {
 		List<String> cols = new ArrayList<String>();
 


### PR DESCRIPTION

## Description
Created the reactors to support the following clean routines for Python Frames:
-  ImputeNullValues
- FilterEmptyValues



## Changes Made
<!-- List the key changes made in this PR -->
Created:
-  ImputeNullValuesReactor
- FilterEmptyValuesReactor

Modified: 
-  Edited the PandasInterpreter to correctly append an empty string object ("") as a filter to a DataFrame.

## How to Test
1) Create a simple CSV with more than 1 column. Column values can be Numbers with empty values mixed in
2) Upload to insight as csv and select Frame type to be PYTHON, rename frame however you wish
3) run recipe in editor to apply python functions to python frame: <PYTHON_FRAME_NAME> | <ImputeNullValues() or FilterEmptyValues>

## Notes
CumulativeSum already exists as a clean routine for Python Frames