### PR TITLE
Standardizing `built_in_tools` param through global_param_override & param_map in py message builders

### DIFF
--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -152,10 +152,13 @@ class AnthropicMessageBuilder:
                         )
                     if "built_in_tools" in param_map:
                         built_in_tools = self._build_built_in_tools(
-                            param_map["built_in_tools"]
+                            param_map.pop("built_in_tools")
                         )
-                        if "tools" in param_map:
-                            param_map["tools"].extend(built_in_tools)
+                        if built_in_tools:
+                            if "tools" in param_map:
+                                param_map["tools"].extend(built_in_tools)
+                            else:
+                                param_map["tools"] = built_in_tools
                     if "tool_choice" in param_map:
                         param_map["tool_choice"] = self._build_tool_choice(
                             param_map["tool_choice"]
@@ -325,10 +328,13 @@ class AnthropicMessageBuilder:
                         )
                     if "built_in_tools" in param_map:
                         built_in_tools = self._build_built_in_tools(
-                            param_map["built_in_tools"]
+                            param_map.pop("built_in_tools")
                         )
-                        if "tools" in param_map:
-                            param_map["tools"].extend(built_in_tools)
+                        if built_in_tools:
+                            if "tools" in param_map:
+                                param_map["tools"].extend(built_in_tools)
+                            else:
+                                param_map["tools"] = built_in_tools
                     if "tool_choice" in param_map:
                         param_map["tool_choice"] = self._build_tool_choice(
                             param_map["tool_choice"]

--- a/py/genai_client/message_builders/bedrock/bedrock_message_builder.py
+++ b/py/genai_client/message_builders/bedrock/bedrock_message_builder.py
@@ -119,13 +119,22 @@ class BedrockMessageBuilder:
                         )
 
                     last_message_tools = message.param_map.get("tools")
+                    last_message_built_in_tools = message.param_map.pop("built_in_tools", None)
                     tool_choice = message.param_map.pop("tool_choice", None)
                     if last_message_tools:
                         mcp_tools = self._convert_mcp_to_bedrock_tools(
                             last_message_tools
                         )
+                        if last_message_built_in_tools:
+                            built_in = self._build_built_in_tools(last_message_built_in_tools)
+                            mcp_tools["tools"].extend(built_in)
                         tools = self._build_tool_config_for_bedrock(
                             mcp_tools, tool_choice
+                        )
+                    elif last_message_built_in_tools:
+                        built_in = self._build_built_in_tools(last_message_built_in_tools)
+                        tools = self._build_tool_config_for_bedrock(
+                            {"tools": built_in}, tool_choice
                         )
 
                     stream = message.param_map.get("stream", True)
@@ -216,13 +225,22 @@ class BedrockMessageBuilder:
                         )
 
                     last_message_tools = message.param_map.get("tools")
+                    last_message_built_in_tools = message.param_map.pop("built_in_tools", None)
                     tool_choice = message.param_map.pop("tool_choice", None)
                     if last_message_tools:
                         mcp_tools = self._convert_mcp_to_bedrock_tools(
                             last_message_tools
                         )
+                        if last_message_built_in_tools:
+                            built_in = self._build_built_in_tools(last_message_built_in_tools)
+                            mcp_tools["tools"].extend(built_in)
                         tools = self._build_tool_config_for_bedrock(
                             mcp_tools, tool_choice
+                        )
+                    elif last_message_built_in_tools:
+                        built_in = self._build_built_in_tools(last_message_built_in_tools)
+                        tools = self._build_tool_config_for_bedrock(
+                            {"tools": built_in}, tool_choice
                         )
 
                     stream = message.param_map.get("stream", True)
@@ -409,6 +427,10 @@ class BedrockMessageBuilder:
 
         return None
 
+    def _build_built_in_tools(self, built_in_tools: List[str]) -> List[Dict[str, Any]]:
+        """Convert generic built-in tool names to Bedrock systemTool format."""
+        return [{"systemTool": {"name": tool}} for tool in built_in_tools]
+
     def _convert_mcp_to_bedrock_tools(self, mcp_tools: List[Dict]) -> Dict[str, Any]:
         """Convert MCP-formatted tools to Bedrock tool configuration."""
         tools_list = []
@@ -471,6 +493,7 @@ class BedrockMessageBuilder:
         param_map.pop("image_url", None)
         param_map.pop("image_encoded", None)
         param_map.pop("tools", None)
+        param_map.pop("built_in_tools", None)
         param_map.pop("stream", None)
         param_map.pop("streaming", None)
         param_map.pop("schema", None)

--- a/py/genai_client/message_builders/openai/openai_message_builder.py
+++ b/py/genai_client/message_builders/openai/openai_message_builder.py
@@ -1,4 +1,3 @@
-from email.mime import message
 from typing import List, Dict, Any, Optional, Tuple, Union
 import json
 from pydantic import BaseModel
@@ -48,13 +47,29 @@ class OpenAIMessageBuilder:
     def build_request(self, semoss_messages: List[SEMOSSMessage]) -> Dict[str, Any]:
         """Build complete OpenAI request with messages and parameters. This is a dictionary that can be sent directly to OpenAI"""
         if self.chat_type == "responses":
-            return self.build_responses_request(semoss_messages)
+            request = self.build_responses_request(semoss_messages)
         elif self.chat_type == "chat-completion":
-            return self.build_chat_completions_request(semoss_messages)
+            request = self.build_chat_completions_request(semoss_messages)
         elif self.chat_type == "completions":
-            return self.build_completions_messages(semoss_messages)
+            request = self.build_completions_messages(semoss_messages)
         else:
             raise ValueError(f"Unsupported chat type: {self.chat_type}")
+
+        if (
+            hasattr(self.model_settings, "global_param_override")
+            and self.model_settings.global_param_override
+        ):
+            request.update(self.model_settings.global_param_override)
+
+        if "built_in_tools" in request:
+            built_in_tools = request.pop("built_in_tools")
+            openai_built_in = [{"type": tool} for tool in built_in_tools]
+            if openai_built_in:
+                existing_tools = request.get("tools", [])
+                existing_tools.extend(openai_built_in)
+                request["tools"] = existing_tools
+
+        return request
 
     def build_responses_request(
         self, semoss_messages: List[SEMOSSMessage]

--- a/py/genai_client/text_generation/openai_clients/openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_client.py
@@ -137,12 +137,6 @@ class OpenAiClient(AbstractTextGenerationClient):
             except Exception as e:
                 raise ValueError(f"Error building OpenAI messages: {e}") from e
 
-            if (
-                hasattr(self.model_settings, "global_param_override")
-                and self.model_settings.global_param_override
-            ):
-                openai_messages.update(self.model_settings.global_param_override)
-
             if self.model_settings.model_type == "image":
                 return self.image_client.ask(openai_messages, **kwargs)
             if self.chat_type == "chat-completion":


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
Standardizing to be able to pass `built_in_tools` through the `global_param_override` and `param_map` like so;

```
INIT_MODEL_ENGINE	import genai_client;${VAR_NAME} = genai_client.OpenAiClient(endpoint="https://us.api.openai.com/v1", model_name = '${MODEL}', api_key = '${OPEN_AI_KEY}', chat_type = '${CHAT_TYPE}', context_window = ${CONTEXT_WINDOW}, max_tokens = ${MAX_TOKENS},global_param_override={"built_in_tools": ["web_search"]})
```


## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->