### PR TITLE
fix: remove tuple causing message.parts to evaluate to true and yield none

### DIFF
--- a/py/genai_client/message_builders/semoss_base/semoss_models.py
+++ b/py/genai_client/message_builders/semoss_base/semoss_models.py
@@ -210,7 +210,7 @@ class SEMOSSMessage(BaseModel):
                 SEMOSSUnknownMessagePart,
             ]
         ]
-    ] = (None,)
+    ] = None
     io: Literal["INPUT", "OUTPUT"]
 
     class Config:


### PR DESCRIPTION
## Description

When a message is created with no parts, perhaps because the model was instructed to call a tool with no textual output, the default value for message.parts was `(None,)`. This evaluates to true, then iterating on it yields a None value. Subsequently, when we try to get the type, we get the following error.

<img width="1832" height="1636" alt="image" src="https://github.com/user-attachments/assets/c9dd94fc-81f8-4440-99e0-f75b8c4fb6e1" />

This PR fixes this issue by switching this to None