### PR TITLE
Adding no-frozen-lockfile flag to install cmd on BuildAndPublishAppReactor

### DIFF
--- a/src/prerna/reactor/test/BuildAndPublishAppReactor.java
+++ b/src/prerna/reactor/test/BuildAndPublishAppReactor.java
@@ -73,7 +73,7 @@ public class BuildAndPublishAppReactor extends AbstractReactor {
 	private static final String PROJECT_ID = ReactorKeysEnum.PROJECT.getKey();
 	private static final String CLIENT_DIR = "client";
 	private static final String NODE_SERVER_ENDPOINT = "NODE_SERVER_ENDPOINT";
-	private static final String BUILD_CMD = "pnpm install && pnpm run build";
+	private static final String BUILD_CMD = "pnpm install --no-frozen-lockfile && pnpm run build";
 
 	public BuildAndPublishAppReactor() {
 		this.keysToGet = new String[] { PROJECT_ID };
@@ -154,9 +154,6 @@ public class BuildAndPublishAppReactor extends AbstractReactor {
 		}
 	}
 
-	// ── HTTP
-	// ─────────────────────────────────────────────────────────────────
-
 	private void postMultipart(String url, Path zipFile, Path destFile) throws IOException {
 		String boundary = "----SemossBuild" + Long.toHexString(System.currentTimeMillis());
 		HttpURLConnection conn = (HttpURLConnection) new URL(url).openConnection();
@@ -188,9 +185,6 @@ public class BuildAndPublishAppReactor extends AbstractReactor {
 			Files.copy(in, destFile, StandardCopyOption.REPLACE_EXISTING);
 		}
 	}
-
-	// ── ZIP helpers
-	// ───────────────────────────────────────────────────────────
 
 	private void zipDirectory(Path dir, Path destZip) throws IOException {
 		try (ZipOutputStream zos = new ZipOutputStream(new BufferedOutputStream(Files.newOutputStream(destZip)))) {
@@ -251,9 +245,6 @@ public class BuildAndPublishAppReactor extends AbstractReactor {
 			}
 		}
 	}
-
-	// ── Pixel input helpers
-	// ───────────────────────────────────────────────────
 
 	private String normalizeProjectId(User user, String rawProjectId) {
 		if (rawProjectId == null) {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Adding `--no-frozen-lockfile` flag to install cmd on BuildAndPublishAppReactor so that when an agent harness makes changes to the package.json it does not need to manually update the lockfile as well when we rebuild. 

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->