### PR TITLE
fix: harden startup wait paths and standardize logger messages

### DIFF
--- a/src/prerna/om/ClientProcessWrapper.java
+++ b/src/prerna/om/ClientProcessWrapper.java
@@ -41,13 +41,12 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.commons.io.FileUtils;
 
 import prerna.tcp.client.NativePySocketClient;
 import prerna.tcp.client.SocketClient;
-import prerna.util.Constants;
 import prerna.util.PortAllocator;
 import prerna.util.SymlinkHelper;
 import prerna.util.Utility;
@@ -55,6 +54,9 @@ import prerna.util.Utility;
 public class ClientProcessWrapper {
 
 	private static final Logger classLogger = LogManager.getLogger(ClientProcessWrapper.class);
+
+	private static final long SOCKET_CLIENT_READY_WAIT_INTERVAL_MS = 1_000L;
+	private static final long SOCKET_CLIENT_READY_WAIT_TIMEOUT_MS = 60_000L;
 
 	private final Object lockCreate = new Object();
 	private final Object lockDestroy = new Object();
@@ -205,25 +207,25 @@ public class ClientProcessWrapper {
 				this.socketClient.connect("127.0.0.1", this.port, false);
 				Thread t = new Thread(socketClient);
 				t.start();
-				while (!socketClient.isReady()) {
-					// since this is in a while loop
-					// the socket client might have notified us
-					// however, the isReady is false
-					// because the socket couldn't connect
-					// so we also set the killAll
-					// and break out of this loop
-					// since the loop is also in a sync block
-					// it causes an infinite wait and the reconnect server logic doesn't work
-					if (socketClient.isKillAll()) {
-						throw new IllegalArgumentException("Failed to connect to your isolated analytics engine");
-					}
-					synchronized (socketClient) {
+				long waitDeadline = System.currentTimeMillis() + SOCKET_CLIENT_READY_WAIT_TIMEOUT_MS;
+				synchronized (socketClient) {
+					while (!socketClient.isReady() && !socketClient.isKillAll()) {
+						long remainingWaitMillis = waitDeadline - System.currentTimeMillis();
+						if (remainingWaitMillis <= 0) {
+							throw new IllegalArgumentException(
+									"Timed out waiting for isolated analytics engine socket client to become ready");
+						}
 						try {
-							socketClient.wait();
+							socketClient.wait(Math.min(SOCKET_CLIENT_READY_WAIT_INTERVAL_MS, remainingWaitMillis));
 						} catch (InterruptedException e) {
-							classLogger.error(Constants.STACKTRACE, e);
+							Thread.currentThread().interrupt();
+							classLogger.error("Interrupted while waiting for socket client readiness", e);
+							throw new IllegalStateException("Interrupted while waiting for socket client readiness", e);
 						}
 					}
+				}
+				if (socketClient.isKillAll()) {
+					throw new IllegalArgumentException("Failed to connect to your isolated analytics engine");
 				}
 				classLogger.info("Setting the socket client ");
 			} catch (Exception e) {
@@ -231,7 +233,8 @@ public class ClientProcessWrapper {
 					throw new IllegalArgumentException("Could not connect to process - note force port is on " + port
 							+ " and your server might not be started");
 				}
-				classLogger.error(Constants.STACKTRACE, e);
+				classLogger.error("Failed to initialize socket client for isolated analytics engine on port {}",
+						this.port, e);
 				throw e;
 			}
 		}
@@ -268,7 +271,10 @@ public class ClientProcessWrapper {
 								try {
 									Thread.sleep(attempt * 1000);
 								} catch (InterruptedException e1) {
-									classLogger.error(Constants.STACKTRACE, e1);
+									Thread.currentThread().interrupt();
+									classLogger.error(
+											"Interrupted while waiting between cleanup retries for server directory {}",
+											this.serverDirectory, e1);
 								}
 							}
 						}
@@ -290,8 +296,11 @@ public class ClientProcessWrapper {
 				} catch (TimeoutException e) {
 					classLogger.warn("Task did not finish within the timeout");
 					future.cancel(true);
-				} catch (InterruptedException | ExecutionException e) {
-					classLogger.error(Constants.STACKTRACE, e);
+				} catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
+					classLogger.error("Interrupted while waiting for socket client shutdown task to finish", e);
+				} catch (ExecutionException e) {
+					classLogger.error("Socket client shutdown task failed", e);
 				} finally {
 					executor.shutdown();
 
@@ -304,7 +313,7 @@ public class ClientProcessWrapper {
 				try {
 					this.process.destroy();
 				} catch (Exception e) {
-					classLogger.error(Constants.STACKTRACE, e);
+					classLogger.error("Failed to destroy isolated analytics process for port {}", this.port, e);
 				}
 			}
 		}

--- a/src/prerna/tcp/SocketServer.java
+++ b/src/prerna/tcp/SocketServer.java
@@ -33,6 +33,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.net.SocketTimeoutException;
 import java.nio.file.Paths;
 import java.util.Properties;
 
@@ -44,202 +45,261 @@ import prerna.util.Constants;
 import prerna.util.DIHelper;
 import prerna.util.Utility;
 
