### PR TITLE
Set tools to auto by default

### DIFF
--- a/src/prerna/reactor/agent/mcp/MakeEngineMCPReactor.java
+++ b/src/prerna/reactor/agent/mcp/MakeEngineMCPReactor.java
@@ -203,7 +203,7 @@ public class MakeEngineMCPReactor extends AbstractReactor {
 			// Parse for specific known keys
 
 			// execution mode
-			String execModeInput = (String) additionalMeta.getOrDefault(MCPUtility.SMSS_MCP_EXECUTION, "ask");
+			String execModeInput = (String) additionalMeta.getOrDefault(MCPUtility.SMSS_MCP_EXECUTION, "auto");
 			MCPExecution execModeEnum = MCPExecution.fromValue(execModeInput);
 			if (execModeEnum == null && !execModeInput.isBlank()) {
 				throw new IllegalArgumentException(MCPUtility.SMSS_MCP_EXECUTION + "can only be a value of: "
@@ -212,10 +212,10 @@ public class MakeEngineMCPReactor extends AbstractReactor {
 			if (execModeEnum != null) {
 				meta.put(MCPUtility.SMSS_MCP_EXECUTION, execModeEnum.getValue());
 			} else {
-				// default to ASK
-				meta.put(MCPUtility.SMSS_MCP_EXECUTION, MCPExecution.ASK.getValue());
+				// default to AUTO
+				meta.put(MCPUtility.SMSS_MCP_EXECUTION, MCPExecution.AUTO.getValue());
 				if (execModeInput != null) {
-					classLogger.warn("Invalid SMSS_MCP_EXECUTION value '{}' for reactor '{}'; falling back to 'ask'.",
+					classLogger.warn("Invalid SMSS_MCP_EXECUTION value '{}' for reactor '{}'; falling back to 'auto'.",
 							execModeInput, reactorNames.get(i));
 				}
 			}

--- a/src/prerna/reactor/agent/mcp/MakePixelMCPReactor.java
+++ b/src/prerna/reactor/agent/mcp/MakePixelMCPReactor.java
@@ -212,12 +212,12 @@ public class MakePixelMCPReactor extends AbstractReactor {
 				if (execModeEnum != null) {
 					meta.put(MCPUtility.SMSS_MCP_EXECUTION, execModeEnum.getValue());
 				} else {
-					meta.put(MCPUtility.SMSS_MCP_EXECUTION, MCPExecution.ASK.getValue());
-					classLogger.warn("Invalid SMSS_MCP_EXECUTION value '{}' for reactor '{}'; falling back to 'ask'.",
+					meta.put(MCPUtility.SMSS_MCP_EXECUTION, MCPExecution.AUTO.getValue());
+					classLogger.warn("Invalid SMSS_MCP_EXECUTION value '{}' for reactor '{}'; falling back to 'auto'.",
 							execModeInput, reactorNames.get(i));
 				}
 			} else if (!hasMethodMeta) {
-				meta.put(MCPUtility.SMSS_MCP_EXECUTION, MCPExecution.ASK.getValue());
+				meta.put(MCPUtility.SMSS_MCP_EXECUTION, MCPExecution.AUTO.getValue());
 			}
 
 			// UI: mcpMetadata overrides getMcpToolMetadata() values


### PR DESCRIPTION
## Description
Set tools to autoexecute by default

## Changes Made
Set tools to autoexecute by default

## How to Test
<!-- Explain how reviewers can test your changes -->
Generate an mcp from an engine via the mcp tab in its settings, see that the mcp json gets set to autoexecute

## Notes
Set tools to autoexecute by default