### PR TITLE
Feat claude model caching

### DIFF
--- a/py/genai_client/constants.py
+++ b/py/genai_client/constants.py
@@ -53,6 +53,12 @@ class AskModelEngineResponse2(BaseModel):
     response_tokens: int = Field(
         default=0, serialization_alias="numberOfTokensInResponse"
     )
+    cache_read_tokens: Optional[int] = Field(
+        default=None, serialization_alias="numberOfCacheReadTokens"
+    )
+    cache_creation_tokens: Optional[int] = Field(
+        default=None, serialization_alias="numberOfCacheCreationTokens"
+    )
     schemaVersion: Optional[int] = None
     io: Optional[str] = None
     parts: Optional[List[Dict[str, Any]]] = None

--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -15,7 +15,6 @@ from .anthropic_models import (
     AnthropicToolResultContentPart,
     AnthropicRequestConfig,
     AnthropicMessageBuilderResponse,
-    PROMPT_CACHING_BETA,
 )
 from ..semoss_base.semoss_models import (
     SEMOSSMessage,
@@ -757,32 +756,11 @@ class AnthropicMessageBuilder:
             if string_to_bool(use_history) is False:
                 history = history[-1:] if history else []
 
-        # Auto-cache the system prompt when present — wraps it as a cacheable
-        # content block, which avoids re-processing it on every call.
-        cacheable_system = None
-        if system_prompt:
-            cacheable_system = [
-                {
-                    "type": "text",
-                    "text": system_prompt,
-                    "cache_control": {"type": "ephemeral"},
-                }
-            ]
-
-        # Collect beta headers: always include prompt-caching when a system
-        # prompt is present; extend with extended-thinking if already enabled.
-        betas: list[str] = []
-        if self.use_beta_header and self.beta_feature_name:
-            betas.append(self.beta_feature_name)
-        if cacheable_system:
-            betas.append(PROMPT_CACHING_BETA)
-        betas = betas if betas else None
-
         return AnthropicRequestConfig(
             model=self.model_name,
-            system=cacheable_system if cacheable_system else system_prompt,
+            system=system_prompt,
             messages=[message.model_dump(mode="json") for message in history],
-            betas=betas,
+            betas=[self.beta_feature_name] if self.use_beta_header else None,
             tools=tools,
             tool_choice=kwargs.pop("tool_choice", None),
             max_tokens=max_tokens,

--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -15,6 +15,7 @@ from .anthropic_models import (
     AnthropicToolResultContentPart,
     AnthropicRequestConfig,
     AnthropicMessageBuilderResponse,
+    PROMPT_CACHING_BETA,
 )
 from ..semoss_base.semoss_models import (
     SEMOSSMessage,
@@ -756,11 +757,32 @@ class AnthropicMessageBuilder:
             if string_to_bool(use_history) is False:
                 history = history[-1:] if history else []
 
+        # Auto-cache the system prompt when present — wraps it as a cacheable
+        # content block, which avoids re-processing it on every call.
+        cacheable_system = None
+        if system_prompt:
+            cacheable_system = [
+                {
+                    "type": "text",
+                    "text": system_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ]
+
+        # Collect beta headers: always include prompt-caching when a system
+        # prompt is present; extend with extended-thinking if already enabled.
+        betas: list[str] = []
+        if self.use_beta_header and self.beta_feature_name:
+            betas.append(self.beta_feature_name)
+        if cacheable_system:
+            betas.append(PROMPT_CACHING_BETA)
+        betas = betas if betas else None
+
         return AnthropicRequestConfig(
             model=self.model_name,
-            system=system_prompt,
+            system=cacheable_system if cacheable_system else system_prompt,
             messages=[message.model_dump(mode="json") for message in history],
-            betas=[self.beta_feature_name] if self.use_beta_header else None,
+            betas=betas,
             tools=tools,
             tool_choice=kwargs.pop("tool_choice", None),
             max_tokens=max_tokens,

--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -759,7 +759,7 @@ class AnthropicMessageBuilder:
         return AnthropicRequestConfig(
             model=self.model_name,
             system=system_prompt,
-            messages=[message.model_dump(mode="json") for message in history],
+            messages=[message.model_dump(mode="json", exclude_none=True) for message in history],
             betas=[self.beta_feature_name] if self.use_beta_header else None,
             tools=tools,
             tool_choice=kwargs.pop("tool_choice", None),

--- a/py/genai_client/message_builders/anthropic/anthropic_models.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_models.py
@@ -111,7 +111,7 @@ class AnthropicRequestConfig(BaseModel):
     model: str
     messages: List[Dict[str, Any]]
     betas: Optional[List[str]] = None
-    system: Optional[str] = None
+    system: Optional[Union[str, List[Dict[str, Any]]]] = None
     cache_control: Optional[Dict[str, Any]] = None
     tools: Optional[List[Dict]] = None
     tool_choice: Optional[Dict[str, str]] = None

--- a/py/genai_client/message_builders/anthropic/anthropic_models.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_models.py
@@ -107,14 +107,12 @@ class AnthropicMessage(BaseModel):
     ]
 
 
-PROMPT_CACHING_BETA = "prompt-caching-2024-07-31"
-
-
 class AnthropicRequestConfig(BaseModel):
     model: str
     messages: List[Dict[str, Any]]
     betas: Optional[List[str]] = None
-    system: Optional[Union[str, List[Dict[str, Any]]]] = None
+    system: Optional[str] = None
+    cache_control: Optional[Dict[str, Any]] = None
     tools: Optional[List[Dict]] = None
     tool_choice: Optional[Dict[str, str]] = None
     max_tokens: Optional[int] = None

--- a/py/genai_client/message_builders/anthropic/anthropic_models.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_models.py
@@ -80,9 +80,14 @@ class AnthropicThinkingContentPart(BaseModel):
     signature: Optional[str] = None
 
 
+class AnthropicCacheControl(BaseModel):
+    type: str = "ephemeral"
+
+
 class AnthropicTextContentPart(BaseModel):
     type: str = "text"
     text: str
+    cache_control: Optional[AnthropicCacheControl] = None
 
 
 class AnthropicMessage(BaseModel):
@@ -102,11 +107,14 @@ class AnthropicMessage(BaseModel):
     ]
 
 
+PROMPT_CACHING_BETA = "prompt-caching-2024-07-31"
+
+
 class AnthropicRequestConfig(BaseModel):
     model: str
     messages: List[Dict[str, Any]]
     betas: Optional[List[str]] = None
-    system: Optional[str] = None
+    system: Optional[Union[str, List[Dict[str, Any]]]] = None
     tools: Optional[List[Dict]] = None
     tool_choice: Optional[Dict[str, str]] = None
     max_tokens: Optional[int] = None

--- a/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
+++ b/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
@@ -51,6 +51,7 @@ class AnthropicTextClient(AbstractTextGenerationClient):
         self,
         provider: str,
         use_beta_header: Optional[Union[str, bool]] = False,
+        prompt_caching: Optional[Union[str, bool]] = False,
         **kwargs,
     ):
         super().__init__(
@@ -64,6 +65,11 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             use_beta_header.lower() in ["true", "1", "yes", "on"]
             if isinstance(use_beta_header, str)
             else use_beta_header
+        )
+        self.prompt_caching = (
+            prompt_caching.lower() in ["true", "1", "yes", "on"]
+            if isinstance(prompt_caching, str)
+            else prompt_caching
         )
         self.beta_feature_name = kwargs.pop("beta_feature_name", None)
         if self.use_beta_header and not self.beta_feature_name:
@@ -158,9 +164,9 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             streaming = msg_builder_response.streaming
             self.has_schema = msg_builder_response.has_structured_input
 
-            # Automatic prompt caching: supported on Anthropic direct and Azure
-            # only. Bedrock and Vertex AI do not support it yet.
-            if self.provider in ("anthropic", "azure"):
+            # Automatic prompt caching: only on Anthropic direct and Azure;
+            # Bedrock and Vertex AI do not support it yet.
+            if self.prompt_caching and self.provider in ("anthropic", "azure"):
                 request_config.cache_control = {"type": "ephemeral"}
 
             if streaming:

--- a/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
+++ b/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
@@ -113,6 +113,32 @@ class AnthropicTextClient(AbstractTextGenerationClient):
                 f"Provider '{self.provider}' is not supported for Anthropic Text Client."
             )
 
+    @staticmethod
+    def _apply_cache_to_last_block(messages: List[Dict[str, Any]]) -> None:
+        """
+        Add cache_control to the last text block of the last message. This
+        replicates Anthropic's automatic caching behaviour for providers
+        (Bedrock, Vertex) that only support block-level cache_control.
+
+        On each turn the last message is the newest one, so the marker
+        naturally moves forward through the conversation as history grows.
+        """
+        if not messages:
+            return
+        last_msg = messages[-1]
+        content = last_msg.get("content")
+        if isinstance(content, str):
+            # Plain-string content — convert to block form so we can attach
+            # cache_control without mutating shared state.
+            last_msg["content"] = [
+                {"type": "text", "text": content, "cache_control": {"type": "ephemeral"}}
+            ]
+        elif isinstance(content, list):
+            for block in reversed(content):
+                if isinstance(block, dict) and block.get("type") == "text":
+                    block["cache_control"] = {"type": "ephemeral"}
+                    break
+
     def ask_call(
         self,
         prefix="",
@@ -164,10 +190,18 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             streaming = msg_builder_response.streaming
             self.has_schema = msg_builder_response.has_structured_input
 
-            # Automatic prompt caching: only on Anthropic direct and Azure;
-            # Bedrock and Vertex AI do not support it yet.
-            if self.prompt_caching and self.provider in ("anthropic", "azure"):
-                request_config.cache_control = {"type": "ephemeral"}
+            if self.prompt_caching:
+                if self.provider in ("anthropic", "azure"):
+                    # Automatic prompt caching: single top-level field; the API
+                    # moves the cache breakpoint to the last cacheable block
+                    # automatically on every turn.
+                    request_config.cache_control = {"type": "ephemeral"}
+                elif self.provider in ("bedrock", "google"):
+                    # Bedrock and Vertex don't support the top-level automatic
+                    # field, but do support block-level cache_control. Replicate
+                    # the same "marker moves forward" behaviour by attaching
+                    # cache_control to the last text block of the last message.
+                    self._apply_cache_to_last_block(request_config.messages)
 
             if streaming:
                 return self._handle_streaming(

--- a/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
+++ b/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
@@ -158,6 +158,11 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             streaming = msg_builder_response.streaming
             self.has_schema = msg_builder_response.has_structured_input
 
+            # Automatic prompt caching: supported on Anthropic direct and Azure
+            # only. Bedrock and Vertex AI do not support it yet.
+            if self.provider in ("anthropic", "azure"):
+                request_config.cache_control = {"type": "ephemeral"}
+
             if streaming:
                 return self._handle_streaming(
                     request_config,

--- a/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
+++ b/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
@@ -171,14 +171,19 @@ class AnthropicTextClient(AbstractTextGenerationClient):
         last_msg = messages[-1]
         content = last_msg.get("content")
         if isinstance(content, str):
-            # Plain-string content — convert to block form so we can attach
-            # cache_control without mutating shared state.
             last_msg["content"] = [
-                {"type": "text", "text": content, "cache_control": {"type": "ephemeral"}}
+                {
+                    "type": "text",
+                    "text": content,
+                    "cache_control": {"type": "ephemeral"},
+                }
             ]
         elif isinstance(content, list):
             for block in reversed(content):
-                if isinstance(block, dict) and block.get("type") in AnthropicTextClient._CACHEABLE_BLOCK_TYPES:
+                if (
+                    isinstance(block, dict)
+                    and block.get("type") in AnthropicTextClient._CACHEABLE_BLOCK_TYPES
+                ):
                     block["cache_control"] = {"type": "ephemeral"}
                     break
 
@@ -235,15 +240,8 @@ class AnthropicTextClient(AbstractTextGenerationClient):
 
             if self.prompt_caching:
                 if self.provider in ("anthropic", "azure"):
-                    # Automatic prompt caching: single top-level field; the API
-                    # moves the cache breakpoint to the last cacheable block
-                    # automatically on every turn.
                     request_config.cache_control = {"type": "ephemeral"}
                 elif self.provider in ("bedrock", "google"):
-                    # Bedrock and Vertex don't support the top-level automatic
-                    # field, but do support block-level cache_control.
-                    # Apply breakpoints in Anthropic's evaluation order:
-                    # tools → system → messages (up to 4 total allowed).
                     self._apply_cache_to_tools(request_config)
                     self._apply_cache_to_system(request_config)
                     self._apply_cache_to_last_block(request_config.messages)
@@ -292,8 +290,12 @@ class AnthropicTextClient(AbstractTextGenerationClient):
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
             )
-            cache_read_tokens = getattr(response.usage, "cache_read_input_tokens", None) or None
-            cache_creation_tokens = getattr(response.usage, "cache_creation_input_tokens", None) or None
+            cache_read_tokens = (
+                getattr(response.usage, "cache_read_input_tokens", None) or None
+            )
+            cache_creation_tokens = (
+                getattr(response.usage, "cache_creation_input_tokens", None) or None
+            )
 
             if self.prompt_caching and (cache_read_tokens or cache_creation_tokens):
                 print(
@@ -404,8 +406,16 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             for event in stream:
                 if event.type == "message_start":
                     input_tokens = event.message.usage.input_tokens
-                    cache_read_tokens = getattr(event.message.usage, "cache_read_input_tokens", None) or None
-                    cache_creation_tokens = getattr(event.message.usage, "cache_creation_input_tokens", None) or None
+                    cache_read_tokens = (
+                        getattr(event.message.usage, "cache_read_input_tokens", None)
+                        or None
+                    )
+                    cache_creation_tokens = (
+                        getattr(
+                            event.message.usage, "cache_creation_input_tokens", None
+                        )
+                        or None
+                    )
 
                 elif event.type == "content_block_start":
                     this_content_block_type = event.content_block.type

--- a/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
+++ b/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
@@ -114,14 +114,57 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             )
 
     @staticmethod
+    def _apply_cache_to_tools(request_config: "AnthropicRequestConfig") -> None:
+        """
+        Add cache_control to the last tool definition. Tools are evaluated
+        first in Anthropic's cache breakpoint order (tools → system → messages),
+        so caching them saves tokens whenever the tool list is large and static.
+        """
+        tools = request_config.tools
+        if not tools:
+            return
+        tools[-1]["cache_control"] = {"type": "ephemeral"}
+
+    @staticmethod
+    def _apply_cache_to_system(request_config: "AnthropicRequestConfig") -> None:
+        """
+        Convert the system prompt to list form and attach cache_control to its
+        last text block. This caches the system prompt on the first call so
+        subsequent turns pay only the cache-read price for those tokens.
+
+        Only called for providers (Bedrock, Vertex) that don't support the
+        top-level automatic cache_control field.
+        """
+        system = request_config.system
+        if not system:
+            return
+        if isinstance(system, str):
+            request_config.system = [
+                {"type": "text", "text": system, "cache_control": {"type": "ephemeral"}}
+            ]
+        elif isinstance(system, list):
+            # Already a list — attach to the last text block.
+            for block in reversed(system):
+                if isinstance(block, dict) and block.get("type") == "text":
+                    block["cache_control"] = {"type": "ephemeral"}
+                    break
+
+    # Block types that Anthropic supports cache_control on.
+    _CACHEABLE_BLOCK_TYPES = {"text", "tool_result", "image", "document"}
+
+    @staticmethod
     def _apply_cache_to_last_block(messages: List[Dict[str, Any]]) -> None:
         """
-        Add cache_control to the last text block of the last message. This
+        Add cache_control to the last cacheable block of the last message. This
         replicates Anthropic's automatic caching behaviour for providers
         (Bedrock, Vertex) that only support block-level cache_control.
 
         On each turn the last message is the newest one, so the marker
         naturally moves forward through the conversation as history grows.
+
+        Supports text, tool_result, image, and document blocks — not just text —
+        so that tool execution turns (whose last message contains tool_result
+        blocks) are also cached correctly.
         """
         if not messages:
             return
@@ -135,7 +178,7 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             ]
         elif isinstance(content, list):
             for block in reversed(content):
-                if isinstance(block, dict) and block.get("type") == "text":
+                if isinstance(block, dict) and block.get("type") in AnthropicTextClient._CACHEABLE_BLOCK_TYPES:
                     block["cache_control"] = {"type": "ephemeral"}
                     break
 
@@ -198,9 +241,11 @@ class AnthropicTextClient(AbstractTextGenerationClient):
                     request_config.cache_control = {"type": "ephemeral"}
                 elif self.provider in ("bedrock", "google"):
                     # Bedrock and Vertex don't support the top-level automatic
-                    # field, but do support block-level cache_control. Replicate
-                    # the same "marker moves forward" behaviour by attaching
-                    # cache_control to the last text block of the last message.
+                    # field, but do support block-level cache_control.
+                    # Apply breakpoints in Anthropic's evaluation order:
+                    # tools → system → messages (up to 4 total allowed).
+                    self._apply_cache_to_tools(request_config)
+                    self._apply_cache_to_system(request_config)
                     self._apply_cache_to_last_block(request_config.messages)
 
             if streaming:
@@ -247,6 +292,15 @@ class AnthropicTextClient(AbstractTextGenerationClient):
                 input_tokens=response.usage.input_tokens,
                 output_tokens=response.usage.output_tokens,
             )
+            cache_read_tokens = getattr(response.usage, "cache_read_input_tokens", None) or None
+            cache_creation_tokens = getattr(response.usage, "cache_creation_input_tokens", None) or None
+
+            if self.prompt_caching and (cache_read_tokens or cache_creation_tokens):
+                print(
+                    f"[prompt_caching] cache_read_tokens={cache_read_tokens} "
+                    f"cache_creation_tokens={cache_creation_tokens}",
+                    flush=True,
+                )
 
             parts = []
             if response_text:
@@ -258,6 +312,8 @@ class AnthropicTextClient(AbstractTextGenerationClient):
                 response=response_text,
                 response_tokens=usage.output_tokens,
                 prompt_tokens=usage.input_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_creation_tokens=cache_creation_tokens,
                 schemaVersion=2,
                 io="OUTPUT",
                 parts=parts,
@@ -317,6 +373,8 @@ class AnthropicTextClient(AbstractTextGenerationClient):
 
         input_tokens = 0
         output_tokens = 0
+        cache_read_tokens: Optional[int] = None
+        cache_creation_tokens: Optional[int] = None
         stop_reason: Optional[str] = None
 
         content_array = []
@@ -346,6 +404,8 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             for event in stream:
                 if event.type == "message_start":
                     input_tokens = event.message.usage.input_tokens
+                    cache_read_tokens = getattr(event.message.usage, "cache_read_input_tokens", None) or None
+                    cache_creation_tokens = getattr(event.message.usage, "cache_creation_input_tokens", None) or None
 
                 elif event.type == "content_block_start":
                     this_content_block_type = event.content_block.type
@@ -634,6 +694,13 @@ class AnthropicTextClient(AbstractTextGenerationClient):
         if current_text_block is not None:
             parts.append(current_text_block)
 
+        if self.prompt_caching and (cache_read_tokens or cache_creation_tokens):
+            print(
+                f"[prompt_caching] cache_read_tokens={cache_read_tokens} "
+                f"cache_creation_tokens={cache_creation_tokens}",
+                flush=True,
+            )
+
         if tool_result:
             if self.has_schema:
                 # TODO: come back to this method and have it properly mantain and update the existing parts instead of making a new one
@@ -650,6 +717,8 @@ class AnthropicTextClient(AbstractTextGenerationClient):
                         response=json_str,
                         response_tokens=output_tokens,
                         prompt_tokens=input_tokens,
+                        cache_read_tokens=cache_read_tokens,
+                        cache_creation_tokens=cache_creation_tokens,
                         schemaVersion=2,
                         io="OUTPUT",
                         parts=parts,
@@ -660,6 +729,8 @@ class AnthropicTextClient(AbstractTextGenerationClient):
                 response=tool_result,
                 response_tokens=output_tokens,
                 prompt_tokens=input_tokens,
+                cache_read_tokens=cache_read_tokens,
+                cache_creation_tokens=cache_creation_tokens,
                 schemaVersion=2,
                 io="OUTPUT",
                 parts=parts,
@@ -670,6 +741,8 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             response=final_response,
             prompt_tokens=input_tokens,
             response_tokens=output_tokens,
+            cache_read_tokens=cache_read_tokens,
+            cache_creation_tokens=cache_creation_tokens,
             schemaVersion=2,
             io="OUTPUT",
             parts=parts,


### PR DESCRIPTION
## Description
This PR adds support for prompt caching in the Anthropic text client, enabling automatic cache control for supported providers (Anthropic, Azure, Bedrock, and Google Vertex AI). The implementation handles provider-specific differences in how cache control is applied.

## Changes Made
- Added `prompt_caching` parameter to `AnthropicTextClient.__init__()` with support for string and boolean values
- Implemented `_apply_cache_to_last_block()` static method to handle block-level cache control for Bedrock and Google Vertex providers that don't support top-level automatic caching
- Added conditional logic in `ask_call()` to apply cache control based on provider:
  - Anthropic and Azure: Use top-level `cache_control` field for automatic caching
  - Bedrock and Google: Apply cache control to the last text block of the last message to replicate automatic behavior
- Added `AnthropicCacheControl` model class to represent cache control configuration
- Extended `AnthropicTextContentPart` with optional `cache_control` field
- Extended `AnthropicRequestConfig` with optional `cache_control` field
- Updated message serialization to use `exclude_none=True` to avoid serializing null cache control values

## How to Test
1. Initialize `AnthropicTextClient` with `prompt_caching=True` 
2. Verify that for Anthropic/Azure providers, the request includes top-level `cache_control: {"type": "ephemeral"}`
3. Verify that for Bedrock/Google providers, the last text block in the last message includes `cache_control: {"type": "ephemeral"}`
4. Verify that cache control marker moves forward through conversation history on each turn
5. Verify that `prompt_caching=False` or omitting the parameter disables caching

## Notes
- The implementation replicates Anthropic's automatic caching behavior for providers with block-level cache control support
- String values for `prompt_caching` are normalized to boolean (e.g., "true", "1", "yes", "on" → True)
- The cache control marker naturally progresses through the conversation as the last message changes with each turn
