### PR TITLE
fix: remove hardcoded limit cap in MyEngineProjectReactor

### DIFF
--- a/src/prerna/reactor/MyEngineProjectReactor.java
+++ b/src/prerna/reactor/MyEngineProjectReactor.java
@@ -56,9 +56,9 @@ public class MyEngineProjectReactor extends AbstractReactor {
 	    organizeKeys();
 	    //Parse input params
 	    String searchTerm = this.keyValue.get(ReactorKeysEnum.FILTER_WORD.getKey());
-	    String limitStr = this.keyValue.getOrDefault(ReactorKeysEnum.LIMIT.getKey(), "20");
+	    String limitStr = this.keyValue.getOrDefault(ReactorKeysEnum.LIMIT.getKey(), "50");
 	    String offset = this.keyValue.getOrDefault(ReactorKeysEnum.OFFSET.getKey(), "0");
-	    int totalLimit = Math.min(Integer.parseInt(limitStr), 20); // Cap at 20
+	    int totalLimit = Integer.parseInt(limitStr);
 	    //Determine types to process
 	    List<String> type = this.getEngineTypes();
 	    List<String> typesToGet = (type == null || type.isEmpty())
@@ -73,16 +73,13 @@ public class MyEngineProjectReactor extends AbstractReactor {
 	    List<Integer> permissionFilters = getPermissionFilters();
 	    Map<String, Object> engineProjectMetadataFilter = getMetaMap();
 	    
-	    //Distribute limit per type
-	    int typeCount = typesToGet.size();
-	    int baseLimit = totalLimit / typeCount;
-	    int remainder = totalLimit % typeCount;
 	    //Fetch data for each type
 	    List<Map<String, Object>> combinedInfo = new ArrayList<>();
 	    
 	    for (int i = 0; i < typesToGet.size(); i++) {
 	        String currentType = typesToGet.get(i);
-	        int limitForType = baseLimit + (i < remainder ? 1 : 0); // even distribution
+	        int limitForType = totalLimit - combinedInfo.size();
+	        if (limitForType <= 0) break;
 
 	        List<Map<String, Object>> result;
 	        if ("PROJECT".equalsIgnoreCase(currentType)) {


### PR DESCRIPTION
## Description
Fixes #1435. MyEngineProjectReactor silently capped the caller-supplied limit to 20 via Math.min(Integer.parseInt(limitStr), 20), then divided that cap evenly across engine types. This caused the UI to receive far fewer results than requested (e.g., requesting limit=25 returned only 4–5 items).

## Changes Made
- Removed the hardcoded cap: Math.min(Integer.parseInt(limitStr), 20) → Integer.parseInt(limitStr), so the caller's requested limit is respected.
- Raised the default limit: Changed the default from "20" to "50" to better serve UI components that don't specify a limit.
- Replaced even-distribution logic with remaining-budget approach: Instead of dividing the limit equally across engine types (baseLimit + remainder), each type now receives the remaining budget (totalLimit - combinedInfo.size()), with an early break when the budget is exhausted. This ensures the full requested limit is filled regardless of how many types return results.

## How to Test
1. Ensure you have enough MCP apps to verify the hard cap is gone (10 or so would be fine)
2. Open up playground
3. Hit the arrow in the bottom left section of the chat box
4. Hit 'Open Room Settings'
5. Open your network tab
6. Hit the plus button next to 'Toolbox'
7. Verify in the UI and the network response for the MyEngineProjectReactor pixel call return the expected number of tools
<img width="1470" height="882" alt="image" src="https://github.com/user-attachments/assets/9863120a-51e3-4ec1-97de-9278676755e5" />


## Notes
- The hardcoded cap was introduced in PR #867. UI callers (mcp-selector.tsx sends limit=25, room toolbox components send limit=15) were all silently affected.
- No new dependencies or schema changes. The fix is 4 insertions / 7 deletions in a single file.