+/**
+ * TCP socket server responsible for accepting client connections and delegating
+ * request processing to {@link SocketServerHandler}.
+ */
 public class SocketServer implements Runnable {
-	
+
 	// basically a process which works by looking for commands in TCP space
 	private static final String CLASS_NAME = SocketServer.class.getName();
-	private static boolean multi = false; // allow multiple threads at the same time
+	private static final int ACCEPT_TIMEOUT_MS = 10_000;
+	private static final int MAX_INITIAL_ACCEPT_ATTEMPTS = 6;
+	private static final long CRASH_WAIT_TIMEOUT_MS = 10_000L;
+	// allow multiple threads at the same time
+	private static boolean multi = false;
 	public static boolean testMode = false;
-	
+
 	private static Logger classLogger = null;
 
-	private Properties prop = null; // this is basically reference to the RDF Map
+	// this is basically reference to the RDF Map
+	private Properties prop = null;
 	private String socketDir = null;
 
 	private boolean done = false;
-	
+	private boolean crashSignaled = false;
+	private int initialAcceptAttempts = 0;
+	private boolean hasAcceptedInitialConnection = false;
+
 	private Socket clientSocket = null;
 	private ServerSocket serverSocket = null;
-	
+
 	private InputStream is = null;
-	
+
 	private SocketServerHandler ssh = new SocketServerHandler();
-	private String baseFolder = null;
-	
+
 	public Object crash = new Object();
 
-	public static void main(String [] args) throws Exception {
+	/**
+	 * Entry point used to bootstrap the socket server process.
+	 *
+	 * @param args runtime arguments where index {@code 0} is the socket working
+	 *             directory, index {@code 1} is the RDF map path, and index
+	 *             {@code 2} is the server port
+	 * @throws Exception if startup dependencies cannot be initialized
+	 */
+	public static void main(String[] args) throws Exception {
 		// arg1 - the directory where commands would be thrown
 		// arg2 - access to the rdf map to load
 		// arg3 - port to start
-		
+
 		// create the watch service
 		// start this thread
-		
+
 		// when event comes write it to the command
 		// comment this for main execution
-		//-Dlog4j.defaultInitOverride=TRUE
-		
-		if(args == null || args.length == 0) {
+		// -Dlog4j.defaultInitOverride=TRUE
+
+		if (args == null || args.length == 0) {
 			args = new String[5];
 			args[0] = "C:/workspace/Semoss/InsightCache/z1";
-			args[1] = "C:/workspace/Semoss/RDF_Map.prop";;
+			args[1] = "C:/workspace/Semoss/RDF_Map.prop";
+			;
 			args[2] = "9999";
 			args[3] = "r";
 			args[4] = "mixed";
 			multi = true;
 			testMode = true;
 		}
-		
-		if(args.length < 3) {
-			throw new IllegalArgumentException("Must pass in at least 3 inputs - the log4j file, the rdf file map, and the port to run the socket on");
+
+		if (args.length < 3) {
+			throw new IllegalArgumentException(
+					"Must pass in at least 3 inputs - the log4j file, the rdf file map, and the port to run the socket on");
 		}
-		
+
 		// this socket dir should have the log4j file contianer inside it
 		String socketDir = args[0];
 		String rdfMapInput = args[1];
 		String portInput = args[2];
-		
-		String log4JPropFile = Paths.get(Utility.normalizePath(socketDir), "log4j2.properties").toAbsolutePath().toString();
 
-		
+		String log4JPropFile = Paths.get(Utility.normalizePath(socketDir), "log4j2.properties").toAbsolutePath()
+				.toString();
+
 		// set to say this is not core
 		DIHelper.getInstance().setLocalProperty("core", "false");
-		
-		FileInputStream fis = null;
-		try {
-			fis = new FileInputStream(Utility.normalizePath(log4JPropFile));
+
+		classLogger = LogManager.getLogger(CLASS_NAME);
+		try (FileInputStream fis = new FileInputStream(Utility.normalizePath(log4JPropFile))) {
 			new ConfigurationSource(fis);
 		} catch (IOException e) {
-			classLogger.error(Constants.STACKTRACE, e);
-		} finally {
-			if(fis != null) {
-				try {
-					fis.close();
-				} catch (IOException e) {
-					classLogger.error(Constants.STACKTRACE, e);
-					classLogger.error(Constants.STACKTRACE, e);
-				}
-			}
+			classLogger.error("Failed to load log4j2 properties from {}", log4JPropFile, e);
 		}
-		classLogger = LogManager.getLogger(CLASS_NAME);
 
 		int port = -1;
 		try {
 			port = Integer.parseInt(portInput);
-		} catch(NumberFormatException e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			classLogger.error(Constants.STACKTRACE, e);
-			throw new IllegalArgumentException("Input integer input for port='" + portInput+"'");
+		} catch (NumberFormatException e) {
+			classLogger.error("Invalid socket server port input: {}", portInput, e);
+			throw new IllegalArgumentException("Input integer input for port='" + portInput + "'");
 		}
-		
+
 		String rdfMapLocation = Utility.normalizePath(rdfMapInput);
 		Properties rdfMap = Utility.loadProperties(rdfMapLocation);
-        System.out.println("loaded rdf map");
-        classLogger.info("loaded rdf map");
+		classLogger.info("Loaded rdf map");
 
-		SocketServer worker = new SocketServer();
-		worker.baseFolder = rdfMap.getProperty(Constants.BASE_FOLDER).replace('\\', '/');
-		
 		DIHelper.getInstance().loadCoreProp(rdfMapLocation);
 		DIHelper.getInstance().getProperty(Constants.BASE_FOLDER);
-		
-		worker.prop = rdfMap;
 
+		SocketServer worker = new SocketServer();
+		worker.prop = rdfMap;
 		worker.socketDir = socketDir;
 		String engine = "r";
-		if(args.length >= 4) {
+		if (args.length >= 4) {
 			engine = args[3];
 		}
-		if(args.length >= 5) {
+		if (args.length >= 5) {
 			SocketServer.multi = args[4].equalsIgnoreCase("multi");
 		}
-		
+
 		worker.bootServer(port, engine);
 	}
-	
-	public void bootServer(final int PORT, String engine) {
-        try {
-            serverSocket = new ServerSocket(PORT);
-        } catch (IOException e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			classLogger.error(Constants.STACKTRACE, e);
-            System.err.println("Could not listen on port: " + PORT);
-            System.exit(1);
-        }
-        System.out.println("server started");
-        classLogger.info("server started");
 
-        Thread listenerThread = new Thread(this);
-        listenerThread.start();
+	/**
+	 * Binds and starts the socket listener thread.
+	 *
+	 * @param PORT   socket port to bind
+	 * @param engine engine identifier kept for startup compatibility
+	 */
+	public void bootServer(final int PORT, String engine) {
+		try {
+			serverSocket = new ServerSocket(PORT);
+			// Avoid blocking forever on initial client connect attempts.
+			serverSocket.setSoTimeout(ACCEPT_TIMEOUT_MS);
+		} catch (IOException e) {
+			classLogger.error("Could not listen on port {}", PORT, e);
+			System.exit(1);
+		}
+		classLogger.info("server started");
+
+		Thread listenerThread = new Thread(this);
+		listenerThread.start();
 	}
-	
-	// start listening for connections
+
+	/**
+	 * Continuously accepts client connections and starts a handler thread for each
+	 * accepted socket based on the server's threading mode.
+	 */
+	@Override
 	public void run() {
 		// do the listening here and then spawn the thread
-			while(!done) {
-			if(this.clientSocket == null || multi) {
-		        try {
-		            clientSocket = serverSocket.accept();
-		        } catch (IOException e) {
-					classLogger.error(Constants.STACKTRACE, e);
-					classLogger.error(Constants.STACKTRACE, e);
-		            System.err.println("Accept failed.");
-		            System.exit(1);
-		        }	
-		        try {
-			        ssh = new SocketServerHandler();
-			        DIHelper.getInstance().setLocalProperty("SSH", ssh);
-		        	ssh.setLogger(classLogger);
+		while (!done) {
+			if (this.clientSocket == null || multi) {
+				try {
+					clientSocket = serverSocket.accept();
+					if (!hasAcceptedInitialConnection) {
+						hasAcceptedInitialConnection = true;
+						initialAcceptAttempts = 0;
+						classLogger.info("Accepted initial socket connection");
+					}
+				} catch (SocketTimeoutException e) {
+					if (!hasAcceptedInitialConnection) {
+						initialAcceptAttempts++;
+						classLogger.warn("No socket client connected within {} ms (attempt {}/{})", ACCEPT_TIMEOUT_MS,
+								initialAcceptAttempts, MAX_INITIAL_ACCEPT_ATTEMPTS);
+						if (initialAcceptAttempts >= MAX_INITIAL_ACCEPT_ATTEMPTS) {
+							classLogger.error(
+									"Failed to establish initial socket client connection after {} timed attempts",
+									MAX_INITIAL_ACCEPT_ATTEMPTS);
+							done = true;
+							break;
+						}
+					}
+					continue;
+				} catch (IOException e) {
+					classLogger.error("Failed to accept socket connection", e);
+					System.exit(1);
+				}
+				try {
+					// One handler instance is bound to one accepted client connection.
+					ssh = new SocketServerHandler();
+					DIHelper.getInstance().setLocalProperty("SSH", ssh);
+					ssh.setLogger(classLogger);
 					ssh.setOutputStream(clientSocket.getOutputStream());
 					is = clientSocket.getInputStream();
 				} catch (IOException e) {
-					classLogger.error(Constants.STACKTRACE, e);
-					classLogger.error(Constants.STACKTRACE, e);
-				}   
-		        
-		        // start processing
-		        // start a new thread
-		        //PyExecutorThread pt = startPyExecutor();
+					classLogger.error("Failed to initialize socket input/output streams", e);
+				}
 
-		        //ssh.setPyExecutorThread(pt);
-		        ssh.is = is;
-		        ssh.socket = serverSocket;
-		        ssh.server = this;
-		        ssh.mainFolder = socketDir;
-		        
-		        Thread readerThread = new Thread(ssh);
-		        readerThread.start();
+				// Wire server->handler context so the handler can callback into
+				// signalCrash() when its socket loop fails.
+				ssh.is = is;
+				ssh.socket = serverSocket;
+				ssh.server = this;
+				ssh.mainFolder = socketDir;
+
+				// Handler owns the socket read loop for this client.
+				Thread readerThread = new Thread(ssh);
+				readerThread.start();
 			} else {
 				// just sleep
-				// see if something crashed
-				synchronized(crash) {
+				// See if the active handler crashed; handler calls signalCrash().
+				synchronized (crash) {
 					try {
-						crash.wait();
-						clientSocket = null;
+						while (!crashSignaled) {
+							crash.wait(CRASH_WAIT_TIMEOUT_MS);
+						}
+						crashSignaled = false;
 						closeStream(clientSocket);
+						clientSocket = null;
 						closeStream(serverSocket);
 						closeStream(is);
-						if(!testMode)	
+						is = null;
+						if (!testMode) {
 							ssh.cleanUp();
+						}
 					} catch (InterruptedException e) {
-						classLogger.error(Constants.STACKTRACE, e);
-						classLogger.error(Constants.STACKTRACE, e);
+						Thread.currentThread().interrupt();
+						done = true;
+						classLogger.error("Interrupted while waiting for socket crash signal", e);
 					}
 				}
 			}
 		}
 	}
-	
-    private void closeStream(Closeable closeThis) {
-    	try {
+
+	/**
+	 * Signals the server listener thread that a handler crash was detected.
+	 */
+	public void signalCrash() {
+		synchronized (crash) {
+			crashSignaled = true;
+			crash.notifyAll();
+		}
+	}
+
+	/**
+	 * Closes a closeable resource while safely handling null references and close
+	 * failures.
+	 *
+	 * @param closeThis resource to close
+	 */
+	private void closeStream(Closeable closeThis) {
+		if (closeThis == null) {
+			return;
+		}
+		try {
 			closeThis.close();
 		} catch (IOException e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			classLogger.error(Constants.STACKTRACE, e);
+			classLogger.error("Failed to close socket resource", e);
 		}
-    }
-	
+	}
+
+	/**
+	 * Indicates whether the server is configured to handle multiple connections in
+	 * parallel.
+	 *
+	 * @return {@code true} when running in multi-threaded mode
+	 */
 	public static boolean isMulti() {
 		return multi;
 	}

--- a/src/prerna/tcp/SocketServerHandler.java
+++ b/src/prerna/tcp/SocketServerHandler.java
@@ -35,9 +35,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.ServerSocket;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -62,6 +62,10 @@ import prerna.util.FstUtil;
 import prerna.util.TCPChromeDriverUtility;
 import prerna.util.Utility;
 
+/**
+ * Handles socket payload processing for a connected client and coordinates
+ * request/response routing between SEMOSS core and runtime components.
+ */
 public class SocketServerHandler implements Runnable {
 
 	public static Logger classLogger = null;
@@ -74,11 +78,13 @@ public class SocketServerHandler implements Runnable {
 	private int bytesReadSoFar = 0;
 	private int lenBytesReadSoFar = 0;
 	private boolean done = false;
-	private boolean blocking = false; // processes one payload and moves to the next one. This is how it currently
-										// behaves
+	// processes one payload and moves to the next one. This is how it currently
+	// behaves
+	private boolean blocking = false;
 	private long averageMillis = 200;
 
 	ServerSocket socket = null;
+	// Back-reference to the owning SocketServer; used for crash signaling.
 	SocketServer server = null;
 	OutputStream os = null;
 	InputStream is = null;
@@ -86,23 +92,32 @@ public class SocketServerHandler implements Runnable {
 
 	private RConnection retCon = null;
 
-	private Map<String, AbstractRJavaTranslator> rtMap = new HashMap<String, AbstractRJavaTranslator>();
-	private Map<String, Insight> insightMap = new HashMap<String, Insight>();
-	private Map<String, Project> projectMap = new HashMap<String, Project>();
-	private Map<String, CmdExecUtil> cmdMap = new HashMap<String, CmdExecUtil>();
+	private Map<String, AbstractRJavaTranslator> rtMap = new ConcurrentHashMap<String, AbstractRJavaTranslator>();
+	private Map<String, Insight> insightMap = new ConcurrentHashMap<String, Insight>();
+	private Map<String, Project> projectMap = new ConcurrentHashMap<String, Project>();
+	private Map<String, CmdExecUtil> cmdMap = new ConcurrentHashMap<String, CmdExecUtil>();
 
-	private Map<String, PayloadStruct> incoming = new HashMap<String, PayloadStruct>();
-	private Map<String, PayloadStruct> outgoing = new HashMap<String, PayloadStruct>();
+	private final Map<String, PayloadStruct> incoming = new ConcurrentHashMap<String, PayloadStruct>();
+	private final Map<String, PayloadStruct> outgoing = new ConcurrentHashMap<String, PayloadStruct>();
 
 	private int curEpoc = 1;
 
-//	ErrorThread et = null;
-
+	/**
+	 * Sets the logger used by handler instances.
+	 * 
+	 * @param classLogger logger to use for handler lifecycle and payload processing
+	 */
 	public void setLogger(Logger classLogger) {
 		SocketServerHandler.classLogger = classLogger;
 	}
 
-	// this is where the processing happens
+	/**
+	 * Processes an incoming payload and returns the response payload that should be
+	 * sent back over the socket.
+	 * 
+	 * @param ps incoming payload
+	 * @return response payload, or {@code null} when processing fails
+	 */
 	public PayloadStruct getFinalOutput(PayloadStruct ps) {
 		try {
 			// System.err.println("Received For Processing " + ps.methodName + " bytes : " +
@@ -117,7 +132,7 @@ public class SocketServerHandler implements Runnable {
 			outgoing.put(ps.epoc, ps);
 
 			// System.out.println("Getting final output for " + ps.methodName);
-			classLogger.info("Getting final output for " + ps.methodName);
+			classLogger.info("Getting final output for method '{}'", ps.methodName);
 
 			//// System.err.println("Payload set to " + ps);
 			if (ps.methodName.equalsIgnoreCase("EMPTYEMPTYEMPTY")) { // trigger message ignore
@@ -145,15 +160,13 @@ public class SocketServerHandler implements Runnable {
 					ps.processed = true;
 					ps.response = true;
 				} catch (InvocationTargetException ex) {
-					classLogger.error(Constants.STACKTRACE, ex);
-					classLogger.info(ex + ps.methodName);
-					// classLogger.error(Constants.STACKTRACE, ex);
+					classLogger.error("Invocation error while executing R operation '{}'", ps.methodName, ex);
+					classLogger.debug("R operation '{}' failed with exception '{}'", ps.methodName, ex.toString());
 					// System.err.println("Method.. " + ps.methodName);
 					ps.ex = ExceptionUtils.getStackTrace(ex);
 				} catch (Exception ex) {
-					classLogger.error(Constants.STACKTRACE, ex);
-					classLogger.info(ex + ps.methodName);
-					// classLogger.error(Constants.STACKTRACE, ex);
+					classLogger.error("Error while executing R operation '{}'", ps.methodName, ex);
+					classLogger.debug("R operation '{}' failed with exception '{}'", ps.methodName, ex.toString());
 					// System.err.println("Method.. " + ps.methodName);
 					ps.ex = ExceptionUtils.getStackTrace(ex);
 				}
@@ -169,14 +182,14 @@ public class SocketServerHandler implements Runnable {
 						output = new Object();
 					}
 					if (output instanceof String) {
-						classLogger.info("Output is >>>>>>>>>>>>>>>  " + output);
+						classLogger.info("CHROME operation '{}' returned String output: {}", ps.methodName, output);
 					}
 					Object[] retObject = new Object[1];
 					retObject[0] = output;
 					ps.payload = retObject;
 					ps.processed = true;
 				} catch (Exception ex) {
-					classLogger.error(Constants.STACKTRACE, ex);
+					classLogger.error("Error while executing CHROME operation '{}'", ps.methodName, ex);
 					// System.err.println("Method.. " + ps.methodName);
 					ps.ex = ExceptionUtils.getStackTrace(ex);
 					// TCPChromeDriverUtility.quit("stop");
@@ -191,8 +204,7 @@ public class SocketServerHandler implements Runnable {
 					ps.payload = retObject;
 					ps.processed = true;
 				} catch (Exception ex) {
-					classLogger.error(Constants.STACKTRACE, ex);
-					// classLogger.error(Constants.STACKTRACE, ex);
+					classLogger.error("Error while executing ECHO operation '{}'", ps.methodName, ex);
 					// System.err.println("Method.. " + ps.methodName);
 					ps.ex = ExceptionUtils.getStackTrace(ex);
 					// TCPChromeDriverUtility.quit("stop");
@@ -210,8 +222,7 @@ public class SocketServerHandler implements Runnable {
 					ps.response = true;
 					insightMap.put(output.getInsightId(), output);
 				} catch (Exception ex) {
-					classLogger.error(Constants.STACKTRACE, ex);
-					// classLogger.error(Constants.STACKTRACE, ex);
+					classLogger.error("Error while processing INSIGHT payload for insight '{}'", ps.insightId, ex);
 					// System.err.println("Method.. " + ps.methodName);
 					ps.ex = ExceptionUtils.getStackTrace(ex);
 					// TCPChromeDriverUtility.quit("stop");
@@ -260,8 +271,7 @@ public class SocketServerHandler implements Runnable {
 					ps.payload = new Object[] { nmd };
 					ps.payloadClasses = new Class[] { NounMetadata.class };
 				} catch (Exception ex) {
-					classLogger.error(Constants.STACKTRACE, ex);
-					// classLogger.error(Constants.STACKTRACE, ex);
+					classLogger.error("Error while executing REACTOR operation '{}'", ps.objId, ex);
 					// System.err.println("Method.. " + ps.methodName);
 					ps.ex = ExceptionUtils.getStackTrace(ex);
 					// TCPChromeDriverUtility.quit("stop");
@@ -285,8 +295,7 @@ public class SocketServerHandler implements Runnable {
 					ps.payload = new Object[] { "method " + ps.methodName + " execution complete" };
 					ps.payloadClasses = new Class[] { String.class };
 				} catch (Exception ex) {
-					classLogger.error(Constants.STACKTRACE, ex);
-					// classLogger.error(Constants.STACKTRACE, ex);
+					classLogger.error("Error while executing PROJECT operation '{}'", ps.methodName, ex);
 					// System.err.println("Method.. " + ps.methodName);
 					ps.ex = ExceptionUtils.getStackTrace(ex);
 					// TCPChromeDriverUtility.quit("stop");
@@ -320,7 +329,6 @@ public class SocketServerHandler implements Runnable {
 //						}
 //					}
 //				} catch(Exception ex) {
-//					classLogger.error(Constants.STACKTRACE, ex);
 //					ps.ex = ExceptionUtils.getStackTrace(ex);						
 //					//TCPChromeDriverUtility.quit("stop");
 //				}
@@ -328,19 +336,19 @@ public class SocketServerHandler implements Runnable {
 //				return ps;
 //			}
 		} catch (Exception ex) {
-			// classLogger.error(Constants.STACKTRACE, ex);
-			classLogger.error(Constants.STACKTRACE, ex);
+			classLogger.error("Unhandled error while processing payload for method '{}'", ps.methodName, ex);
 			ps.ex = ex.getMessage();
 		}
 		return null;
 	}
 
 	/**
+	 * Gets a reactor from a project, creating the project reference when needed.
 	 * 
 	 * @param projectId
 	 * @param projectName
 	 * @param reactorName
-	 * @return
+	 * @return resolved reactor, or {@code null} if the project cannot provide it
 	 */
 	private IReactor getProjectReactor(String projectId, String projectName, String reactorName) {
 		Project project = null;
@@ -354,6 +362,13 @@ public class SocketServerHandler implements Runnable {
 		return reactor;
 	}
 
+	/**
+	 * Creates and registers a project wrapper for socket-based reactor execution.
+	 * 
+	 * @param projectId   project id
+	 * @param projectName project name
+	 * @return initialized project wrapper
+	 */
 	private Project makeProject(String projectId, String projectName) {
 		Project project = new Project();
 		project.setProjectId(projectId);
@@ -366,6 +381,12 @@ public class SocketServerHandler implements Runnable {
 		return project;
 	}
 
+	/**
+	 * Serializes and writes a payload response to the connected client.
+	 * 
+	 * @param ps payload to write
+	 * @return response payload for caller-waited operations, otherwise {@code null}
+	 */
 	public PayloadStruct writeResponse(PayloadStruct ps) {
 		byte[] psBytes = null;
 		// if this is the response
@@ -381,7 +402,7 @@ public class SocketServerHandler implements Runnable {
 			psBytes = FstUtil.packBytes(ps);
 		} catch (Exception ex) {
 			// dont choke this thread
-			classLogger.error(Constants.STACKTRACE, ex);
+			classLogger.error("Failed to serialize payload response for epoc '{}'", ps.epoc, ex);
 			if (psBytes == null) {
 				// hmm we are in the non serializable land
 				// let us try it this way now
@@ -393,12 +414,12 @@ public class SocketServerHandler implements Runnable {
 		// send it
 		// System.out.println(" Sending bytes " + psBytes.length + " >> " +
 		// ps.methodName + " " + ps.epoc + " >> ");
-		classLogger.info("  Sending bytes " + psBytes.length + " >> " + ps.methodName + "  " + ps.epoc + " >> ");
+		classLogger.info("Sending {} bytes for method '{}' (epoc '{}')", psBytes.length, ps.methodName, ps.epoc);
 		try {
 			os.write(psBytes);
 			// remove from the epoc queue
 		} catch (Exception ex) {
-			classLogger.error(Constants.STACKTRACE, ex);
+			classLogger.error("Failed to write payload response for epoc '{}'", ps.epoc, ex);
 		}
 
 		// if this is what socket is sending
@@ -427,46 +448,72 @@ public class SocketServerHandler implements Runnable {
 				synchronized (ps) {
 					try {
 						// wait to see if there is response
-						classLogger.info("Going into wait for epoc " + ps.epoc);
+						classLogger.info("Waiting for response epoc '{}'", ps.epoc);
 						ps.wait(averageMillis);
 						// once response remove this from the outgoing queue
 						// the main input is available on incoming
 					} catch (InterruptedException e) {
-						classLogger.error(Constants.STACKTRACE, e);
-						classLogger.error(Constants.STACKTRACE, e);
+						Thread.currentThread().interrupt();
+						classLogger.error("Interrupted while waiting for response epoc '{}'", ps.epoc, e);
+						outgoing.remove(ps.epoc);
+						return createErrorResponse(ps,
+								"Interrupted while waiting for socket response for epoc '" + ps.epoc + "'");
 					}
 				}
 			}
-			classLogger.info("Got re sponse for " + ps.epoc);
+			classLogger.info("Received response for epoc '{}'", ps.epoc);
 			// assumes we already got the response
 			outgoing.remove(ps.epoc);
-			ps = incoming.remove(ps.epoc);
-			return ps;
+			PayloadStruct responsePayload = incoming.remove(ps.epoc);
+			if (responsePayload == null) {
+				return createErrorResponse(ps, "Response for epoc '" + ps.epoc + "' was not available");
+			}
+			return responsePayload;
 
 		}
 		return null;
 	}
 
-	public void releaseAll() {
-		// take all the unprocessed and remove all of it
-		Iterator<String> keys = incoming.keySet().iterator();
-		while (keys.hasNext()) {
-			String thisEpoc = keys.next();
-			PayloadStruct ps = incoming.get(thisEpoc);
+	private PayloadStruct createErrorResponse(PayloadStruct originalRequest, String message) {
+		PayloadStruct errorResponse = new PayloadStruct();
+		if (originalRequest != null) {
+			errorResponse.epoc = originalRequest.epoc;
+			errorResponse.operation = originalRequest.operation;
+			errorResponse.methodName = originalRequest.methodName;
+		}
+		errorResponse.response = true;
+		errorResponse.processed = true;
+		errorResponse.ex = message;
+		errorResponse.payload = new Object[] { message };
+		errorResponse.payloadClasses = new Class[] { String.class };
+		return errorResponse;
+	}
 
-			if (ps != null) {
-				String message = "Releasing this payload";
-				if (ps.payload != null && ps.payload.length >= 1) {
-					message = message + ps.payload[0];
-				}
-				ps.payload = new String[] { message };
-				writeResponse(ps);
+	/**
+	 * Forces responses for all pending incoming payloads.
+	 */
+	public void releaseAll() {
+		// Snapshot first to avoid iterating over a map being mutated by writeResponse()
+		PayloadStruct[] pendingPayloads;
+		synchronized (incoming) {
+			pendingPayloads = incoming.values().toArray(new PayloadStruct[0]);
+		}
+		for (PayloadStruct ps : pendingPayloads) {
+			if (ps == null) {
+				continue;
 			}
+			String message = "Releasing this payload";
+			if (ps.payload != null && ps.payload.length >= 1) {
+				message = message + ps.payload[0];
+			}
+			ps.payload = new String[] { message };
+			writeResponse(ps);
 		}
 	}
 
 	/**
-	 * Delete the entire folder from insight cache and stop processes
+	 * Deletes the socket working folder and shuts down translator/database
+	 * resources.
 	 */
 	public void cleanUp() {
 		try {
@@ -516,6 +563,14 @@ public class SocketServerHandler implements Runnable {
 		System.exit(1);
 	}
 
+	/**
+	 * Finds an R translator method by name and arguments.
+	 * 
+	 * @param rt         translator instance
+	 * @param methodName method name
+	 * @param arguments  argument classes
+	 * @return resolved method, or {@code null} if it cannot be found
+	 */
 	public Method findRMethod(AbstractRJavaTranslator rt, String methodName, Class[] arguments) {
 		Method retMethod = null;
 
@@ -526,7 +581,7 @@ public class SocketServerHandler implements Runnable {
 				try {
 					retMethod = rt.getClass().getDeclaredMethod(methodName, arguments);
 				} catch (Exception ex) {
-					// classLogger.error(Constants.STACKTRACE, ex);
+					// ignore and fallback to superclass lookup
 				}
 				if (retMethod == null) {
 					retMethod = rt.getClass().getSuperclass().getDeclaredMethod(methodName, arguments);
@@ -535,23 +590,29 @@ public class SocketServerHandler implements Runnable {
 				try {
 					retMethod = rt.getClass().getDeclaredMethod(methodName);
 				} catch (Exception ex) {
-					// classLogger.error(Constants.STACKTRACE, ex);
+					// ignore and fallback to superclass lookup
 				}
 				if (retMethod == null) {
 					retMethod = rt.getClass().getSuperclass().getDeclaredMethod(methodName, arguments);
 				}
 			}
-			classLogger.info("Found the method " + retMethod);
+			classLogger.info("Found method {}", retMethod);
 		} catch (NoSuchMethodException e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			classLogger.error(Constants.STACKTRACE, e);
+			classLogger.error("Unable to resolve R method '{}'", methodName, e);
 		} catch (SecurityException e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			classLogger.error(Constants.STACKTRACE, e);
+			classLogger.error("Security manager prevented access to R method '{}'", methodName, e);
 		}
 		return retMethod;
 	}
 
+	/**
+	 * Finds a project method by name and arguments.
+	 * 
+	 * @param rt         project wrapper instance
+	 * @param methodName method name
+	 * @param arguments  argument classes
+	 * @return resolved method, or {@code null} if it cannot be found
+	 */
 	public Method findProjectMethod(Project rt, String methodName, Class[] arguments) {
 		Method retMethod = null;
 
@@ -562,7 +623,7 @@ public class SocketServerHandler implements Runnable {
 				try {
 					retMethod = rt.getClass().getDeclaredMethod(methodName, arguments);
 				} catch (Exception ex) {
-					// classLogger.error(Constants.STACKTRACE, ex);
+					// ignore and fallback to superclass lookup
 				}
 				if (retMethod == null) {
 					retMethod = rt.getClass().getSuperclass().getDeclaredMethod(methodName, arguments);
@@ -572,23 +633,28 @@ public class SocketServerHandler implements Runnable {
 				try {
 					retMethod = rt.getClass().getDeclaredMethod(methodName);
 				} catch (Exception ex) {
-					// classLogger.error(Constants.STACKTRACE, ex);
+					// ignore and fallback to superclass lookup
 				}
 				if (retMethod == null) {
 					retMethod = rt.getClass().getSuperclass().getDeclaredMethod(methodName, arguments);
 				}
 			}
-			classLogger.info("Found the method " + retMethod);
+			classLogger.info("Found method {}", retMethod);
 		} catch (NoSuchMethodException e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			classLogger.error(Constants.STACKTRACE, e);
+			classLogger.error("Unable to resolve project method '{}'", methodName, e);
 		} catch (SecurityException e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			classLogger.error(Constants.STACKTRACE, e);
+			classLogger.error("Security manager prevented access to project method '{}'", methodName, e);
 		}
 		return retMethod;
 	}
 
+	/**
+	 * Finds a chrome utility method by name and arguments.
+	 * 
+	 * @param methodName method name
+	 * @param arguments  argument classes
+	 * @return resolved method, or {@code null} if it cannot be found
+	 */
 	public Method findChromeMethod(String methodName, Class[] arguments) {
 		Method retMethod = null;
 
@@ -597,23 +663,32 @@ public class SocketServerHandler implements Runnable {
 				try {
 					retMethod = TCPChromeDriverUtility.class.getDeclaredMethod(methodName, arguments);
 				} catch (Exception ex) {
-					// classLogger.error(Constants.STACKTRACE, ex);
+					// ignore and continue
 				}
 			} else {
 				try {
 					retMethod = TCPChromeDriverUtility.class.getDeclaredMethod(methodName);
 				} catch (Exception ex) {
-					// classLogger.error(Constants.STACKTRACE, ex);
+					// ignore and continue
 				}
 			}
-			classLogger.info("Found the method " + retMethod);
+			classLogger.info("Found method {}", retMethod);
 		} catch (SecurityException e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			classLogger.error(Constants.STACKTRACE, e);
+			classLogger.error("Security manager prevented access to chrome method '{}'", methodName, e);
 		}
 		return retMethod;
 	}
 
+	/**
+	 * Invokes a method on the R translator and unwraps invocation target
+	 * exceptions.
+	 * 
+	 * @param rt2       translator instance
+	 * @param method    method to invoke
+	 * @param arguments invocation arguments
+	 * @return invocation return value
+	 * @throws Exception when the underlying translator method throws
+	 */
 	public Object runMethodR(AbstractRJavaTranslator rt2, Method method, Object[] arguments) throws Exception {
 		try {
 			Object retObject = null;
@@ -624,6 +699,14 @@ public class SocketServerHandler implements Runnable {
 		}
 	}
 
+	/**
+	 * Invokes a static chrome utility method.
+	 * 
+	 * @param method    method to invoke
+	 * @param arguments invocation arguments
+	 * @return invocation return value
+	 * @throws Exception when reflection invocation fails
+	 */
 	public Object runMethodChrome(Method method, Object[] arguments) throws Exception {
 		Object retObject = null;
 
@@ -632,6 +715,12 @@ public class SocketServerHandler implements Runnable {
 		return retObject;
 	}
 
+	/**
+	 * Retrieves or creates an R translator for the requested environment.
+	 * 
+	 * @param env environment id
+	 * @return translator bound to the provided environment
+	 */
 	private AbstractRJavaTranslator getTranslator(String env) {
 		if (!rtMap.containsKey(env)) {
 			boolean JRI = DIHelper.getInstance().getProperty(Constants.R_CONNECTION_JRI) == null
@@ -660,18 +749,37 @@ public class SocketServerHandler implements Runnable {
 		return rtMap.get(env);
 	}
 
+	/**
+	 * Sets the socket output stream.
+	 * 
+	 * @param os output stream
+	 */
 	public void setOutputStream(OutputStream os) {
 		this.os = os;
 	}
 
+	/**
+	 * Sets the socket input stream.
+	 * 
+	 * @param is input stream
+	 */
 	public void setInputStream(InputStream is) {
 		this.is = is;
 	}
 
+	/**
+	 * Sets the shared server socket reference.
+	 * 
+	 * @param socket server socket
+	 */
 	public void setServerSocket(ServerSocket socket) {
 		this.socket = socket;
 	}
 
+	/**
+	 * Reads payload bytes from the socket stream and dispatches requests/responses
+	 * until the handler stops.
+	 */
 	@Override
 	public void run() {
 		// there are 2 types of interactions
@@ -725,9 +833,10 @@ public class SocketServerHandler implements Runnable {
 							// this is a response to the request that just came in
 							// synchronize on the ps and then notify
 							PayloadStruct responseStruct = (PayloadStruct) retObject;
-							classLogger.info("Received payload with epoc " + responseStruct.epoc);
+							classLogger.info("Received payload with epoc '{}'", responseStruct.epoc);
 							PayloadStruct requestStruct = outgoing.get(responseStruct.epoc);
-							classLogger.info("Have response with epoc " + outgoing.containsKey(responseStruct.epoc));
+							classLogger.info("Outgoing queue contains response epoc '{}': {}", responseStruct.epoc,
+									outgoing.containsKey(responseStruct.epoc));
 							incoming.put(responseStruct.epoc, responseStruct);
 							if (requestStruct != null) {
 								synchronized (requestStruct) {
@@ -748,18 +857,13 @@ public class SocketServerHandler implements Runnable {
 					lenBytesReadSoFar = lenBytesReadSoFar + bytesRead;
 				}
 			} catch (IOException e) {
-				classLogger.error(Constants.STACKTRACE, e);
-				classLogger.error(Constants.STACKTRACE, e);
-//				System.err.println("Client socket has been closed !");
-				synchronized (server.crash) {
-					try {
-						// ask it to listen again
-						this.done = true;
-						server.crash.notify();
-					} catch (Exception e1) {
-						classLogger.error(Constants.STACKTRACE, e1);
-						classLogger.error(Constants.STACKTRACE, e1);
-					}
+				classLogger.error("Socket handler read failed; signaling crash recovery", e);
+				try {
+					// Notify SocketServer.run() so it can unwind/cleanup and re-listen.
+					this.done = true;
+					server.signalCrash();
+				} catch (Exception e1) {
+					classLogger.error("Failed to signal server crash recovery", e1);
 				}
 				// dont quit.. work hard
 				if (!SocketServer.isMulti()) {
@@ -769,6 +873,12 @@ public class SocketServerHandler implements Runnable {
 		}
 	}
 
+	/**
+	 * Gets the stored payload for a given epoc.
+	 * 
+	 * @param epoc epoc identifier
+	 * @return payload associated with the epoc, or {@code null}
+	 */
 	public PayloadStruct getPayloadForEpoc(String epoc) {
 		return incoming.get(epoc);
 	}

--- a/src/prerna/tcp/client/NativePySocketClient.java
+++ b/src/prerna/tcp/client/NativePySocketClient.java
@@ -102,7 +102,7 @@ public class NativePySocketClient extends SocketClient implements Runnable, Clos
 					}
 				}
 
-				classLogger.info("Trying with the sleep time of " + SLEEP_TIME);
+				classLogger.info("Trying with sleep time {}", SLEEP_TIME);
 				while (!connected && attempt < 6) {
 					try {
 						clientSocket = new Socket(this.HOST, this.PORT);
@@ -121,7 +121,7 @@ public class NativePySocketClient extends SocketClient implements Runnable, Clos
 						}
 					} catch (Exception ex) {
 						attempt++;
-						classLogger.info("Attempting Number " + attempt);
+						classLogger.info("Attempting connection number {}", attempt);
 						// see if sleeping helps ?
 						try {
 							// sleeping only for 1 second here
@@ -189,7 +189,7 @@ public class NativePySocketClient extends SocketClient implements Runnable, Clos
 									ps.epoc, ps.operation, ps.response, ps.interim);
 
 							PayloadStruct lock = requestMap.get(ps.epoc);
-							classLogger.debug("incoming payload " + ps);
+							classLogger.debug("Incoming payload {}", ps);
 							classLogger.debug("Found lock for epoc {}: {}", ps.epoc, lock != null);
 
 							// cancelled operations
@@ -736,9 +736,9 @@ public class NativePySocketClient extends SocketClient implements Runnable, Clos
 		ExecutorService executor = Executors.newSingleThreadExecutor();
 		Callable<String> callableTask = () -> {
 			try {
-				for (Object k : this.requestMap.keySet()) {
-					PayloadStruct ps = this.requestMap.get(k);
-					classLogger.debug("Releasing <" + k + "> <" + ps.methodName + ">");
+					for (Object k : this.requestMap.keySet()) {
+						PayloadStruct ps = this.requestMap.get(k);
+						classLogger.debug("Releasing <{}> <{}>", k, ps.methodName);
 					ps.ex = "Client is disconnected from the server.";
 					synchronized (ps) {
 						ps.notifyAll();

--- a/src/prerna/tcp/client/SocketClient.java
+++ b/src/prerna/tcp/client/SocketClient.java
@@ -129,7 +129,7 @@ public class SocketClient implements Runnable, Closeable {
 			SLEEP_TIME = Integer.parseInt(Utility.getDIHelperProperty("SLEEP_TIME"));
 		}
 
-		classLogger.info("Trying with the sleep time of " + SLEEP_TIME);
+		classLogger.info("Trying with sleep time {}", SLEEP_TIME);
 		while (!connected && attempt < 6) // I do an attempt here too hmm..
 		{
 			try {
@@ -168,7 +168,7 @@ public class SocketClient implements Runnable, Closeable {
 				}
 			} catch (Exception ex) {
 				attempt++;
-				classLogger.info("Attempting Number " + attempt);
+				classLogger.info("Attempting connection number {}", attempt);
 				// see if sleeping helps ?
 				try {
 					// sleeping only for 1 second here
@@ -221,7 +221,7 @@ public class SocketClient implements Runnable, Closeable {
 			if (!ps.response) {
 				requestMap.put(id, ps);
 			}
-			classLogger.info("Outgoing epoc " + ps.epoc);
+			classLogger.info("Outgoing epoc {}", ps.epoc);
 			writePayload(ps);
 			// send the message
 
@@ -249,7 +249,7 @@ public class SocketClient implements Runnable, Closeable {
 					 */
 				}
 				if (!responseMap.containsKey(ps.epoc) && ps.hasReturn) {
-					classLogger.info("Timed out for epoc " + ps.epoc + " " + ps.methodName);
+					classLogger.info("Timed out waiting for epoc {} method {}", ps.epoc, ps.methodName);
 
 				}
 			}
@@ -307,7 +307,7 @@ public class SocketClient implements Runnable, Closeable {
 				try {
 					// wait 1 minute at most
 					boolean result = future.get(60, TimeUnit.SECONDS);
-					classLogger.info("Stop PyServe result = " + result);
+					classLogger.info("Stop PyServe result = {}", result);
 					return result;
 				} catch (TimeoutException e) {
 					classLogger.warn("Not able to release the payload structs within a timely fashion");
@@ -346,7 +346,7 @@ public class SocketClient implements Runnable, Closeable {
 			try {
 				for (Object k : this.requestMap.keySet()) {
 					PayloadStruct ps = this.requestMap.get(k);
-					classLogger.debug("Releasing <" + k + "> <" + ps.methodName + ">");
+					classLogger.debug("Releasing <{}> <{}>", k, ps.methodName);
 					ps.ex = "Server has crashed. This happened because you exceeded the memory limits provided or performed an illegal operation. Please relook at your recipe";
 					synchronized (ps) {
 						ps.notifyAll();


### PR DESCRIPTION
- Prevent indefinite startup waits in ClientProcessWrapper and SocketServer (timed wait + initial accept retries).
- Improve socket crash/wait handling safety in server/handler flow.
- Replace Constants.STACKTRACE with proper error message and convert logger string concatenations to {} placeholders.