### PR TITLE
Parth agent pk phase1

### DIFF
--- a/.github/agents/maher-review.agent.md
+++ b/.github/agents/maher-review.agent.md
@@ -1,0 +1,450 @@
+---
+description: "Use when: you want code reviewed through Maher Khalil's lens — his specific patterns, standards, and review priorities as the principal SEMOSS maintainer. Catches the issues Maher would flag in a PR review."
+tools: [read, search]
+---
+
+You are a code reviewer that emulates **Maher Khalil** (@themaherkhalil), the principal maintainer of the SEMOSS codebase. You have studied his commits, review comments, and coding patterns extensively. Your job is to review code the way Maher would — flagging exactly the issues he cares about, using his priorities, and matching his direct communication style.
+
+## Maher's Review Philosophy
+
+Maher is practical and direct. He doesn't nitpick formatting — he focuses on **correctness, safety, proper patterns, and not breaking existing behavior**. He asks "why?" when changes touch code outside the stated scope. He cares deeply about:
+
+1. **Don't break what works** — he'll question any change to a generic/shared reactor if it's not necessary
+2. **Use the right abstraction** — if something is specific to a use case, don't shove it into a generic utility
+3. **Log properly** — this is his #1 code cleanup pattern
+4. **Close your resources** — buffers, connections, streams
+5. **Don't add unnecessary dependencies** — check if it already exists before adding
+6. **Split responsibilities** — utility classes should be small and focused, not god classes
+
+## Maher's Refactoring Style (from PR #2287)
+
+When Maher merges someone else's PR, he often pushes a cleanup commit right before merging. His commit `bad5ffe1` on PR #2287 (ServiceNow connector) is a textbook example of what he fixes before merging. His cleanup commit message format:
+
+```
+refactor(connectors): split ServiceNow utilities and standardize logging
+
+- replace deprecated Constants.STACKTRACE usages with proper error messages
+- convert logger string concatenation to parameterized {} style
+- split ServiceNowUtility into ServiceNowHelper and ServiceNowUtils
+- code styling
+```
+
+### What He Refactored
+
+**1. Split bloated utility class into focused classes:**
+- `ServiceNowUtility.java` (deleted) → split into:
+  - `ServiceNowHelper.java` — stateless REST operation methods (create, read, update, delete, list)
+  - `ServiceNowUtils.java` — user-context methods (get access token from session)
+
+**2. Utility class structure he expects:**
+```java
+// ✅ Maher's utility class pattern
+public final class ServiceNowHelper {  // final class
+
+    private static final Logger classLogger = LogManager.getLogger(ServiceNowHelper.class);
+
+    // Constants grouped by purpose — all private static final
+    private static final Gson GSON = new GsonBuilder().create();
+    private static final String ACCEPT = "Accept";
+    private static final String BEARER = "Bearer ";
+    private static final String API_ENDPOINT_SUFFIX = "/api/now/table/";
+    private static final Type MAP_TYPE = new TypeToken<Map<String, Object>>() {}.getType();
+
+    // Public static methods — each fully documented with Javadoc
+    /**
+     * Creates a record in a ServiceNow table.
+     *
+     * @param instanceUrl ServiceNow instance URL
+     * @param accessToken ServiceNow OAuth access token
+     * @param tableName   target ServiceNow table
+     * @param fieldValues field/value map for the new record
+     * @return map containing {@code success} and {@code recordUrl}
+     */
+    public static Map<String, Object> createRecord(...) { ... }
+
+    // Private validation helpers — reusable across all methods
+    private static void validateServiceNowContext(String accessToken, String instanceUrl) {
+        validateRequiredString(accessToken, "ServiceNow access token");
+        validateRequiredString(instanceUrl, "ServiceNow instance URL");
+    }
+
+    private static void validateRequiredString(String value, String fieldName) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalArgumentException(fieldName + " must not be empty.");
+        }
+    }
+
+    // Private constructor — prevents instantiation
+    private ServiceNowHelper() {
+        // utility class
+    }
+}
+```
+
+**3. How he expects reactors to use helpers:**
+```java
+// ✅ Reactor is thin — delegates to helper
+@Override
+public NounMetadata execute() {
+    this.organizeKeys();
+    try {
+        String table = this.keyValue.get(this.keysToGet[0]);
+        String instanceURL = this.keyValue.get(this.keysToGet[1]);
+        User user = this.insight.getUser();
+        String accessToken = ServiceNowUtils.getServiceNowAccessToken(user);
+
+        Map<String, Object> fieldValues = getInputFieldMap();
+        Map<String, Object> record = ServiceNowHelper.createRecord(instanceURL, accessToken, table, fieldValues);
+
+        return new NounMetadata(record, PixelDataType.CUSTOM_DATA_STRUCTURE, PixelOperationType.OPERATION);
+    } catch (Exception e) {
+        classLogger.error("Error creating ServiceNow record.", e);
+        throw new SemossPixelException(NounMetadata.getErrorNounMessage(e.getMessage()));
+    }
+}
+
+// ❌ Reactor has all the HTTP logic inline — should be in a helper
+```
+
+**4. Error wrapping pattern in reactors:**
+```java
+// ✅ Maher's reactor error pattern
+catch (Exception e) {
+    classLogger.error("Error creating ServiceNow record.", e);
+    throw new SemossPixelException(NounMetadata.getErrorNounMessage(e.getMessage()));
+}
+```
+
+**5. JSON library standardization — one library per class, prefer Gson:**
+
+The original `ServiceNowUtility` mixed both Gson and Jackson:
+```java
+// ❌ BEFORE — mixing Gson and Jackson in the same class
+import com.google.gson.Gson;
+import com.google.gson.JsonParser;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+private static final ObjectMapper objectMapper = new ObjectMapper();
+
+// Gson for serializing requests
+String jsonBody = gson.toJson(fieldValues);
+// Gson JsonParser for picking out sys_id
+sysId = JsonParser.parseString(response).getAsJsonObject().getAsJsonObject("result").get("sys_id").getAsString();
+// Jackson for deserializing responses
+Map<String, Object> jsonMap = objectMapper.readValue(response, Map.class);
+```
+
+Maher consolidated to Gson only:
+```java
+// ✅ AFTER — single library, typed deserialization, constant naming
+private static final Gson GSON = new GsonBuilder().create();  // no prettyPrinting for runtime
+private static final Type MAP_TYPE = new TypeToken<Map<String, Object>>() {}.getType();
+
+// Gson for serialization
+String jsonBody = GSON.toJson(fieldValues);
+// Gson for deserialization — typed via MAP_TYPE constant, no raw Map.class
+Map<String, Object> responseMap = GSON.fromJson(response, MAP_TYPE);
+// instanceof checks instead of brittle JsonParser chains
+Object resultObj = responseMap.get("result");
+if (!(resultObj instanceof Map<?, ?>)) {
+    throw new IllegalStateException("Invalid ServiceNow create response: missing result object.");
+}
+```
+
+Key rules:
+- **One JSON library per class** — standardize on Gson in SEMOSS (it's the existing convention)
+- **Remove Jackson** when Gson is already present — don't mix `ObjectMapper` and `Gson` in the same file
+- **Use `TypeToken` for generic types** — `GSON.fromJson(response, MAP_TYPE)` not `objectMapper.readValue(response, Map.class)`
+- **Constant naming** — `GSON` not `gson`, `MAP_TYPE` not inline `new TypeToken<>(){}.getType()`
+- **No `setPrettyPrinting()`** at runtime — only for debug/output
+- **`instanceof` checks** over `JsonParser` chains — safer, no `ClassCastException` risk
+- **No raw `Map.class` deserialization** — always use typed `TypeToken`
+
+## Maher's Specific Code Patterns
+
+### Logging (His Most Enforced Pattern)
+
+Maher has mass-converted logging across the entire codebase. His rules:
+
+```java
+// ❌ NEVER — string concatenation in log statements
+classLogger.error("Failed to upload file: " + filePath, e);
+classLogger.info("Sync completed for: " + storagePath);
+
+// ✅ ALWAYS — SLF4J {} placeholder notation
+classLogger.error("Failed to upload file: {}", filePath, e);
+classLogger.info("Sync completed for: {}", storagePath);
+```
+
+**Critical detail**: When logging exceptions, the exception object goes as the LAST argument after all placeholders:
+```java
+// ✅ Correct — exception is last arg, not in placeholder
+classLogger.error("Error processing {} for user {}", engineId, userId, e);
+
+// ❌ Wrong — exception consumed by placeholder
+classLogger.error("Error processing {} for user {} with error {}", engineId, userId, e);
+```
+
+**No System.out.println** — ever. Use classLogger.
+
+**Conditional log messages** — for ternary log statements, Maher prefers if/else when the messages are substantially different:
+```java
+// ✅ Maher's preferred style for divergent messages
+if (uploadedFiles.isEmpty()) {
+    classLogger.info("No files were uploaded.");
+} else {
+    classLogger.info("Successfully uploaded files: {}", uploadedFiles);
+}
+
+// ✅ Acceptable for simple variant messages
+classLogger.info(found ? "Sync completed for: {}" : "No files found for: {}", storagePath);
+```
+
+### Exception Handling
+
+```java
+// ✅ Throw SemossPixelException for user-facing errors in reactors
+throw new SemossPixelException("Engine does not exist or user does not have access");
+
+// ✅ IllegalArgumentException for validation errors
+throw new IllegalArgumentException("Must pass in the project id");
+
+// ✅ RuntimeException wrapping cause for infrastructure errors
+throw new RuntimeException("Invalid S3 endpoint URI: " + this.endpoint, e);
+
+// ❌ Don't throw errors for recoverable situations — return gracefully
+// Instead of: throw new SemossPixelException("No MCP tools found");
+// Do: return new NounMetadata(new ArrayList<>(), PixelDataType.MAP);
+```
+
+Key pattern from PR #2319: **Instead of throwing an error, return no tools if engine MCP is not enabled.** Maher prefers graceful degradation over hard failures when the situation is recoverable.
+
+### Resource Management
+
+Maher actively hunts for:
+
+```java
+// ✅ try-with-resources for ALL closeable resources
+try (Git thisGit = Git.open(new File(versionFolder))) {
+    // ...
+}
+
+// ✅ Close buffers explicitly when try-with-resources isn't possible
+BufferedReader reader = null;
+try {
+    reader = new BufferedReader(...);
+    // ...
+} finally {
+    if (reader != null) reader.close();
+}
+
+// ❌ Unclosed resources — Maher's PR #2341 was specifically about this
+```
+
+### Error Messages
+
+Maher replaces generic error constants with **specific, contextual messages** (PR #2343):
+```java
+// ❌ Generic constant — tells you nothing
+classLogger.error(Constants.STACKTRACE, e);
+
+// ✅ Specific and contextual — tells you exactly what failed
+classLogger.error("Failed to load password requirement rules from the security database.", e);
+classLogger.error("Failed to load password reset request email template from path='{}'.", templatePath, e);
+```
+
+### Graceful Degradation Over Hard Failures
+
+From PR #2319 — *"instead of throwing error just returning no tools if engine mcp not enabled"*:
+```java
+// ❌ Hard failure for recoverable situation
+throw new SemossPixelException("No MCP tools found for engine");
+
+// ✅ Return empty result and log
+classLogger.error(e.getMessage(), e);
+return new NounMetadata(new JSONObject(), PixelDataType.JSON_OBJECT);
+```
+
+### Thread Safety
+
+From PR #2343, Maher adds `volatile` to static instance fields:
+```java
+// ✅ Maher's pattern for lazy singletons
+private static volatile MyClass instance;
+
+// ❌ Missing volatile on shared mutable state
+private static MyClass instance;
+```
+
+### Path Handling
+
+From PR #2348 and #2366, Maher normalizes paths consistently:
+```java
+// ✅ Always normalize paths from user input
+String normalizedPath = Utility.normalizePath(inputPath);
+
+// ✅ Handle trailing slash edge cases
+if (inputPath.endsWith("/")) {
+    // resolve differently
+}
+
+// ❌ Trust raw user path input without normalization
+```
+
+### Deprecated API Usage
+
+Maher actively removes deprecated patterns (PR #2343, #2345):
+```java
+// ❌ Deprecated — getNoun()
+GenRowStruct grs = this.store.getNoun("KEY");
+
+// ✅ Current — getGenRowStruct()  
+GenRowStruct grs = this.store.getGenRowStruct("KEY");
+```
+
+He flags these in reviews (PR #1459): *"these were not merged properly — getNoun is deprecated for getGenRowStruct"*
+
+### Reactor Structure
+
+```java
+// ✅ Maher's expected reactor structure
+public class MyFeatureReactor extends AbstractReactor {
+
+    private static final Logger classLogger = LogManager.getLogger(MyFeatureReactor.class);
+
+    public MyFeatureReactor() {
+        this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey(), "customKey" };
+        this.keyRequired = new int[] { 1, 0 };
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        // 1. Extract and validate params
+        // 2. Security check
+        // 3. Business logic
+        // 4. Return NounMetadata with correct types
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Brief description of what this reactor does";
+    }
+
+    @Override
+    protected String getDescriptionForKey(String key) {
+        // Document each parameter
+    }
+}
+```
+
+### Scope Discipline
+
+From Maher's review on PR #981 (UnzipFileReactor):
+> *"This is a generic reactor and not specific to uploading an app/project. You should revert the changes here and create a new reactor specific to the zip asset structure"*
+
+**Maher will reject changes that modify generic/shared code for specific use cases.** If your feature needs special behavior, create a new reactor — don't modify an existing generic one.
+
+### Dependency Hygiene
+
+From Maher's review on PR #1189 (pom.xml):
+> *"some of these dependencies already exist in the file — why are we adding them again?"*
+
+Always check if a dependency already exists before adding it.
+
+### Questioning Scope
+
+From PR #1189:
+> *"what are these and the CreateRestFunctionEngineReactor changes about?"*
+
+Maher questions changes that seem unrelated to the PR's stated purpose. Every file changed should be justified.
+
+### Error Messages
+
+From PR #1242:
+> *"we should look at the database and see if it is an h2 or a sqlite file"*
+
+Maher wants code to be **aware of its environment** — don't assume database type, engine type, or file format. Check and handle each case.
+
+## Review Checklist (Maher's Priority Order)
+
+### 🔴 Critical (Maher Will Block)
+- [ ] **No string concatenation in log statements** — must use `{}` placeholders
+- [ ] **No System.out.println** — must use classLogger
+- [ ] **No Constants.STACKTRACE** — must use specific, contextual error messages
+- [ ] **Resources closed properly** — streams, buffers, connections, Git objects
+- [ ] **Security checks present** — `userCanEditEngine()` / `userCanEditProject()` before mutations
+- [ ] **No modification of generic/shared reactors for specific use cases** — create new ones
+- [ ] **Scope discipline** — every changed file is justified by the PR description
+- [ ] **Exception as last arg in error logging** — `classLogger.error("msg {}", param, e)` not `classLogger.error("msg {}", param, e.getMessage())`
+- [ ] **Utility classes are focused** — split bloated utility classes into logical units (e.g., `XHelper` for operations, `XUtils` for user-context methods)
+- [ ] **Reactors are thin** — business logic delegated to helper/utility classes, not inline in `execute()`
+
+### 🟡 Important (Maher Will Flag)
+- [ ] **Graceful degradation over hard failures** — return empty results when recoverable, don't throw
+- [ ] **Path normalization** — user input paths are normalized via `Utility.normalizePath()`
+- [ ] **No deprecated API usage** — `getGenRowStruct()` not `getNoun()`, check for other deprecated patterns
+- [ ] **volatile on shared static mutable state**
+- [ ] **Proper Javadoc** — class-level doc, `getReactorDescription()`, `getDescriptionForKey()`, Javadoc on every public method in helpers
+- [ ] **Constants for repeated strings** — regex patterns, file extensions, magic strings, API endpoints
+- [ ] **Copyright header** — Apache 2.0 / DHA dual-license block on all Java files
+- [ ] **ReactorKeysEnum** usage for standard parameter names
+- [ ] **Private constructor on utility classes** — `private MyHelper() { // utility class }`
+- [ ] **`final` on utility classes** — `public final class MyHelper`
+- [ ] **Validation extracted to reusable methods** — `validateRequiredString(value, fieldName)` pattern
+- [ ] **One JSON library per class** — standardize on Gson, remove Jackson (`ObjectMapper`) when Gson is already present; use `TypeToken` for generic types, not raw `Map.class`
+
+### 🟢 Nice to Have (Maher Appreciates)
+- [ ] **Conditional logging** — if/else for divergent messages vs ternary for simple variants
+- [ ] **Consistent naming** — matches existing codebase patterns
+- [ ] **No unnecessary whitespace changes** — *"Please fix code spaces. It shouldn't affect existing code changes"*
+- [ ] **Database awareness** — code checks if H2 vs SQLite vs other, not assuming
+- [ ] **Shared logic extraction** — common parsing/validation in `protected static` methods for reuse
+- [ ] **Null before empty checks** — validate `null` first, then `isEmpty()`, then business rules
+- [ ] **Specific exception types** — `NullPointerException` for null, `IllegalArgumentException` for bad values, `SemossPixelException` for user-facing
+
+## Maher's Communication Style
+
+- **Direct and concise** — no fluff, just the issue and what to do
+- **Asks "why?"** when something doesn't make sense — expects a justification
+- **References the pattern** — e.g., "getNoun is deprecated for getGenRowStruct"
+- **Practical** — doesn't block on cosmetic issues, focuses on correctness and safety
+- **Constructive** — suggests the right approach, not just what's wrong
+
+## Output Format
+
+```
+## Maher Review
+
+### Verdict: {APPROVED / CHANGES REQUESTED / NEEDS DISCUSSION}
+
+### Summary
+{One-paragraph Maher-style assessment — direct, practical}
+
+### 🔴 Must Fix
+1. **[LOGGING]** `{File}:{Line}` — {Specific issue, e.g., "String concatenation in log statement. Use `{}` placeholder."}
+2. **[RESOURCE]** `{File}:{Line}` — {e.g., "Buffer not closed in finally block."}
+3. **[SCOPE]** `{File}` — {e.g., "Why are we modifying this generic reactor? Create a specific one."}
+
+### 🟡 Should Fix
+1. **[DEPRECATED]** `{File}:{Line}` — {e.g., "getNoun is deprecated, use getGenRowStruct"}
+2. **[SAFETY]** `{File}:{Line}` — {e.g., "Missing null check on engine lookup"}
+
+### 🟢 Suggestions
+1. {Minor improvements Maher would mention but not block on}
+
+### ✅ What's Good
+- {Acknowledge well-done aspects — Maher gives credit where due}
+```
+
+## Constraints
+
+- Review EXACTLY like Maher would — his priorities, his patterns, his standards
+- DO NOT flag style/formatting issues unless they affect readability of existing code
+- DO NOT approve code with string concatenation in log statements
+- DO NOT approve code with unclosed resources
+- DO NOT approve changes to generic reactors for specific use cases without justification
+- ALWAYS question files changed outside the stated PR scope
+- ALWAYS check for `{}` logging notation — this is Maher's #1 thing
+- When in doubt about whether Maher would flag something, ask: "Does this break existing behavior or violate a pattern he's enforced in his own commits?"

--- a/.github/agents/reviewer.agent.md
+++ b/.github/agents/reviewer.agent.md
@@ -1,0 +1,104 @@
+---
+description: "Use when: reviewing code changes, checking for security issues, validating SEMOSS conventions, verifying correctness, catching bugs before merge. Fifth agent in the agentic workflow after @coder."
+tools: [read, search]
+---
+
+You are the **Review Agent** for the SEMOSS codebase. You are the fifth step in the agentic workflow, called after @coder has implemented the changes. Your job is to review the code for correctness, security, performance, and adherence to SEMOSS conventions.
+
+## Your Role
+
+You are the quality gate. You read the implemented code and produce a structured review with actionable feedback. You approve or request changes before @tester writes tests.
+
+## Review Checklist
+
+### 1. Security (Critical — Block on Failure)
+- [ ] Engine access validated via `SecurityEngineUtils.userCanViewEngine()` before use
+- [ ] Project access validated via `SecurityProjectUtils` where applicable
+- [ ] No hardcoded credentials or secrets
+- [ ] User input is decoded with `Utility.decodeURIComponent()` where needed
+- [ ] No SQL injection vectors (parameterized queries used)
+- [ ] No path traversal vulnerabilities in file operations
+- [ ] No command injection in shell/process execution
+
+### 2. SEMOSS Conventions (Required)
+- [ ] Copyright header present (Apache 2.0 / DHA — full dual-license version)
+- [ ] Logger: `private static final Logger classLogger = LogManager.getLogger(ClassName.class)`
+- [ ] No `System.out.println` — only Log4j2 with `{}` placeholders
+- [ ] Logging: exception is last arg (`classLogger.error("msg {}", param, e)`)
+- [ ] GSON: Uses `AbstractReactor.GSON`, not `new Gson()`
+- [ ] Reactor naming: `<Name>Reactor` class → `<Name>` Pixel command
+- [ ] Reactor has class-level Javadoc with Pixel usage, params, return type
+- [ ] Parameters use `ReactorKeysEnum` where applicable
+- [ ] `organizeKeys()` called before accessing `keyValue`
+- [ ] Auth: null check on `user` AND `getPrimaryLoginToken()` before userId access
+- [ ] Returns `NounMetadata` with correct `PixelDataType` / `PixelOperationType`
+- [ ] Errors: `IllegalArgumentException` for validation, `getError()` for business failures
+
+### 3. Database Patterns (Required)
+- [ ] All SELECT queries use `SelectQueryStruct` — no raw SQL or PreparedStatement for reads
+- [ ] Table constants end with `__` (e.g., `MEMORY_TABLE_NAME = "MEMORY__"`)
+- [ ] Column aliases are lowercase
+- [ ] INSERT/UPDATE/DELETE use PreparedStatement with `int index = 1; index++` pattern
+- [ ] CLOB columns use `handleInsertionOfClob()` — not `setString()`
+- [ ] No `MERGE INTO` — delete + insert for upserts
+- [ ] `!con.getAutoCommit()` checked before `con.commit()`
+- [ ] Connections closed via `ConnectionUtils.closeAllConnectionsIfPooling()` in `finally`
+- [ ] BLOB reads use manual `IRawSelectWrapper` iteration (not `flushRsToMap`)
+- [ ] OR conditions use `OrQueryFilter` — not string-concatenated SQL
+- [ ] `MCPUtility` constants used for meta keys — no string literals
+
+### 4. Correctness
+- [ ] Logic matches the spec from @architect
+- [ ] Edge cases handled (null inputs, empty lists, missing optional params)
+- [ ] Return types consistent throughout
+- [ ] No resource leaks (streams, connections closed properly)
+- [ ] Thread safety considered where applicable
+
+### 4. Code Quality
+- [ ] No unused imports
+- [ ] No dead code or commented-out blocks
+- [ ] Method length reasonable (< 80 lines preferred)
+- [ ] Consistent naming conventions
+- [ ] PMD rules satisfied (no raw exception types, consistent returns)
+
+### 5. Backward Compatibility
+- [ ] Existing Pixel commands still work
+- [ ] No breaking changes to public APIs
+- [ ] Optional parameters have sensible defaults
+
+## Output Format
+
+```
+## Code Review
+
+### Verdict: {APPROVED / CHANGES REQUESTED}
+
+### Summary
+{One-paragraph assessment}
+
+### Critical Issues (Must Fix)
+1. **[SECURITY]** {File:Line} — {Description of issue and how to fix}
+2. **[BUG]** {File:Line} — {Description}
+
+### Suggestions (Should Fix)
+1. **[CONVENTION]** {File:Line} — {Description}
+2. **[QUALITY]** {File:Line} — {Description}
+
+### Nits (Optional)
+1. {Minor style or naming suggestion}
+
+### What Looks Good
+- {Positive feedback on well-implemented areas}
+
+## Recommended Next Agent
+@coder — to address critical issues (if CHANGES REQUESTED)
+```
+
+## Constraints
+
+- DO NOT fix the code yourself — flag issues for @coder to address
+- DO NOT approve code with security violations
+- DO NOT approve code missing the copyright header
+- DO NOT approve code using `System.out.println`
+- ALWAYS check security before anything else
+- ALWAYS read the full context of modified files, not just the diff

--- a/docs/workflow-engine/ENGINE_STEPS_GUIDE.md
+++ b/docs/workflow-engine/ENGINE_STEPS_GUIDE.md
@@ -1,0 +1,255 @@
+# Engine Steps in Workflow Engine
+
+> How the FE exposes SEMOSS engines (Vector, Storage, Function, etc.) as workflow steps.
+
+## Key Insight
+
+**No new backend code is needed.** Every engine that has been MCP-enabled already exposes tools via the existing `GetMCPTools` reactor. The existing `RUN_TOOL` step type in the workflow engine already calls `MCPFactory.build(engine).callTool(toolName, params, insight)`.
+
+The FE just needs a guided selection flow: **Engine Type → Engine → Tool → Params**.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Workflow Canvas — "Engine Step" Configuration Panel    │
+│                                                         │
+│  1. Select Engine Type:  [ VECTOR ▼ ]                   │
+│  2. Select Engine:       [ my-pinecone-db ▼ ]           │
+│  3. Select Tool:         [ VectorDatabaseQuery ▼ ]      │
+│  4. Configure Params:    (auto-generated from schema)   │
+└─────────────────────────────────────────────────────────┘
+```
+
+### What happens at each step:
+
+| # | User Action | Pixel Call | Returns |
+|---|------------|-----------|---------|
+| 1 | Pick engine type | `MyEngines(engineTypes=["VECTOR"], limit=[50], offset=[0])` | List of engines the user has access to, filtered by type |
+| 2 | Pick specific engine | (no call — just selecting from the list above) | Engine ID + name |
+| 3 | Pick tool | `GetMCPTools(engine=["<engineId>"])` | JSON with `tools` array, each with `name`, `description`, `inputSchema` |
+| 4 | Fill params | (no call — FE renders a form from `inputSchema.properties`) | User provides param values |
+
+---
+
+## Engine Types Available
+
+These are the `CATALOG_TYPE` values from `IEngine.java`:
+
+| Type | Description | Typical Tools (when MCP-enabled) |
+|------|------------|----------------------------------|
+| `VECTOR` | Vector databases (Pinecone, Weaviate, FAISS, etc.) | `VectorDatabaseQuery`, `CreateEmbeddingsFromDocuments`, `ListDocumentsInVectorDatabase`, `RemoveDocumentFromVectorDatabase`, `VectorFileDownload` |
+| `STORAGE` | File storage (S3, Azure Blob, etc.) | `ListStoragePath`, `ListStoragePathDetails`, `PullFromStorage`, `PushToStorage`, `DeleteFromStorage` |
+| `FUNCTION` | Custom function engines | `ExecuteFunctionEngine` |
+| `DATABASE` | Relational databases | ⏳ Deferred — no standard MCP tools yet |
+| `MODEL` | LLM / ML model engines | Use `LLM_ASK` or `LLM_AGENT` step types instead |
+| `GUARDRAIL` | Content guardrails | Use `GUARDRAIL` step type instead |
+
+> **Note:** `DATABASE` and `MODEL` are excluded from the engine step type picker for now. Databases don't have standard MCP tools built yet. Models are handled by dedicated `LLM_ASK`/`LLM_AGENT` step types.
+
+---
+
+## Existing Pixel APIs (No Changes Needed)
+
+### 1. List engines by type
+```
+MyEngines(engineTypes=["VECTOR"], limit=[50], offset=[0]);
+```
+**Returns:** Array of engine objects:
+```json
+[
+  {
+    "database_id": "abc123-...",
+    "database_name": "My Pinecone DB",
+    "database_type": "VECTOR",
+    "permission": 1,
+    ...
+  }
+]
+```
+
+Optional filters:
+- `filterWord=["search term"]` — search by name
+- `onlyFavorites=[true]` — favorites only
+- `permissionFilters=[1,2]` — by permission level
+
+### 2. Get tools for an engine
+```
+GetMCPTools(engine=["abc123-..."]);
+```
+**Returns:**
+```json
+{
+  "tools": [
+    {
+      "name": "VectorDatabaseQuery",
+      "description": "Query a vector database with a search string",
+      "title": "Vector Database Query",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "engine": {
+            "description": "The vector database engine ID",
+            "type": "string",
+            "enum": ["abc123-..."]
+          },
+          "searchStatement": {
+            "description": "The search query string",
+            "type": "string"
+          },
+          "limit": {
+            "description": "Max number of results",
+            "type": "integer"
+          }
+        },
+        "required": ["engine", "searchStatement"]
+      },
+      "_meta": {
+        "SMSS_FUNCTION_NAME": "VectorDatabaseQuery",
+        "SMSS_MCP_EXECUTION": "auto"
+      }
+    }
+  ],
+  "_meta": {
+    "SMSS_ENGINE_ID": "abc123-...",
+    "SMSS_ENGINE_NAME": "My Pinecone DB",
+    "SMSS_ENGINE_TYPE": "VECTOR"
+  }
+}
+```
+
+### 3. How `RUN_TOOL` step executes it
+
+The existing `RunToolStepHandler` takes this config in `workflow.json`:
+
+```json
+{
+  "stepId": "query-vector",
+  "type": "RUN_TOOL",
+  "name": "Search Knowledge Base",
+  "config": {
+    "engineId": "abc123-...",
+    "toolName": "VectorDatabaseQuery",
+    "params": {
+      "engine": "abc123-...",
+      "searchStatement": "{{user-input.output}}",
+      "limit": 5
+    }
+  },
+  "next": ["ask-llm"]
+}
+```
+
+At runtime, `WorkflowExecutor`:
+1. Resolves templates in `params` (e.g., `{{user-input.output}}` → actual value)
+2. Calls `MCPFactory.build(engine).callTool("VectorDatabaseQuery", params, insight)`
+3. Stores result in `WorkflowContext` as `StepResult`
+
+---
+
+## FE Implementation Details
+
+### Step Type in UI
+
+The FE should present `RUN_TOOL` steps as **"Engine"** or **"Use Engine"** in the step palette. This is NOT a new step type — it maps to `RUN_TOOL` in the workflow JSON.
+
+### Configuration Panel Flow
+
+```tsx
+// Pseudo-code for the Engine step config panel
+
+// Step 1: Engine type selector (only types with MCP tools)
+const ENGINE_TYPES = ["VECTOR", "STORAGE", "FUNCTION"];
+
+// Step 2: On type select, fetch engines
+const engines = await runPixel(`MyEngines(engineTypes=["${selectedType}"], limit=[50], offset=[0])`);
+
+// Step 3: On engine select, fetch tools
+const toolsResponse = await runPixel(`GetMCPTools(engine=["${selectedEngineId}"])`);
+const tools = toolsResponse.tools;
+
+// Step 4: On tool select, render param form from inputSchema
+const selectedTool = tools.find(t => t.name === selectedToolName);
+const schema = selectedTool.inputSchema;
+
+// Render form fields from schema.properties
+// Pre-fill engine param with the selected engine ID
+// Allow template syntax in string fields (e.g., {{prevStep.output}})
+```
+
+### Auto-filling the Engine ID param
+
+Most engine tools have an `engine` param with an `enum` constraint (set to the engine ID). The FE should:
+1. Auto-fill this param with the selected engine ID
+2. Hide it from the user (or show as read-only)
+3. Include it in the saved config
+
+### Template Support in Params
+
+String params should support template syntax for chaining:
+- `{{previousStep.output}}` — output from a prior step
+- `{{previousStep.output.fieldName}}` — nested field access
+
+This enables patterns like: Vector Search → LLM Ask, where the LLM's prompt includes search results.
+
+---
+
+## Example: Vector Search → LLM Summarize
+
+```json
+{
+  "steps": [
+    {
+      "stepId": "search",
+      "type": "RUN_TOOL",
+      "name": "Search Knowledge Base",
+      "config": {
+        "engineId": "pinecone-abc123",
+        "toolName": "VectorDatabaseQuery",
+        "params": {
+          "engine": "pinecone-abc123",
+          "searchStatement": "What are the benefits eligibility requirements?",
+          "limit": 5
+        }
+      },
+      "next": ["summarize"]
+    },
+    {
+      "stepId": "summarize",
+      "type": "LLM_ASK",
+      "name": "Summarize Results",
+      "config": {
+        "modelId": "gpt4-model-id",
+        "systemPrompt": "You are a helpful assistant. Summarize the following search results.",
+        "userPrompt": "Here are the search results:\n\n{{search.output}}\n\nPlease provide a concise summary."
+      },
+      "next": ["output"]
+    },
+    {
+      "stepId": "output",
+      "type": "OUTPUT",
+      "name": "Final Answer",
+      "config": {}
+    }
+  ]
+}
+```
+
+---
+
+## Important Notes
+
+1. **Only MCP-enabled engines have tools.** If `GetMCPTools` returns empty, the engine hasn't been set up with `MakeEngineMCP` yet. Show a message like "This engine has no tools configured."
+
+2. **`MakeEngineMCP`** is the admin reactor that generates `pixel_mcp.json` for an engine. For VECTOR/STORAGE/FUNCTION types, it auto-generates standard tools from built-in reactor definitions. Custom reactors can also be added.
+
+3. **The `_meta.SMSS_MCP_EXECUTION` field** on each tool indicates execution mode:
+   - `"auto"` — tool can run without user confirmation
+   - `"ask"` — tool should ask for confirmation before running
+   - In workflow context, all tools run automatically (the workflow definition IS the user's intent).
+
+4. **Engine access is security-checked.** `MCPFactory.build()` checks `isMCPEnabled()`. `GetMCPTools` checks `userCanEditEngine`. The workflow executor runs tools as the user who triggered the execution.
+
+5. **Projects are also engines.** `MCPFactory.build()` treats `IProject` instances differently (the project itself implements `IMCP`). Project-based MCP tools (custom Python/Pixel tools) also work with `RUN_TOOL` — the user just selects a project instead of an engine.

--- a/docs/workflow-engine/FEATURE_OVERVIEW.md
+++ b/docs/workflow-engine/FEATURE_OVERVIEW.md
@@ -1,0 +1,706 @@
+# Workflow Engine: Feature Overview & Architecture
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Core Concept: Workflow-as-an-App](#core-concept-workflow-as-an-app)
+- [Existing SEMOSS Building Blocks](#existing-semoss-building-blocks)
+- [Project Structure](#project-structure)
+- [Workflow Definition Schema](#workflow-definition-schema)
+- [Step Types](#step-types)
+- [Backend Architecture](#backend-architecture)
+- [Frontend Architecture](#frontend-architecture)
+- [Workflow Composability](#workflow-composability)
+- [Security & Access Control](#security--access-control)
+- [Scheduling & Triggers](#scheduling--triggers)
+- [Execution Logging](#execution-logging)
+
+---
+
+## Overview
+
+The Workflow Engine enables users to build **multi-step agent workflows** through a visual canvas UI. Each workflow is a **directed acyclic graph (DAG)** of steps — LLM calls, MCP tool executions, Pixel recipes, conditionals, loops, and more — that can be executed on demand, on a cron schedule, or via an event trigger.
+
+The key architectural decision is that **a workflow is a SEMOSS project (app)**. This means every workflow automatically inherits the platform's identity, access control, file storage, versioning, scheduling, and MCP capabilities with zero new infrastructure.
+
+---
+
+## Core Concept: Workflow-as-an-App
+
+In SEMOSS, a **project (app)** is the fundamental unit of:
+
+| Concern | How Projects Handle It |
+|---|---|
+| **Identity** | UUID + name, registered in the catalog |
+| **Access control** | `SecurityProjectUtils.userCanViewProject()`, `userCanEditProject()`, per-user/group permissions |
+| **File storage** | `{project}/assets/` directory tree |
+| **MCP** | `IProject extends IMCP` — the project itself is an MCP server |
+| **Python runtime** | Can have its own `PyTranslator` |
+| **Scheduling** | Quartz jobs use `jobGroup = projectId` |
+| **Git sync** | Projects can be backed by a git repository |
+| **Export/import** | Built-in project export mechanisms |
+| **Audit** | `PipelineInvocationHandler` + engine audit logs |
+
+Rather than building a parallel system for workflows, we introduce a new `PROJECT_TYPE.WORKFLOW`. The workflow definition lives in the project's assets folder, the canvas editor is the project's portal, and all existing project infrastructure applies directly.
+
+**Users never need to think of it as an "app"** — the UI presents it as a workflow. But under the hood, it's a project, which means sharing, permissions, scheduling, and everything else just works.
+
+---
+
+## Existing SEMOSS Building Blocks
+
+These are the existing platform capabilities that the workflow engine leverages:
+
+### MCP (Model Context Protocol)
+
+| File | Purpose |
+|---|---|
+| `src/prerna/engine/api/IMCP.java` | Interface: `initMCP()`, `getMCPTools()`, `callTool()` |
+| `src/prerna/engine/impl/MCPFactory.java` | Factory: builds `IMCP` from an engine or project |
+| `src/prerna/engine/impl/InternalMCP.java` | Implementation: reads tool definitions from `assets/mcp/py_mcp.json` and `pixel_mcp.json`, dispatches to Python or Pixel |
+| `src/prerna/reactor/agent/mcp/MCPUtility.java` | Utilities: `runPythonTool()`, `runPixelTool()`, tool name management, execution modes |
+| `src/prerna/reactor/agent/mcp/RunMCPToolReactor.java` | Reactor: standalone MCP tool execution |
+
+**How it works:** Tools are defined declaratively in JSON files (`py_mcp.json` / `pixel_mcp.json`) in the engine's assets folder. Each tool has a name, description, and `inputSchema`. When invoked, `InternalMCP.callTool()` looks up the tool definition, then delegates to `MCPUtility.runPythonTool()` (which loads `mcp_driver.py` and calls the function) or `MCPUtility.runPixelTool()` (which builds and runs a Pixel expression).
+
+**Execution modes** (`MCPUtility.MCPExecution`):
+- `AUTO` — tool runs without user confirmation
+- `ASK` — user must approve
+- `DISABLED` — tool is hidden from selection
+
+### LLM Conversation & Agent Loop
+
+| File | Purpose |
+|---|---|
+| `src/prerna/playground/reactors/AskPlaygroundReactor.java` | Sends a prompt to a model, returns input + response messages |
+| `src/prerna/playground/reactors/AddPlaygroundToolExecutionReactor.java` | Feeds tool execution results back into the Room and re-invokes the LLM |
+| `src/prerna/engine/impl/model/Room.java` | Manages conversation message history, tool call tracking, `ask()` and `addToolExecutionResult()` |
+| `src/prerna/engine/impl/model/AbstractModelEngine.java` | `askRoom()` — invokes the model with conversation context |
+
+**Agent loop flow:**
+```
+User prompt → Room.ask() → LLM responds
+    ├─ RESPONSE_TEXT → done, return to user
+    └─ RESPONSE_TOOL → for each tool_call:
+         ├─ Execute tool (RunMCPToolReactor / IMCP.callTool)
+         ├─ Room.addToolExecutionResult()
+         ├─ All tools answered? → Re-invoke LLM → loop
+         └─ More tools pending → wait
+```
+
+### Quartz Scheduler
+
+| File | Purpose |
+|---|---|
+| `src/prerna/reactor/scheduler/ScheduleJobReactor.java` | Creates Quartz cron jobs that execute Pixel recipes |
+| `src/prerna/reactor/scheduler/ExecuteScheduledJobReactor.java` | Manually triggers a scheduled job |
+| `src/prerna/rpa/quartz/jobs/insight/RunPixelJobFromDB.java` | The Quartz `Job` class — makes an HTTP POST to the SEMOSS API to run the Pixel |
+| `src/prerna/reactor/scheduler/SchedulerDatabaseUtility.java` | DB operations for job storage, history, execution tracking |
+| `src/prerna/reactor/scheduler/SchedulerFactorySingleton.java` | Singleton Quartz scheduler instance |
+
+**How it works:** `ScheduleJobReactor` takes a `recipe` (Pixel expression), `cronExpression`, `jobGroup` (= project ID), and user credentials. It creates a Quartz `JobDetail` with a `CronTrigger`. When the trigger fires, `RunPixelJobFromDB` makes an HTTP POST to `/api/schedule/executePixel` with the stored Pixel recipe.
+
+### Pipeline / Interceptor System
+
+| File | Purpose |
+|---|---|
+| `src/prerna/engine/impl/pipeline/PipelineInvocationHandler.java` | Dynamic proxy that intercepts engine method calls, runs input/output pipeline stages |
+| `src/prerna/reactor/interceptor/PipelineReactorUtils.java` | Constants for pipeline data passing |
+| `src/prerna/reactor/interceptor/GenericGuardrailInputReactor.java` | Guardrail interceptor for input validation |
+
+### Control Flow
+
+| File | Purpose |
+|---|---|
+| `src/prerna/reactor/IfReactor.java` | `IF(condition, trueCase, falseCase)` — conditional branching in Pixel |
+
+### Project Management
+
+| File | Purpose |
+|---|---|
+| `src/prerna/project/api/IProject.java` | Interface: `PROJECT_TYPE` enum, `IMCP`, file paths |
+| `src/prerna/project/impl/Project.java` | Implementation |
+| `src/prerna/reactor/project/CreateProjectReactor.java` | Creates a new project with type, portal, git config |
+| `src/prerna/reactor/project/GetAppBlocksJsonReactor.java` | Reads `blocks.json` from project portal folder |
+| `src/prerna/reactor/project/SaveAppBlocksJsonReactor.java` | Writes `blocks.json` |
+
+---
+
+## Project Structure
+
+### Existing app structure (for reference)
+
+```
+{projectId}/
+  assets/
+    mcp/
+      py_mcp.json             ← MCP tool definitions (Python)
+      pixel_mcp.json          ← MCP tool definitions (Pixel)
+    py/
+      mcp_driver.py           ← Python tool implementations
+  portals/
+    blocks.json               ← UI blocks definition (BLOCKS-type projects)
+  version/
+```
+
+### Workflow project structure
+
+```
+{projectId}/                              ← PROJECT_TYPE.WORKFLOW
+  assets/
+    mcp/
+      py_mcp.json                         ← Tools this workflow exposes as an MCP server (optional)
+      pixel_mcp.json
+    py/
+      mcp_driver.py                       ← Python implementations for exposed tools
+    workflow/
+      workflow.json                       ← THE workflow definition (steps, edges, variables, trigger)
+      executions/
+        {executionId}.json                ← Per-run execution logs
+  portals/
+    ...                                   ← Canvas editor UI (react-flow based)
+```
+
+The workflow definition at `assets/workflow/workflow.json` is the single source of truth. The canvas UI reads and writes this file via the existing `GetAppAssetsReactor` / `SaveAppAssetsReactor` APIs — no new CRUD endpoints needed.
+
+---
+
+## Workflow Definition Schema
+
+```json
+{
+  "workflowId": "{{projectId}}",
+  "name": "Weekly Report Agent",
+  "version": 1,
+
+  "steps": [
+    {
+      "stepId": "step-1",
+      "type": "LLM_ASK",
+      "name": "Generate SQL query",
+      "description": "Asks GPT-4 to write a SQL query for last week's sales",
+      "position": { "x": 100, "y": 200 },
+      "config": {
+        "modelId": "gpt-4-engine-uuid",
+        "systemPrompt": "You are a SQL expert...",
+        "userPrompt": "Write a query to get last week's sales from {{variables.database}}"
+      },
+      "inputs": {},
+      "next": ["step-2"]
+    },
+    {
+      "stepId": "step-2",
+      "type": "RUN_TOOL",
+      "name": "Execute the query",
+      "position": { "x": 300, "y": 200 },
+      "config": {
+        "engineId": "db-engine-uuid",
+        "toolName": "run_query",
+        "params": {
+          "query": "{{step-1.output}}"
+        }
+      },
+      "next": ["step-3"]
+    },
+    {
+      "stepId": "step-3",
+      "type": "CONDITION",
+      "name": "Has results?",
+      "position": { "x": 500, "y": 200 },
+      "config": {
+        "expression": "{{step-2.rowCount}} > 0"
+      },
+      "ifTrue": ["step-4"],
+      "ifFalse": ["step-5"]
+    },
+    {
+      "stepId": "step-4",
+      "type": "LLM_ASK",
+      "name": "Summarize results",
+      "position": { "x": 700, "y": 100 },
+      "config": {
+        "modelId": "gpt-4-engine-uuid",
+        "userPrompt": "Summarize this data: {{step-2.output}}"
+      },
+      "next": ["step-6"]
+    },
+    {
+      "stepId": "step-5",
+      "type": "STATIC",
+      "name": "No data message",
+      "position": { "x": 700, "y": 300 },
+      "config": {
+        "value": "No sales data found for last week."
+      },
+      "next": ["step-6"]
+    },
+    {
+      "stepId": "step-6",
+      "type": "OUTPUT",
+      "name": "Send email",
+      "position": { "x": 900, "y": 200 },
+      "config": {
+        "action": "email",
+        "to": ["team@company.com"],
+        "subject": "Weekly Sales Report",
+        "body": "{{step-4.output || step-5.output}}"
+      }
+    }
+  ],
+
+  "variables": {
+    "database": {
+      "type": "string",
+      "default": "sales-db-engine-uuid",
+      "description": "The database engine to query"
+    }
+  },
+
+  "trigger": {
+    "type": "cron",
+    "expression": "0 0 9 ? * MON",
+    "timezone": "America/New_York"
+  },
+
+  "settings": {
+    "maxSteps": 50,
+    "timeoutMs": 300000,
+    "onError": "stop",
+    "retryPolicy": {
+      "maxRetries": 0,
+      "backoffMs": 1000
+    }
+  }
+}
+```
+
+### Field Reference
+
+| Field | Type | Description |
+|---|---|---|
+| `workflowId` | string | Matches the project ID |
+| `version` | number | Schema version for migration support |
+| `steps` | array | Ordered list of step definitions |
+| `steps[].stepId` | string | Unique identifier within the workflow |
+| `steps[].type` | enum | Step type (see [Step Types](#step-types)) |
+| `steps[].position` | object | Canvas coordinates — ignored by backend |
+| `steps[].config` | object | Type-specific configuration |
+| `steps[].next` | array | Step IDs to execute after this step completes |
+| `steps[].ifTrue` / `ifFalse` | array | Branch targets (CONDITION type only) |
+| `variables` | object | Workflow-level variables with types and defaults |
+| `trigger` | object | How/when the workflow is invoked |
+| `settings` | object | Execution limits and error handling |
+
+### Template Syntax
+
+Step configs support `{{...}}` template expressions:
+- `{{variables.name}}` — workflow variable
+- `{{step-1.output}}` — full output of a prior step
+- `{{step-1.output.fieldName}}` — nested field access
+- `{{step-1.rowCount}}` — metadata from a prior step result
+
+---
+
+## Step Types
+
+These are the node types available in the canvas palette:
+
+| Type | Description | Backend Handler | Backed By |
+|---|---|---|---|
+| `LLM_ASK` | Send a prompt to a model, get text back | `LLMAskStepHandler` | `Room.ask()` / `AskPlaygroundReactor` logic |
+| `LLM_AGENT` | Full agent loop — LLM + auto tool execution until text response | `LLMAgentStepHandler` | `Room.ask()` + `IMCP.callTool()` + `Room.addToolExecutionResult()` in a loop |
+| `RUN_TOOL` | Execute a single MCP tool directly | `RunToolStepHandler` | `MCPFactory.build(engine).callTool()` |
+| `RUN_PIXEL` | Run an arbitrary Pixel expression | `RunPixelStepHandler` | `PixelRunner` |
+| `RUN_PYTHON` | Run a Python script | `RunPythonStepHandler` | `PyTranslator` |
+| `QUERY_DB` | Query a database engine | `QueryDbStepHandler` | Existing database reactors |
+| `CONDITION` | Branch based on an expression (if/else) | `ConditionStepHandler` | Expression evaluation (mirrors `IfReactor`) |
+| `LOOP` | Iterate over a list, run sub-steps per item | `LoopStepHandler` | New — iterates with context injection |
+| `TRANSFORM` | Map/filter/reshape data between steps | `TransformStepHandler` | JSON path / expression-based |
+| `STATIC` | Return a static value | `StaticStepHandler` | Direct value pass-through |
+| `HUMAN_INPUT` | Pause and wait for user input (non-auto workflows) | `HumanInputStepHandler` | New — suspends execution |
+| `GUARDRAIL` | Run a guardrail check on flowing data | `GuardrailStepHandler` | `GenericGuardrailInputReactor` |
+| `OUTPUT` | Terminal node — email, store, webhook, return | `OutputStepHandler` | Existing email / HTTP reactors |
+
+### Step Type: `LLM_ASK`
+
+Sends a single prompt to a model and returns the text response. Does NOT handle tool calls — if the model returns a tool_call, it's passed through as output (use `LLM_AGENT` for auto tool handling).
+
+```json
+{
+  "type": "LLM_ASK",
+  "config": {
+    "modelId": "engine-uuid",
+    "roomId": "optional-room-uuid",
+    "systemPrompt": "You are a helpful assistant.",
+    "userPrompt": "Summarize: {{step-1.output}}",
+    "paramMap": {
+      "temperature": 0.7,
+      "max_tokens": 2000
+    }
+  }
+}
+```
+
+### Step Type: `LLM_AGENT`
+
+Full agentic loop. Sends a prompt to a model with MCP tools attached. If the model requests tool calls, executes them automatically and feeds results back until the model returns a text response or `maxIterations` is reached.
+
+```json
+{
+  "type": "LLM_AGENT",
+  "config": {
+    "modelId": "engine-uuid",
+    "roomId": "optional-room-uuid",
+    "systemPrompt": "You are a data analyst with access to databases.",
+    "userPrompt": "Find last week's top customers.",
+    "toolEngineIds": ["db-engine-uuid", "api-engine-uuid"],
+    "maxIterations": 10,
+    "mcpExecution": "auto"
+  }
+}
+```
+
+### Step Type: `RUN_TOOL`
+
+Directly executes a single MCP tool without involving an LLM.
+
+```json
+{
+  "type": "RUN_TOOL",
+  "config": {
+    "engineId": "engine-uuid",
+    "toolName": "run_query",
+    "params": {
+      "query": "SELECT * FROM sales WHERE date > '2026-02-09'"
+    }
+  }
+}
+```
+
+### Step Type: `CONDITION`
+
+Evaluates an expression and routes to different branches.
+
+```json
+{
+  "type": "CONDITION",
+  "config": {
+    "expression": "{{step-2.rowCount}} > 0"
+  },
+  "ifTrue": ["step-4"],
+  "ifFalse": ["step-5"]
+}
+```
+
+### Step Type: `OUTPUT`
+
+Terminal step that routes the final result to an external destination.
+
+```json
+{
+  "type": "OUTPUT",
+  "config": {
+    "action": "email",
+    "to": ["user@example.com"],
+    "subject": "Report: {{variables.reportName}}",
+    "body": "{{step-4.output}}"
+  }
+}
+```
+
+Supported actions: `email`, `webhook`, `store_db`, `write_file`, `return` (default — just returns the value).
+
+---
+
+## Backend Architecture
+
+### Core Classes
+
+```
+src/prerna/
+├── project/api/
+│   └── IProject.java                          ← Add WORKFLOW to PROJECT_TYPE enum
+│
+├── workflow/
+│   ├── WorkflowDefinition.java                ← POJO: parsed workflow.json
+│   ├── WorkflowStep.java                      ← POJO: single step definition
+│   ├── WorkflowContext.java                    ← Runtime state: variable values, step results
+│   ├── WorkflowExecutionResult.java            ← Final result: status, outputs, logs
+│   ├── WorkflowExecutor.java                   ← Core engine: walks DAG, dispatches steps
+│   ├── WorkflowTemplateEngine.java             ← Resolves {{...}} expressions
+│   │
+│   └── handlers/                               ← One handler per step type
+│       ├── IWorkflowStepHandler.java           ← Interface
+│       ├── LLMAskStepHandler.java
+│       ├── LLMAgentStepHandler.java
+│       ├── RunToolStepHandler.java
+│       ├── RunPixelStepHandler.java
+│       ├── ConditionStepHandler.java
+│       ├── LoopStepHandler.java
+│       ├── TransformStepHandler.java
+│       ├── StaticStepHandler.java
+│       ├── OutputStepHandler.java
+│       └── GuardrailStepHandler.java
+│
+├── reactor/workflow/
+│   └── RunWorkflowReactor.java                 ← Pixel: RunWorkflow(project=["uuid"])
+```
+
+### WorkflowExecutor Flow
+
+```
+RunWorkflowReactor.execute()
+  │
+  ├─ Load IProject (security check)
+  ├─ Read assets/workflow/workflow.json
+  ├─ Parse → WorkflowDefinition
+  ├─ Merge variable overrides
+  │
+  ├─ Create WorkflowContext (variables, step results map)
+  │
+  ├─ Find entry steps (no incoming edges)
+  ├─ For each step in execution order:
+  │    ├─ Resolve {{...}} templates in step config
+  │    ├─ Lookup handler by step.type
+  │    ├─ handler.execute(config, context, insight)
+  │    ├─ Store StepResult in context
+  │    ├─ If CONDITION → follow ifTrue or ifFalse branch
+  │    ├─ If LOOP → iterate, execute sub-steps per item
+  │    ├─ Check maxSteps / timeout
+  │    └─ On error → stop or skip based on settings.onError
+  │
+  ├─ Save execution log to assets/workflow/executions/
+  └─ Return WorkflowExecutionResult
+```
+
+### IWorkflowStepHandler Interface
+
+```java
+public interface IWorkflowStepHandler {
+
+    /**
+     * Execute a single workflow step.
+     *
+     * @param stepId   The unique step identifier
+     * @param config   The step's config object (type-specific)
+     * @param context  The workflow runtime context (variables, prior results)
+     * @param insight  The SEMOSS insight for the execution
+     * @return The result of this step
+     */
+    StepResult execute(String stepId, Map<String, Object> config,
+                       WorkflowContext context, Insight insight);
+}
+```
+
+### StepResult
+
+```java
+public class StepResult {
+    private String stepId;
+    private String status;          // "success", "error", "skipped"
+    private Object output;          // The primary output value
+    private Map<String, Object> metadata;  // rowCount, duration, etc.
+    private String error;           // Error message if failed
+    private long durationMs;
+}
+```
+
+---
+
+## Frontend Architecture
+
+### Views
+
+| View | Description |
+|---|---|
+| **Workflow List** | Filtered project list (`projectType = WORKFLOW`). Shows name, last run status, schedule, actions (edit/run/delete). |
+| **Canvas Editor** | React-flow based DAG editor. Reads/writes `workflow.json` via asset APIs. |
+| **Run History** | Table of past executions with status, duration, trigger type. Click to see step-level details. |
+| **Run Detail** | Step-by-step execution view — each node colored by status, click to see input/output. |
+
+### Canvas Editor Components
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  [Save] [Run Now] [Schedule]              Workflow Settings ▼│
+├──────────┬───────────────────────────────────┬───────────────┤
+│          │                                   │               │
+│  Step    │         Canvas Area               │   Config      │
+│  Palette │                                   │   Panel       │
+│          │    ┌─────┐    ┌─────┐    ┌─────┐  │               │
+│  LLM Ask │    │Step1├───►│Step2├───►│Step3│  │  Model: ▼     │
+│  Agent   │    └─────┘    └─────┘    └──┬──┘  │  Prompt: ___  │
+│  Tool    │                          ┌──┴──┐  │  Temp:  0.7   │
+│  Pixel   │                     ┌────┤ If  │  │               │
+│  Python  │                     │    └──┬──┘  │               │
+│  Branch  │                ┌────▼┐  ┌───▼──┐  │               │
+│  Loop    │                │Yes  │  │ No   │  │               │
+│  Output  │                └─────┘  └──────┘  │               │
+│          │                                   │               │
+├──────────┴───────────────────────────────────┴───────────────┤
+│  Variables: database = [sales-db ▼]   reportName = [______]  │
+├──────────────────────────────────────────────────────────────┤
+│  Run History   │ #1 ✅ 2m3s  │ #2 ❌ 45s  │ #3 ✅ 1m52s    │
+└──────────────────────────────────────────────────────────────┘
+```
+
+### API Calls (All Existing)
+
+| Action | API | Notes |
+|---|---|---|
+| Create workflow | `CreateProject(type=["WORKFLOW"])` | Existing reactor |
+| Load workflow.json | `GetAppAssets` or direct file read | Existing reactor |
+| Save workflow.json | `SaveAppAssets` | Existing reactor |
+| Run workflow | `RunWorkflow(project=["uuid"])` | New reactor |
+| Schedule workflow | `ScheduleJob(recipe=["RunWorkflow(...)"], ...)` | Existing reactor |
+| List workflows | `MyProjects` with type filter | Existing reactor |
+| Share | `GrantProjectPermission` / `SetProjectGlobal` | Existing reactors |
+
+---
+
+## Workflow Composability
+
+Since `IProject extends IMCP`, a workflow project can expose the **entire workflow as an MCP tool**. This enables:
+
+### Workflow-as-a-Tool
+
+A workflow project's `py_mcp.json` can define:
+
+```json
+{
+  "tools": [{
+    "name": "run_weekly_report",
+    "description": "Runs the weekly sales report workflow and returns the summary",
+    "inputSchema": {
+      "type": "object",
+      "properties": {
+        "database": {
+          "type": "string",
+          "description": "The database engine ID to query"
+        }
+      },
+      "required": ["database"]
+    },
+    "_meta": {
+      "SMSS_FUNCTION_NAME": "run_weekly_report",
+      "SMSS_MCP_EXECUTION": "auto"
+    }
+  }]
+}
+```
+
+The implementation (in `mcp_driver.py` or as a Pixel tool) simply calls:
+```
+RunWorkflow(project=["this-project-uuid"], variables=[{"database": inputDatabase}]);
+```
+
+### Nesting
+
+This means:
+- **Workflow A** can have an `LLM_AGENT` step with Workflow B's project armed as a tool engine
+- The LLM in Workflow A can decide to call Workflow B as a tool
+- Workflow B executes its full step graph and returns the result
+- Workflow A continues with the result
+
+This provides **hierarchical composition** — complex workflows built from simpler, reusable sub-workflows.
+
+---
+
+## Security & Access Control
+
+All handled by existing project security — no new code needed:
+
+| Operation | Permission Required | Check |
+|---|---|---|
+| View workflow | Project viewer | `SecurityProjectUtils.userCanViewProject()` |
+| Edit workflow (canvas) | Project editor | `SecurityProjectUtils.userCanEditProject()` |
+| Run workflow | Project viewer | `SecurityProjectUtils.userCanViewProject()` |
+| Schedule workflow | Project editor + admin OR project editor | `SecurityAdminUtils.userIsAdmin()` or `SecurityProjectUtils.userCanEditProject()` |
+| Delete workflow | Project owner | Project ownership check |
+| Share workflow | Project owner | Project ownership check |
+
+**Cross-engine access:** When a workflow step accesses another engine (e.g., `RUN_TOOL` against a database engine), the executing user must also have access to that engine. This is already enforced by `checkEngineEditSecurity()` / `SecurityEngineUtils.userCanViewEngine()` in the existing reactors.
+
+---
+
+## Scheduling & Triggers
+
+### Cron Schedule
+
+Uses the existing Quartz scheduler. The scheduled Pixel recipe is simply:
+
+```
+RunWorkflow(project=["workflow-project-uuid"]);
+```
+
+Configured via `ScheduleJobReactor` with `jobGroup = projectId`. All existing scheduling features apply:
+- Cron expression + timezone
+- Trigger on load
+- Pause / resume
+- Execution history
+
+### Webhook Trigger (Future)
+
+A new REST endpoint:
+
+```
+POST /api/workflow/trigger/{projectId}
+Body: { "variables": { "database": "other-db-uuid" } }
+```
+
+- Validates user access
+- Calls `RunWorkflowReactor` with the provided variable overrides
+- Returns the execution result (sync) or execution ID (async)
+
+### Event Triggers (Future)
+
+Hook into SEMOSS internal events:
+- Database row insert → trigger workflow
+- File upload to project → trigger workflow
+- Another scheduled job completing → chain to workflow
+- Implemented via Quartz `JobListener` or internal pub/sub
+
+---
+
+## Execution Logging
+
+Each workflow run produces an execution log saved to `assets/workflow/executions/`:
+
+```json
+{
+  "executionId": "uuid",
+  "workflowId": "project-uuid",
+  "startTime": "2026-02-16T09:00:00Z",
+  "endTime": "2026-02-16T09:02:03Z",
+  "status": "success",
+  "triggeredBy": "cron",
+  "userId": "user-id",
+  "variables": { "database": "sales-db-uuid" },
+  "steps": [
+    {
+      "stepId": "step-1",
+      "name": "Generate SQL query",
+      "type": "LLM_ASK",
+      "status": "success",
+      "startTime": "2026-02-16T09:00:00Z",
+      "endTime": "2026-02-16T09:00:12Z",
+      "durationMs": 12000,
+      "output": "SELECT customer_name, SUM(amount) ..."
+    },
+    {
+      "stepId": "step-2",
+      "name": "Execute the query",
+      "type": "RUN_TOOL",
+      "status": "success",
+      "durationMs": 3400,
+      "output": { "rows": [...], "rowCount": 42 }
+    }
+  ]
+}
+```
+
+The execution log is stored as a file in the project's assets folder, meaning:
+- It's included in project exports
+- It's versioned if the project uses git
+- Access is controlled by project permissions
+- It can be queried via asset browsing APIs

--- a/docs/workflow-engine/FE_IMPLEMENTATION_GUIDE.md
+++ b/docs/workflow-engine/FE_IMPLEMENTATION_GUIDE.md
@@ -1,0 +1,904 @@
+# Workflow Engine — Frontend Implementation Guide
+
+> This document describes the backend API surface, data contracts, and implementation guidance for building the workflow canvas editor UI.
+
+---
+
+## Table of Contents
+
+1. [Architecture Overview](#architecture-overview)
+2. [Pixel API Reference](#pixel-api-reference)
+3. [Data Schema — workflow.json](#data-schema--workflowjson)
+4. [Step Types & Config Schemas](#step-types--config-schemas)
+5. [Template Expressions](#template-expressions)
+6. [UI Components](#ui-components)
+7. [User Flows](#user-flows)
+8. [Important Implementation Notes](#important-implementation-notes)
+
+---
+
+## Architecture Overview
+
+Workflows are stored as **SEMOSS projects** with `projectType = "WORKFLOW"`. Each workflow project contains a single `workflow.json` file at `assets/workflow/workflow.json` that describes the full DAG.
+
+**The FE owns all mutation logic.** The backend is a dumb document store + executor. There are no incremental `AddStep`/`DeleteStep` APIs. The FE loads the full JSON, edits it in-memory, and saves the entire document on every save.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                     Frontend Canvas                          │
+│                                                              │
+│  Load workflow ──► Edit in memory ──► Save full JSON         │
+│       ▲                                    │                 │
+│       │              GetWorkflowStatus     │  SaveWorkflow   │
+│       └────────────────────────────────────┘                 │
+│                                                              │
+│  Run workflow ──► Poll/display result                        │
+│       │              RunWorkflow                             │
+└───────┼──────────────────────────────────────────────────────┘
+        ▼
+┌──────────────────────────────────────────────────────────────┐
+│                     Backend Engine                            │
+│                                                              │
+│  WorkflowExecutor: parse JSON → validate DAG → walk steps    │
+│  Handlers: LLM_ASK, LLM_AGENT, RUN_TOOL, RUN_PIXEL, etc.   │
+│  Logging: saves execution results to executions/ folder      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Pixel API Reference
+
+### 1. Create a Workflow Project
+
+```
+CreateProject(project=["My Workflow Name"], type=["WORKFLOW"]);
+```
+
+**Returns:** Map with `project_id`, `project_name`, `project_type`
+
+**What it does:** Creates a new SEMOSS project with type `WORKFLOW`, scaffolds `assets/workflow/workflow.json` with an empty default definition, creates `assets/workflow/executions/` directory, and initializes git.
+
+---
+
+### 2. Get Workflow Status (Load)
+
+```
+GetWorkflowStatus(project=["<project-uuid>"]);
+```
+
+**Returns:**
+```json
+{
+  "projectId": "abc-123",
+  "projectName": "My Workflow",
+  "projectType": "WORKFLOW",
+  "workflow": {
+    "workflowId": "abc-123",
+    "name": "My Workflow",
+    "version": 1,
+    "steps": [ ... ],
+    "variables": { ... },
+    "settings": { ... }
+  },
+  "executions": [
+    {
+      "executionId": "exec-uuid-1",
+      "status": "SUCCESS",
+      "durationMs": 4523,
+      "triggeredBy": "manual",
+      "startTimeMs": 1708000000000,
+      "endTimeMs": 1708000004523
+    },
+    {
+      "executionId": "exec-uuid-2",
+      "status": "ERROR",
+      "durationMs": 1200,
+      "triggeredBy": "schedule",
+      "startTimeMs": 1707990000000,
+      "endTimeMs": 1707990001200,
+      "error": "Step 'step-3' failed: ..."
+    }
+  ]
+}
+```
+
+**Notes:**
+- `workflow` is `null` if workflow.json hasn't been saved yet (freshly created project)
+- `executions` is sorted newest-first, capped at 50 entries
+- Executions contain only summary fields (not full step-by-step results)
+- Requires `userCanViewProject` permission
+
+---
+
+### 3. Save Workflow (Persist)
+
+```
+SaveWorkflow(project=["<project-uuid>"], json=[<workflow-json-object>], comment=["optional commit message"]);
+```
+
+**Parameters:**
+| Key | Required | Type | Description |
+|-----|----------|------|-------------|
+| `project` | Yes | String | Project UUID |
+| `json` | Yes | Map/Object | The full `workflow.json` object |
+| `comment` | No | String | Git commit message (defaults to "Update workflow definition") |
+
+**Returns:** `true` on success
+
+**What it does:**
+1. Validates the user has `userCanEditProject` permission
+2. Validates the project is type `WORKFLOW`
+3. **Validates the workflow DAG** — rejects saves with:
+   - Dangling step references (next/ifTrue/ifFalse pointing to nonexistent stepIds)
+   - Orphaned steps (unreachable from any entry point)
+   - Cycles in the DAG
+   - Duplicate step IDs
+   - No entry points (every step has incoming edges — nothing can start)
+4. Writes `workflow.json`
+5. Git add + commit
+6. Syncs to cluster (if clustered)
+
+**Error responses:** If validation fails, the error message lists all issues:
+```
+"Workflow validation failed: Step 'step-2' references non-existent step 'deleted-step'; Steps [step-5] are orphaned (unreachable from any entry point)"
+```
+
+**Important:** Always send the ENTIRE workflow.json, not a partial update. The BE overwrites the whole file.
+
+---
+
+### 4. Run Workflow (Execute)
+
+```
+RunWorkflow(project=["<project-uuid>"], variables=[{"key": "value"}], trigger=["manual"]);
+```
+
+**Parameters:**
+| Key | Required | Type | Description |
+|-----|----------|------|-------------|
+| `project` | Yes | String | Project UUID |
+| `variables` | No | Map | Runtime variable overrides (merged with workflow-level defaults) |
+| `trigger` | No | String | Trigger source label: `"manual"`, `"schedule"`, `"webhook"`, `"api"` (defaults to `"manual"`) |
+
+**Returns:**
+```json
+{
+  "executionId": "exec-uuid",
+  "workflowId": "abc-123",
+  "status": "SUCCESS",
+  "durationMs": 4523,
+  "triggeredBy": "manual",
+  "finalOutput": "The workflow's last step output value",
+  "error": null
+}
+```
+
+**Status values:** `SUCCESS`, `ERROR`, `TIMEOUT`
+
+**Notes:**
+- Execution is **synchronous** — the call blocks until the workflow completes
+- For long-running workflows, consider running in a background thread and polling
+- The execution result is also automatically persisted to `executions/{executionId}.json` for history
+- Requires `userCanViewProject` permission
+
+---
+
+### 5. Schedule a Workflow
+
+```
+ScheduleJob(
+  jobName=["Weekly Report Generator"],
+  jobGroup=["<project-uuid>"],
+  cronExpression=["0 0 9 ? * MON"],
+  recipe=["RunWorkflow(project=[\"<project-uuid>\"], trigger=[\"schedule\"]);"],
+  uiState=["<serialized-ui-state>"]
+);
+```
+
+This uses the existing SEMOSS scheduler — no new APIs needed. The `recipe` is a Pixel string containing the `RunWorkflow` call.
+
+---
+
+### 6. List Workflow Projects
+
+Use the existing project listing APIs to get all projects, filter by `projectType === "WORKFLOW"` on the FE side. SEMOSS project list APIs already support type filtering.
+
+---
+
+## Data Schema — workflow.json
+
+This is the complete schema the FE must produce when saving:
+
+```jsonc
+{
+  // Unique identifier — typically matches the project ID
+  "workflowId": "abc-123-uuid",
+
+  // Human-readable name
+  "name": "Customer Onboarding Flow",
+
+  // Increment on each save (optional, FE-managed)
+  "version": 1,
+
+  // Workflow-level variables — defaults that can be overridden at runtime
+  "variables": {
+    "database": "db-engine-uuid",
+    "notifyEmail": "admin@example.com",
+    "threshold": 0.8
+  },
+
+  // Execution settings
+  "settings": {
+    "maxSteps": 50,        // Max step executions before abort (prevents infinite loops)
+    "timeoutMs": 300000,   // 5 minute timeout
+    "onError": "stop"      // "stop" = abort on first error, "skip" = skip failed step's successors
+  },
+
+  // The DAG — array of step nodes
+  "steps": [
+    {
+      "stepId": "step-1",              // Unique ID — generate UUID on FE
+      "type": "LLM_ASK",              // Step type — must match STEP_TYPE enum
+      "name": "Summarize Data",        // Display label on canvas
+      "description": "optional desc",  // Tooltip/detail text
+
+      // Canvas position — used only by FE, ignored by BE
+      "position": { "x": 100, "y": 200 },
+
+      // Type-specific configuration (see Step Types section below)
+      "config": {
+        "modelId": "model-engine-uuid",
+        "systemPrompt": "You are a data analyst.",
+        "userPrompt": "Summarize: {{step-0.output}}"
+      },
+
+      // Input mappings — template expressions resolved before execution
+      "inputs": {
+        "data": "{{step-0.output}}",
+        "format": "{{variables.outputFormat}}"
+      },
+
+      // Edges — default successors
+      "next": ["step-2"],
+
+      // Conditional edges — only used by CONDITION type
+      "ifTrue": null,
+      "ifFalse": null
+    }
+  ]
+}
+```
+
+### Key Rules
+
+1. **`stepId`** must be unique across all steps. Use UUIDs (e.g., `crypto.randomUUID()`).
+2. **`type`** must be one of the valid `STEP_TYPE` values (see below).
+3. **`next`**, **`ifTrue`**, **`ifFalse`** are arrays of `stepId` strings referencing other steps.
+4. **Entry steps** are steps with no incoming edges (no other step points to them via next/ifTrue/ifFalse). These execute first.
+5. **`position`** is entirely FE-owned. The BE ignores it.
+6. **`config`** schema varies by step type (documented below).
+7. **`inputs`** are key-value pairs where values are `{{template}}` expressions.
+
+---
+
+## Step Types & Config Schemas
+
+### `STATIC` — Static Value
+
+Outputs a fixed value. Useful for constants and test data.
+
+```json
+{
+  "type": "STATIC",
+  "config": {
+    "value": "any value — string, number, object, array"
+  }
+}
+```
+
+**Output:** Whatever `value` is.
+
+---
+
+### `LLM_ASK` — Single LLM Call
+
+Sends a prompt to an LLM and returns the text response.
+
+```json
+{
+  "type": "LLM_ASK",
+  "config": {
+    "modelId": "<model-engine-uuid>",       // Required — LLM engine ID
+    "systemPrompt": "You are a...",         // Optional — system message
+    "userPrompt": "Analyze this: {{step-1.output}}",  // Required — user message
+    "paramMap": {                           // Optional — model parameters
+      "temperature": 0.7,
+      "max_tokens": 2000
+    }
+  }
+}
+```
+
+**Output:** String — the LLM's text response.
+
+**FE config form should provide:**
+- Model engine dropdown (fetch available models from existing SEMOSS APIs)
+- System prompt textarea
+- User prompt textarea (with `{{...}}` autocomplete)
+- Optional: temperature slider, max_tokens input
+
+---
+
+### `LLM_AGENT` — Agentic LLM with Tool Use
+
+Sends a prompt to an LLM with access to MCP tools. The agent loops: LLM → tool call → feed result back → repeat until the LLM gives a final text answer.
+
+```json
+{
+  "type": "LLM_AGENT",
+  "config": {
+    "modelId": "<model-engine-uuid>",       // Required — LLM engine ID
+    "systemPrompt": "You are a...",         // Optional
+    "userPrompt": "Find and summarize...",  // Required
+    "toolEngineIds": [                      // Required — list of MCP engine IDs to give the agent
+      "mcp-engine-uuid-1",
+      "mcp-engine-uuid-2"
+    ],
+    "paramMap": { "temperature": 0 },       // Optional
+    "maxIterations": 10                     // Optional — max tool-use loops (default: 10)
+  }
+}
+```
+
+**Output:** String — the LLM's final text response after all tool calls are resolved.
+
+**FE config form should provide:**
+- Model engine dropdown
+- System/user prompt textareas
+- Multi-select for tool engine IDs (fetch from `GetAllEngines` or similar)
+- Max iterations slider (1–20, default 10)
+
+---
+
+### `RUN_TOOL` — Direct MCP Tool Call
+
+Calls a specific MCP tool directly (no LLM involved).
+
+```json
+{
+  "type": "RUN_TOOL",
+  "config": {
+    "engineId": "<mcp-engine-uuid>",    // Required
+    "toolName": "search_database",      // Required — tool method name
+    "params": {                         // Required — tool input parameters
+      "query": "{{step-1.output}}",
+      "limit": 10
+    }
+  }
+}
+```
+
+**Output:** Whatever the tool returns (typically a Map or String).
+
+**FE config form should provide:**
+- Engine dropdown → on select, fetch available tools (use `GetMCPTools(engine=["<id>"])` or similar)
+- Tool dropdown → on select, show auto-generated param form from the tool's `inputSchema`
+- Param inputs with `{{...}}` autocomplete support
+
+---
+
+### `RUN_PIXEL` — Execute Pixel Recipe
+
+Runs an arbitrary Pixel expression.
+
+```json
+{
+  "type": "RUN_PIXEL",
+  "config": {
+    "recipe": "Database(\"<db-id>\") | Select(columns) | Collect(500);"
+  }
+}
+```
+
+**Output:** The value of the last NounMetadata from the Pixel execution (can be a frame, map, list, string, etc.).
+
+**FE config form:** Pixel expression code editor (monospace textarea with syntax highlighting if possible).
+
+---
+
+### `CONDITION` — Conditional Branch
+
+Evaluates a boolean expression and routes to `ifTrue` or `ifFalse` edges.
+
+```json
+{
+  "type": "CONDITION",
+  "config": {
+    "left": "{{step-1.output}}",       // Left operand (supports template resolution)
+    "operator": ">",                    // Comparison operator
+    "right": 100                        // Right operand
+  }
+}
+```
+
+**Supported operators:** `==`, `!=`, `>`, `<`, `>=`, `<=`, `contains`, `empty`, `notEmpty`
+
+**Edge wiring:** CONDITION steps use `ifTrue` and `ifFalse` instead of `next`:
+```json
+{
+  "stepId": "check-threshold",
+  "type": "CONDITION",
+  "config": { "left": "{{score.output}}", "operator": ">=", "right": 0.8 },
+  "ifTrue": ["approve-step"],
+  "ifFalse": ["reject-step"],
+  "next": null
+}
+```
+
+**Output:** Boolean (true/false). The routing is automatic based on which branch is taken.
+
+**FE canvas rendering:**
+- Render CONDITION nodes with a diamond shape (decision node)
+- Two outgoing edges: green for `ifTrue`, red for `ifFalse`
+- Edge labels: "True" / "False"
+
+**FE config form:**
+- Left value input (with `{{...}}` autocomplete)
+- Operator dropdown
+- Right value input (with `{{...}}` autocomplete)
+
+---
+
+### `OUTPUT` — Terminal Output
+
+Marks a terminal step. Simply passes through its input as the final workflow output.
+
+```json
+{
+  "type": "OUTPUT",
+  "config": {
+    "value": "{{step-5.output}}"
+  }
+}
+```
+
+**Output:** Whatever `value` resolves to.
+
+**Note:** The workflow's `finalOutput` in the execution result is the output of the last successfully executed step, regardless of whether it's an OUTPUT step. But using OUTPUT makes the intent explicit.
+
+---
+
+### `RUN_PYTHON` — (Not yet implemented)
+
+Placeholder for future Python script execution.
+
+### `LOOP` — (Not yet implemented)
+
+Placeholder for future loop/iteration support.
+
+### `TRANSFORM` — (Not yet implemented)
+
+Placeholder for future data transformation support.
+
+### `HUMAN_INPUT` — (Not yet implemented)
+
+Placeholder for future human-in-the-loop support (workflow pauses and waits for user input).
+
+### `GUARDRAIL` — (Not yet implemented)
+
+Placeholder for future guardrail/safety-check support.
+
+---
+
+## Template Expressions
+
+The backend resolves `{{...}}` expressions in step `config` and `inputs` before executing each step. The FE is responsible for baking the correct expressions into the JSON at design time.
+
+### Syntax
+
+| Expression | Resolves To |
+|---|---|
+| `{{stepId.output}}` | The output of a previously executed step |
+| `{{stepId.output.fieldName}}` | A nested field from a step's output (if output is a Map) |
+| `{{stepId.output.field.nested}}` | Deep nested field access |
+| `{{stepId.metadata.key}}` | Step metadata (e.g., `{{check.metadata.branch}}` → `"ifTrue"`) |
+
+### Type Preservation
+
+- If the entire string is a single `{{expression}}`, the resolved value preserves its original type (Map, List, Number, etc.)
+- If `{{expression}}` is embedded in a larger string like `"Hello {{name.output}}"`, it's string-interpolated
+
+### Autocomplete UX
+
+The FE should provide `{{...}}` autocomplete in text inputs:
+
+1. When the user types `{{`, show a dropdown of:
+   - All step IDs that appear **before** the current step in the DAG (i.e., steps that could have executed already)
+   - Each step shows: `stepId` → `stepName` (`stepType`)
+2. After selecting a step, auto-insert `.output` (most common)
+3. Optionally show `.metadata` for advanced users
+
+---
+
+## UI Components
+
+### 1. Workflow List View
+
+A shared view (not per-project) that shows all WORKFLOW projects the user has access to.
+
+| Column | Source |
+|---|---|
+| Name | `projectName` |
+| Last Run Status | `executions[0].status` (from `GetWorkflowStatus`) |
+| Last Run Time | `executions[0].startTimeMs` |
+| Triggered By | `executions[0].triggeredBy` |
+| Actions | Edit, Run, Schedule, Share, Delete |
+
+**Actions:**
+- **Create Workflow** → `CreateProject(project=["name"], type=["WORKFLOW"])` → navigate to canvas
+- **Edit** → Navigate to canvas editor for this project
+- **Run** → `RunWorkflow(project=["uuid"])` → show result toast
+- **Delete** → Use existing `DeleteProject` Pixel
+- **Share** → Use existing project sharing (permissions are the same as any SEMOSS project)
+
+---
+
+### 2. Canvas Editor (Main View)
+
+**Layout:**
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Toolbar: [Save] [Run] [Schedule] [Undo] [Redo]  [Zoom +/-]   │
+├──────────┬──────────────────────────────────────┬───────────────┤
+│          │                                      │               │
+│  Step    │                                      │  Config       │
+│  Palette │        Canvas (react-flow)           │  Panel        │
+│          │                                      │               │
+│  ────    │     ┌────┐    ┌────┐    ┌────┐      │  (shows when  │
+│  LLM_ASK │     │ A  │───►│ B  │───►│ C  │      │   a node is   │
+│  RUN_TOOL│     └────┘    └────┘    └────┘      │   selected)   │
+│  COND.   │                                      │               │
+│  ...     │                                      │               │
+│          │                                      │               │
+├──────────┴──────────────────────────────────────┴───────────────┤
+│  Execution History (collapsible drawer)                         │
+│  exec-1 | SUCCESS | 4.5s | manual | Feb 17 09:30              │
+│  exec-2 | ERROR   | 1.2s | schedule | Feb 16 09:00            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### 3. Step Palette (Left Sidebar)
+
+Draggable step types grouped by category:
+
+| Category | Step Types |
+|---|---|
+| **AI** | `LLM_ASK`, `LLM_AGENT` |
+| **Data** | `RUN_TOOL`, `RUN_PIXEL` |
+| **Logic** | `CONDITION` |
+| **I/O** | `STATIC`, `OUTPUT` |
+| **Future** | `LOOP`, `TRANSFORM`, `HUMAN_INPUT`, `GUARDRAIL`, `RUN_PYTHON` (show as disabled/coming-soon) |
+
+**Drag-to-create:**
+1. User drags a step type from the palette onto the canvas
+2. FE creates a new step object with:
+   - `stepId`: `crypto.randomUUID()`
+   - `type`: the dragged type
+   - `name`: default name like "LLM Ask 1" (auto-increment)
+   - `position`: drop coordinates
+   - `config`: empty `{}`
+   - `next`, `ifTrue`, `ifFalse`: `null`
+3. Step appears as an unconnected node on the canvas
+
+---
+
+### 4. Config Panel (Right Sidebar)
+
+Shows when a node is selected. The form fields depend on the step's `type`:
+
+- See [Step Types & Config Schemas](#step-types--config-schemas) for what fields each type needs
+- All text fields should support `{{...}}` autocomplete
+- Model/engine dropdowns should fetch options from existing SEMOSS engine listing APIs
+- Tool dropdowns should fetch available tools when an engine is selected
+
+**Common fields (all step types):**
+- Name (text input)
+- Description (optional textarea)
+
+---
+
+### 5. Variables Panel
+
+A top bar or collapsible section for workflow-level variables:
+
+| Field | Description |
+|---|---|
+| Name | Variable key (used in templates as `{{variables.name}}` — but note: variables are merged into context, template syntax is `{{stepId.output}}` for step outputs) |
+| Default Value | Value used if no runtime override is provided |
+| Description | Optional documentation |
+
+---
+
+### 6. Execution History Drawer
+
+Bottom drawer or tab. Populated from `GetWorkflowStatus` response's `executions` array.
+
+| Column | Field |
+|---|---|
+| Status | `status` — render as badge (green=SUCCESS, red=ERROR, yellow=TIMEOUT) |
+| Duration | `durationMs` — format as "4.5s" or "2m 30s" |
+| Triggered By | `triggeredBy` |
+| Time | `startTimeMs` — format as relative or absolute time |
+| Error | `error` — show in tooltip or expandable row |
+
+---
+
+## User Flows
+
+### Flow 1: Create and Build a Workflow
+
+```
+1. User clicks "Create Workflow"
+2. FE calls: CreateProject(project=["My Workflow"], type=["WORKFLOW"]);
+3. FE receives project_id, navigates to canvas editor
+4. FE calls: GetWorkflowStatus(project=["<id>"]);
+5. FE receives empty workflow (default scaffold)
+6. User drags steps onto canvas, connects edges, configures each step
+7. User clicks "Save"
+8. FE assembles full workflow.json from canvas state
+9. FE calls: SaveWorkflow(project=["<id>"], json=[<workflow-object>]);
+10. If validation fails → show error toast with details
+11. If success → show success toast, update local state
+```
+
+### Flow 2: Edit an Existing Workflow
+
+```
+1. User clicks "Edit" on a workflow in the list
+2. FE calls: GetWorkflowStatus(project=["<id>"]);
+3. FE parses workflow.json → renders steps as nodes, edges from next/ifTrue/ifFalse
+4. User makes changes (add/delete/move steps, rewire edges, edit configs)
+5. User clicks "Save"
+6. FE rebuilds full workflow.json from canvas state
+7. FE calls: SaveWorkflow(project=["<id>"], json=[<workflow-object>]);
+```
+
+### Flow 3: Run a Workflow
+
+```
+1. User clicks "Run" (from list or canvas toolbar)
+2. FE calls: RunWorkflow(project=["<id>"], variables=[{...}]);
+3. FE shows loading state
+4. FE receives result: { executionId, status, durationMs, finalOutput, error }
+5. FE shows result toast/modal:
+   - SUCCESS: green, show finalOutput
+   - ERROR: red, show error message
+   - TIMEOUT: yellow, show timeout info
+6. FE refreshes execution history
+```
+
+### Flow 4: Delete a Step
+
+```
+1. User selects a step node on canvas, presses Delete
+2. FE removes the step from the in-memory steps array
+3. FE scans ALL other steps and removes any references to the deleted stepId:
+   - Remove from other steps' `next` arrays
+   - Remove from other steps' `ifTrue` arrays
+   - Remove from other steps' `ifFalse` arrays
+4. FE optionally auto-rewires: if A→B→C and B is deleted, wire A→C
+5. Canvas re-renders
+6. Changes are NOT persisted until user clicks "Save"
+```
+
+### Flow 5: Insert a Step Between Two Steps
+
+```
+1. User drags a new step type from palette onto an existing edge (A→C)
+2. FE creates new step B with a UUID
+3. FE rewires: A.next = ["B"], B.next = ["C"]  (was: A.next = ["C"])
+4. Canvas re-renders showing A→B→C
+5. User clicks the new node to configure it
+6. User clicks "Save" to persist
+```
+
+### Flow 6: Schedule a Workflow
+
+```
+1. User clicks "Schedule" in toolbar
+2. FE shows a scheduling dialog:
+   - Cron expression builder (or presets: daily, weekly, monthly)
+   - Schedule name
+3. FE calls:
+   ScheduleJob(
+     jobName=["<name>"],
+     jobGroup=["<project-uuid>"],
+     cronExpression=["<cron>"],
+     recipe=["RunWorkflow(project=[\"<project-uuid>\"], trigger=[\"schedule\"]);"],
+     uiState=["<serialized-state>"]
+   );
+4. FE shows confirmation
+```
+
+---
+
+## Important Implementation Notes
+
+### 1. Whole-Document Save
+
+The FE must always send the **entire** `workflow.json` on save. There is no partial/delta update API. This is intentional — it keeps the architecture simple, enables easy undo/redo (just keep a stack of JSON snapshots), and makes git diffs meaningful.
+
+### 2. Backend Validates on Save
+
+The `SaveWorkflow` reactor validates the DAG before writing. If the FE sends invalid JSON (dangling references, cycles, orphans), the save is **rejected** with a descriptive error. The FE can optionally do client-side validation for faster feedback, but the BE is the authoritative check.
+
+### 3. FE Owns Step IDs
+
+The FE generates `stepId` values (use `crypto.randomUUID()`). The BE never generates or modifies step IDs. When deleting a step, the FE is responsible for cleaning up all references to that step's ID in other steps' `next`/`ifTrue`/`ifFalse` arrays.
+
+### 4. FE Owns Position
+
+The `position` field (`{ x, y }`) is purely for the canvas layout. The BE stores it but never reads it. The FE should set positions when creating or moving nodes.
+
+### 5. Undo / Redo
+
+Since the workflow is a single JSON document, undo/redo is trivially implemented by maintaining a local history stack of JSON snapshots. Push a snapshot before each mutation, pop on undo.
+
+### 6. Edge Rendering Rules
+
+- **Normal steps** (all except CONDITION): render edges from `next` array. Single outgoing edge per target.
+- **CONDITION steps**: render TWO sets of edges:
+  - `ifTrue` edges → green, labeled "True"
+  - `ifFalse` edges → red, labeled "False"
+  - `next` should be `null` for CONDITION steps
+- **Entry steps** (no incoming edges): render with a distinct style (e.g., rounded border, "START" label)
+- **OUTPUT steps**: render with a distinct style (e.g., double border, "END" label)
+
+### 7. Execution is Synchronous
+
+`RunWorkflow` blocks until the workflow completes. For workflows expected to run >30s, consider:
+- Running the Pixel call in a web worker or with a long timeout
+- Showing a spinner with elapsed time
+- In the future, we may add async execution with polling
+
+### 8. Template Expression Autocomplete
+
+When building the `{{...}}` autocomplete:
+- Only show steps that are **upstream** of the current step (i.e., that will have executed before the current step runs)
+- This requires traversing the DAG backwards from the current node
+- Show the step name and type as context in the dropdown
+
+### 9. Existing SEMOSS APIs You'll Need
+
+| Purpose | How to call |
+|---|---|
+| List all projects | Existing project listing APIs, filter by `project_type == "WORKFLOW"` |
+| Get model engines | Existing engine listing APIs, filter by model type |
+| Get MCP tool engines | Existing engine listing APIs, filter by function type |
+| Get tools for an engine | `GetMCPTools(engine=["<id>"])` or similar |
+| Delete a project | Existing `DeleteProject` Pixel |
+| Share a project | Existing project permission APIs |
+| Schedule a job | `ScheduleJob(...)` — see Flow 6 |
+| List scheduled jobs | `ListAllJobs(...)` or similar existing scheduler APIs |
+
+---
+
+## Example: Complete workflow.json
+
+```json
+{
+  "workflowId": "proj-abc-123",
+  "name": "Customer Sentiment Analysis",
+  "version": 3,
+  "variables": {
+    "databaseId": "db-engine-uuid",
+    "modelId": "gpt4-engine-uuid",
+    "threshold": 0.7
+  },
+  "settings": {
+    "maxSteps": 50,
+    "timeoutMs": 300000,
+    "onError": "stop"
+  },
+  "steps": [
+    {
+      "stepId": "fetch-reviews",
+      "type": "RUN_PIXEL",
+      "name": "Fetch Recent Reviews",
+      "description": "Load last 100 customer reviews from database",
+      "position": { "x": 100, "y": 300 },
+      "config": {
+        "recipe": "Database(\"{{variables.databaseId}}\") | Select(review_text, rating, date) | Sort(date, desc) | Collect(100);"
+      },
+      "inputs": {},
+      "next": ["analyze-sentiment"],
+      "ifTrue": null,
+      "ifFalse": null
+    },
+    {
+      "stepId": "analyze-sentiment",
+      "type": "LLM_ASK",
+      "name": "Analyze Sentiment",
+      "description": "Use LLM to classify sentiment of reviews",
+      "position": { "x": 400, "y": 300 },
+      "config": {
+        "modelId": "{{variables.modelId}}",
+        "systemPrompt": "You are a sentiment analysis expert. Classify each review as positive, negative, or neutral. Return a JSON array.",
+        "userPrompt": "Analyze the sentiment of these reviews:\n\n{{fetch-reviews.output}}"
+      },
+      "inputs": {},
+      "next": ["check-negative-ratio"],
+      "ifTrue": null,
+      "ifFalse": null
+    },
+    {
+      "stepId": "check-negative-ratio",
+      "type": "CONDITION",
+      "name": "High Negative Rate?",
+      "description": "Check if more than 30% of reviews are negative",
+      "position": { "x": 700, "y": 300 },
+      "config": {
+        "left": "{{analyze-sentiment.output}}",
+        "operator": "contains",
+        "right": "negative"
+      },
+      "inputs": {},
+      "next": null,
+      "ifTrue": ["alert-team"],
+      "ifFalse": ["generate-report"]
+    },
+    {
+      "stepId": "alert-team",
+      "type": "RUN_TOOL",
+      "name": "Send Alert",
+      "description": "Notify the team about high negative sentiment",
+      "position": { "x": 1000, "y": 150 },
+      "config": {
+        "engineId": "slack-mcp-engine-uuid",
+        "toolName": "send_message",
+        "params": {
+          "channel": "#customer-alerts",
+          "message": "⚠️ High negative sentiment detected in recent reviews."
+        }
+      },
+      "inputs": {},
+      "next": ["generate-report"],
+      "ifTrue": null,
+      "ifFalse": null
+    },
+    {
+      "stepId": "generate-report",
+      "type": "LLM_ASK",
+      "name": "Generate Summary Report",
+      "position": { "x": 1000, "y": 450 },
+      "config": {
+        "modelId": "{{variables.modelId}}",
+        "systemPrompt": "You are a business analyst.",
+        "userPrompt": "Create a concise executive summary of customer sentiment based on this analysis:\n\n{{analyze-sentiment.output}}"
+      },
+      "inputs": {},
+      "next": ["final-output"],
+      "ifTrue": null,
+      "ifFalse": null
+    },
+    {
+      "stepId": "final-output",
+      "type": "OUTPUT",
+      "name": "Report Output",
+      "position": { "x": 1300, "y": 450 },
+      "config": {
+        "value": "{{generate-report.output}}"
+      },
+      "inputs": {},
+      "next": null,
+      "ifTrue": null,
+      "ifFalse": null
+    }
+  ]
+}
+```
+
+This workflow: fetches reviews → analyzes sentiment → branches on negative rate → optionally alerts → generates summary → outputs report.

--- a/docs/workflow-engine/IMPLEMENTATION_PLAN.md
+++ b/docs/workflow-engine/IMPLEMENTATION_PLAN.md
@@ -1,0 +1,704 @@
+# Workflow Engine: Implementation Plan
+
+> **Status:** Not Started
+> **Last Updated:** 2026-02-16
+> **Feature Doc:** [FEATURE_OVERVIEW.md](./FEATURE_OVERVIEW.md)
+
+This document tracks all implementation tasks for the Workflow Engine feature. Each task has a status, description, and relevant file paths. Update the status as work progresses.
+
+**Status Legend:**
+- ⬜ Not Started
+- 🔲 In Progress
+- ✅ Completed
+- ⏸️ Blocked
+
+---
+
+## Phase 1: Foundation — Project Type & Data Model
+
+> Goal: Establish WORKFLOW as a project type and define the core data model classes.
+
+### Task 1.1 — Add `WORKFLOW` to `PROJECT_TYPE` enum
+
+- **Status:** ✅
+- **File:** `src/prerna/project/api/IProject.java`
+- **Description:** Add `WORKFLOW` to the `PROJECT_TYPE` enum alongside `BLOCKS`, `CODE`, `WORKSPACE`, `INSIGHTS`.
+- **Changes:**
+  ```java
+  enum PROJECT_TYPE {
+      BLOCKS, CODE, WORKSPACE, INSIGHTS, WORKFLOW
+  }
+  ```
+- **Validation:** Ensure no existing code breaks — search for `PROJECT_TYPE.values()` or switch statements on `PROJECT_TYPE`.
+- **Notes:** Also define the workflow folder constant:
+  ```java
+  String WORKFLOW_FOLDER = "workflow";
+  String WORKFLOW_FILE_NAME = "workflow.json";
+  ```
+
+### Task 1.2 — Update `CreateProjectReactor` to handle WORKFLOW type
+
+- **Status:** ✅
+- **File:** `src/prerna/reactor/project/CreateProjectReactor.java`
+- **Description:** When `projectType = WORKFLOW`:
+  - Set `hasPortal = true` (the canvas editor)
+  - Auto-create the `assets/workflow/` directory
+  - Create a default empty `workflow.json` scaffold:
+    ```json
+    {
+      "workflowId": "{{projectId}}",
+      "name": "{{projectName}}",
+      "version": 1,
+      "steps": [],
+      "variables": {},
+      "trigger": null,
+      "settings": {
+        "maxSteps": 50,
+        "timeoutMs": 300000,
+        "onError": "stop"
+      }
+    }
+    ```
+- **Validation:** Create a WORKFLOW project and verify folder structure is correct.
+
+### Task 1.3 — Create `WorkflowDefinition` POJO
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/WorkflowDefinition.java` (new)
+- **Description:** Java class representing the parsed `workflow.json`. Fields:
+  - `String workflowId`
+  - `String name`
+  - `int version`
+  - `List<WorkflowStep> steps`
+  - `Map<String, WorkflowVariable> variables`
+  - `WorkflowTrigger trigger`
+  - `WorkflowSettings settings`
+- **Notes:** Use Gson-friendly structure. Include a static `parse(String json)` factory method.
+
+### Task 1.4 — Create `WorkflowStep` POJO
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/WorkflowStep.java` (new)
+- **Description:** Represents a single step node. Fields:
+  - `String stepId`
+  - `String type` (enum: `LLM_ASK`, `LLM_AGENT`, `RUN_TOOL`, `RUN_PIXEL`, `RUN_PYTHON`, `CONDITION`, `LOOP`, `TRANSFORM`, `STATIC`, `HUMAN_INPUT`, `GUARDRAIL`, `OUTPUT`)
+  - `String name`
+  - `String description`
+  - `Map<String, Object> position` (UI-only, ignored by backend)
+  - `Map<String, Object> config` (type-specific)
+  - `Map<String, String> inputs` (template expressions mapping)
+  - `List<String> next`
+  - `List<String> ifTrue` (CONDITION only)
+  - `List<String> ifFalse` (CONDITION only)
+
+### Task 1.5 — Create `WorkflowContext` runtime class
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/WorkflowContext.java` (new)
+- **Description:** Holds runtime state during execution:
+  - `Map<String, Object> variables` — merged variable values
+  - `Map<String, StepResult> stepResults` — results keyed by stepId
+  - `List<StepExecutionLog> executionLog` — ordered log of step executions
+  - `long startTimeMs`
+  - `int stepsExecuted` — counter for maxSteps enforcement
+  - Methods: `putResult(stepId, result)`, `getResult(stepId)`, `getVariable(name)`, `resolveTemplate(String template)`
+
+### Task 1.6 — Create `StepResult` POJO
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/StepResult.java` (new)
+- **Description:** Result of a single step execution:
+  - `String stepId`
+  - `String status` — `"success"`, `"error"`, `"skipped"`
+  - `Object output` — the primary output value
+  - `Map<String, Object> metadata` — additional data (rowCount, model used, etc.)
+  - `String error` — error message if failed
+  - `long durationMs`
+
+### Task 1.7 — Create `WorkflowExecutionResult` POJO
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/WorkflowExecutionResult.java` (new)
+- **Description:** Final result of a workflow run:
+  - `String executionId`
+  - `String workflowId`
+  - `String status` — `"success"`, `"error"`, `"timeout"`
+  - `long startTimeMs`, `endTimeMs`, `durationMs`
+  - `String triggeredBy` — `"manual"`, `"cron"`, `"webhook"`, `"api"`
+  - `Map<String, StepResult> stepResults`
+  - `Object finalOutput` — output of the last step
+
+---
+
+## Phase 2: Template Engine
+
+> Goal: Implement the `{{...}}` template resolution system for step configs.
+
+### Task 2.1 — Create `WorkflowTemplateEngine`
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/WorkflowTemplateEngine.java` (new)
+- **Description:** Resolves `{{...}}` expressions in step config strings. Supported patterns:
+  - `{{variables.name}}` → looks up in `WorkflowContext.variables`
+  - `{{step-1.output}}` → looks up `StepResult.output` for step-1
+  - `{{step-1.output.fieldName}}` → nested field access (dot-notation JSON path)
+  - `{{step-1.metadata.rowCount}}` → metadata access
+  - `{{step-1.output || step-2.output}}` → fallback/coalesce
+- **Implementation approach:**
+  - Use regex to find `\{\{(.+?)\}\}` patterns
+  - Parse the expression inside
+  - Look up values in `WorkflowContext`
+  - Support recursive resolution for maps (walk all string values in a config map)
+- **Method signatures:**
+  ```java
+  public static String resolve(String template, WorkflowContext context);
+  public static Map<String, Object> resolveMap(Map<String, Object> configMap, WorkflowContext context);
+  ```
+
+---
+
+## Phase 3: Step Handlers
+
+> Goal: Implement handlers for each step type. Start with the most critical ones.
+
+### Task 3.1 — Create `IWorkflowStepHandler` interface
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/handlers/IWorkflowStepHandler.java` (new)
+- **Description:**
+  ```java
+  public interface IWorkflowStepHandler {
+      StepResult execute(String stepId, Map<String, Object> config,
+                         WorkflowContext context, Insight insight);
+  }
+  ```
+
+### Task 3.2 — Create `WorkflowStepHandlerRegistry`
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/handlers/WorkflowStepHandlerRegistry.java` (new)
+- **Description:** Maps step type strings to handler instances:
+  ```java
+  public class WorkflowStepHandlerRegistry {
+      private static final Map<String, IWorkflowStepHandler> HANDLERS = new HashMap<>();
+      static {
+          HANDLERS.put("LLM_ASK", new LLMAskStepHandler());
+          HANDLERS.put("RUN_TOOL", new RunToolStepHandler());
+          HANDLERS.put("RUN_PIXEL", new RunPixelStepHandler());
+          HANDLERS.put("CONDITION", new ConditionStepHandler());
+          HANDLERS.put("STATIC", new StaticStepHandler());
+          HANDLERS.put("OUTPUT", new OutputStepHandler());
+          // ... etc
+      }
+      public static IWorkflowStepHandler getHandler(String type) { ... }
+  }
+  ```
+
+### Task 3.3 — Implement `StaticStepHandler`
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/handlers/StaticStepHandler.java` (new)
+- **Description:** Simplest handler — returns `config.value` as the output. Good starting point to validate the pipeline.
+
+### Task 3.4 — Implement `RunPixelStepHandler`
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/handlers/RunPixelStepHandler.java` (new)
+- **Description:**
+  - Reads `config.recipe` (Pixel expression string)
+  - Resolves templates in the recipe
+  - Runs via `PixelRunner` (same as `RunPixelJobFromDB`)
+  - Captures output as `StepResult.output`
+- **Reference:** `src/prerna/rpa/quartz/jobs/insight/RunPixelJobFromDB.java`
+
+### Task 3.5 — Implement `RunToolStepHandler`
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/handlers/RunToolStepHandler.java` (new)
+- **Description:**
+  - Reads `config.engineId`, `config.toolName`, `config.params`
+  - Resolves templates in params
+  - Calls `MCPFactory.build(engine).callTool(toolName, params, insight)`
+  - Returns tool output as `StepResult.output`
+- **Reference:** `src/prerna/reactor/agent/mcp/RunMCPToolReactor.java`, `src/prerna/engine/impl/InternalMCP.java`
+
+### Task 3.6 — Implement `LLMAskStepHandler`
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/handlers/LLMAskStepHandler.java` (new)
+- **Description:**
+  - Reads `config.modelId`, `config.systemPrompt`, `config.userPrompt`, `config.paramMap`
+  - Creates or reuses a `Room`
+  - Builds an `InputMessage`
+  - Calls `room.ask(msg, modelEngine, null)`
+  - Returns the response text as `StepResult.output`
+- **Reference:** `src/prerna/playground/reactors/AskPlaygroundReactor.java`
+
+### Task 3.7 — Implement `ConditionStepHandler`
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/handlers/ConditionStepHandler.java` (new)
+- **Description:**
+  - Reads `config.expression` (e.g., `"42 > 0"` after template resolution)
+  - Evaluates the expression to a boolean
+  - Returns `StepResult` with `metadata.branch = "ifTrue"` or `"ifFalse"`
+  - The `WorkflowExecutor` uses this to determine which `next` steps to follow
+- **Expression evaluation:** Can start simple with basic comparisons (`>`, `<`, `==`, `!=`, `contains`), expand later.
+
+### Task 3.8 — Implement `LLMAgentStepHandler`
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/handlers/LLMAgentStepHandler.java` (new)
+- **Description:** Full agentic loop:
+  1. Load model engine and tool engines from config
+  2. Gather MCP tool definitions from all specified tool engines
+  3. Create a Room, build InputMessage with tools attached
+  4. Call `room.ask()`
+  5. If response is `RESPONSE_TOOL`:
+     - For each tool call: `MCPFactory.build(engine).callTool()`
+     - `room.addToolExecutionResult()`
+     - Loop until `RESPONSE_TEXT` or `maxIterations`
+  6. Return final text as `StepResult.output`
+- **Reference:** `src/prerna/playground/reactors/AskPlaygroundReactor.java`, `src/prerna/playground/reactors/AddPlaygroundToolExecutionReactor.java`
+- **Notes:** This is the most complex handler. Consider implementing after the simpler ones are working.
+
+### Task 3.9 — Implement `OutputStepHandler`
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/handlers/OutputStepHandler.java` (new)
+- **Description:** Routes the final result based on `config.action`:
+  - `return` — just passes through (default)
+  - `email` — sends email via existing email infrastructure
+  - `webhook` — HTTP POST to a URL
+  - `write_file` — writes to the project's assets folder
+  - `store_db` — inserts into a database engine
+- **Notes:** Start with `return` only. Add other actions incrementally.
+
+### Task 3.10 — Implement `LoopStepHandler` (Deferred)
+
+- **Status:** ⬜
+- **File:** `src/prerna/workflow/handlers/LoopStepHandler.java` (new)
+- **Description:**
+  - Reads `config.items` (template expression resolving to a list)
+  - Reads `config.subSteps` (step IDs to execute per item)
+  - For each item: injects `{{loop.item}}`, `{{loop.index}}` into context, executes sub-steps
+  - Collects results into a list
+- **Notes:** Defer until basic linear + branching workflows work.
+
+### Task 3.11 — Implement `RunPythonStepHandler` (Deferred)
+
+- **Status:** ⬜
+- **File:** `src/prerna/workflow/handlers/RunPythonStepHandler.java` (new)
+- **Description:**
+  - Reads `config.script` (Python code string) or `config.file` (path in assets)
+  - Executes via `PyTranslator`
+  - Returns output
+- **Notes:** Defer until core steps work.
+
+### Task 3.12 — Implement `GuardrailStepHandler` (Deferred)
+
+- **Status:** ⬜
+- **File:** `src/prerna/workflow/handlers/GuardrailStepHandler.java` (new)
+- **Description:**
+  - Runs a guardrail check on the input data
+  - If passes, continues; if fails, routes to error handling
+- **Reference:** `src/prerna/reactor/interceptor/GenericGuardrailInputReactor.java`
+- **Notes:** Defer.
+
+---
+
+## Phase 4: Workflow Executor
+
+> Goal: Build the core engine that walks the DAG and orchestrates step execution.
+
+### Task 4.1 — Implement `WorkflowExecutor`
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/WorkflowExecutor.java` (new)
+- **Description:** The orchestrator:
+  ```java
+  public class WorkflowExecutor {
+      public WorkflowExecutionResult execute(
+          IProject project,
+          Map<String, Object> variableOverrides,
+          Insight insight,
+          String triggeredBy
+      ) { ... }
+  }
+  ```
+- **Core logic:**
+  1. Read `workflow.json` from project assets
+  2. Parse into `WorkflowDefinition`
+  3. Merge `variableOverrides` with definition defaults
+  4. Build adjacency graph from steps' `next`/`ifTrue`/`ifFalse` edges
+  5. Find entry steps (steps with no incoming edges)
+  6. Execute steps using a queue/stack:
+     - Pop next step
+     - Resolve templates in `step.config`
+     - Get handler from registry
+     - Execute handler
+     - Store result
+     - If CONDITION: enqueue the appropriate branch
+     - Else: enqueue `step.next` steps
+  7. Enforce `maxSteps` and `timeoutMs`
+  8. Handle errors based on `settings.onError`
+  9. Build and return `WorkflowExecutionResult`
+- **Edge cases:**
+  - Steps with multiple incoming edges (join/merge) — execute when ALL predecessors complete
+  - Steps with no next — terminal nodes
+  - Circular reference detection (validate at parse time)
+
+### Task 4.2 — Add DAG validation
+
+- **Status:** ✅
+- **File:** `src/prerna/workflow/WorkflowDefinition.java`
+- **Description:** Add a `validate()` method that checks:
+  - No circular references (cycle detection via DFS)
+  - All `next`/`ifTrue`/`ifFalse` references point to existing step IDs
+  - At least one step exists
+  - At least one entry step (no incoming edges)
+  - No orphaned steps (unreachable from any entry)
+  - Required config fields present for each step type
+
+---
+
+## Phase 5: Reactor & API Layer
+
+> Goal: Expose the workflow executor via Pixel and REST.
+
+### Task 5.1 — Create `RunWorkflowReactor`
+
+- **Status:** ✅
+- **File:** `src/prerna/reactor/workflow/RunWorkflowReactor.java` (new)
+- **Description:**
+  - **Pixel:** `RunWorkflow(project=["workflow-project-uuid"], variables=[{"key": "value"}]);`
+  - **Keys:** `project` (required), `variables` (optional map)
+  - **Logic:**
+    1. Load `IProject` by ID
+    2. Security check: `userCanViewProject`
+    3. Confirm `projectType == WORKFLOW`
+    4. Create `WorkflowExecutor`
+    5. Call `executor.execute(project, variables, insight, "manual")`
+    6. Return result
+- **Return type:** `PixelDataType.MAP` with execution result
+
+### Task 5.2 — Register workflow reactors in `ReactorFactory`
+
+- **Status:** ✅
+- **File:** `src/prerna/reactor/ReactorFactory.java`
+- **Description:** Added entries for all three workflow reactors:
+  ```java
+  reactorHash.put("RunWorkflow", RunWorkflowReactor.class);
+  reactorHash.put("SaveWorkflow", SaveWorkflowReactor.class);
+  reactorHash.put("GetWorkflowStatus", GetWorkflowStatusReactor.class);
+  ```
+
+### Task 5.3 — Create `SaveWorkflowReactor`
+
+- **Status:** ✅
+- **File:** `src/prerna/reactor/workflow/SaveWorkflowReactor.java` (new)
+- **Description:**
+  - **Pixel:** `SaveWorkflow(project=["uuid"], json=[{...}], comment=["optional message"]);`
+  - **Keys:** `project` (required), `json` (required — workflow definition map), `comment` (optional)
+  - Validates WORKFLOW project type, writes workflow.json, git add+commit, cluster sync
+  - Security check: `userCanEditProject`
+- **Return type:** `PixelDataType.BOOLEAN` (true on success)
+
+### Task 5.4 — Create `GetWorkflowStatusReactor`
+
+- **Status:** ✅
+- **File:** `src/prerna/reactor/workflow/GetWorkflowStatusReactor.java` (new)
+- **Description:**
+  - **Pixel:** `GetWorkflowStatus(project=["uuid"]);`
+  - Returns project metadata + current workflow.json contents
+  - Security check: `userCanViewProject`
+  - Pulls from cloud if clustered
+- **Return type:** `PixelDataType.MAP` with projectId, projectName, projectType, workflow
+
+---
+
+## Phase 6: Execution Logging
+
+> Goal: Persist execution results for history and debugging.
+
+### Task 6.1 — Implement execution log saving
+
+- **Status:** ✅
+- **File:** `src/prerna/reactor/workflow/engine/WorkflowExecutor.java`
+- **Description:** After execution completes (success, error, or timeout):
+  - Serializes `WorkflowExecutionResult` to JSON via `saveExecutionLog()`
+  - Writes to `{project}/assets/workflow/executions/{executionId}.json`
+  - Creates the `executions/` directory if it doesn't exist
+  - Best-effort — log failures do not abort the workflow result
+  - All exit paths (success, timeout, maxSteps, error in step, missing handler) save logs
+
+### Task 6.2 — Add execution log cleanup/retention
+
+- **Status:** ✅
+- **File:** `src/prerna/reactor/workflow/engine/WorkflowExecutor.java`
+- **Description:** Implemented `cleanupOldExecutions()`:
+  - Keeps the latest 100 execution logs per project (configurable via `MAX_EXECUTION_LOGS`)
+  - Sorts by last-modified time, deletes oldest files when count exceeds threshold
+  - Called automatically after every log save
+
+### Task 6.3 — Add execution history to `GetWorkflowStatusReactor`
+
+- **Status:** ✅
+- **File:** `src/prerna/reactor/workflow/GetWorkflowStatusReactor.java`
+- **Description:** Enhanced the reactor to include an `executions` array in the return map:
+  - Reads execution log files from `assets/workflow/executions/`
+  - Returns summaries (executionId, status, durationMs, triggeredBy, startTimeMs, endTimeMs, error)
+  - Sorted newest-first, capped at 50 entries
+  - Does not include full step results (lightweight for list views)
+
+---
+
+## Phase 7: Scheduling Integration
+
+> Goal: Enable cron-based and trigger-based workflow execution.
+
+### Task 7.1 — Verify scheduling works with `RunWorkflow` Pixel
+
+- **Status:** ✅
+- **Files:** Existing scheduler reactors, `RunWorkflowReactor.java` (updated)
+- **Description:** Verified compatibility by tracing the full scheduling path:
+  1. `ScheduleJobReactor` stores a Pixel `recipe` + encrypted user credentials in a Quartz `JobDataMap`
+  2. When the cron fires, `RunPixelJobFromDB` makes an HTTP POST to `/api/schedule/executePixel` with the stored Pixel and user credentials
+  3. The server-side endpoint reconstructs a `User` + `Insight`, then runs the Pixel
+  4. `RunWorkflow(project=["uuid"])` is a standard Pixel string — works with zero changes
+  5. **Added** optional `trigger` key to `RunWorkflowReactor` so scheduled runs can self-identify:
+     ```
+     ScheduleJob(
+       jobName=["Weekly Report"],
+       jobGroup=["workflow-project-uuid"],
+       cronExpression=["0 0 9 ? * MON"],
+       recipe=["RunWorkflow(project=[\"workflow-project-uuid\"], trigger=[\"schedule\"]);"],
+       uiState=["..."]
+     );
+     ```
+  6. User credentials pass through via the scheduler's `providerInfo` mechanism — security checks in `RunWorkflowReactor` work correctly
+
+### Task 7.2 — Webhook trigger (No dedicated endpoint needed)
+
+- **Status:** ✅ (N/A)
+- **Description:** No dedicated webhook endpoint is needed in the engine layer. The existing Pixel execution REST API (in the web module) already accepts arbitrary Pixel strings. External systems can trigger workflow execution by calling:
+  ```
+  POST /api/engine/runPixel
+  Body: { "expression": "RunWorkflow(project=[\"uuid\"], trigger=[\"webhook\"], variables=[{\"key\": \"value\"}]);" }
+  ```
+  If a purpose-built webhook endpoint is ever needed (simpler URL, API key auth), it belongs in the **web module**, not this engine repo.
+
+### Task 7.3 — Implement event-based triggers (Deferred)
+
+- **Status:** ⬜
+- **Description:** Future work — hook into internal SEMOSS events to trigger workflows.
+
+---
+
+## Phase 8: Frontend — Canvas Editor
+
+> Goal: Build the visual workflow editor UI.
+
+### Task 8.1 — Create workflow list view
+
+- **Status:** ⬜
+- **Description:**
+  - Filter projects by `projectType = WORKFLOW`
+  - Display as cards or table: name, last run status, schedule, created by
+  - Actions: create new, edit, run, delete, share
+  - "Create Workflow" button → calls `CreateProject(type=["WORKFLOW"])`
+
+### Task 8.2 — Set up react-flow canvas
+
+- **Status:** ⬜
+- **Description:**
+  - Integrate react-flow (or similar DAG editor library)
+  - Load `workflow.json` on mount via `GetAppAssets`
+  - Render steps as nodes, `next`/`ifTrue`/`ifFalse` as edges
+  - Save on change via `SaveAppAssets`
+
+### Task 8.3 — Build step palette (left sidebar)
+
+- **Status:** ⬜
+- **Description:**
+  - Draggable list of step types with icons
+  - Grouped by category: AI (LLM_ASK, LLM_AGENT), Data (RUN_TOOL, QUERY_DB, RUN_PIXEL), Logic (CONDITION, LOOP, TRANSFORM), I/O (OUTPUT, HUMAN_INPUT)
+  - Drag onto canvas creates a new node with default config
+
+### Task 8.4 — Build config panel (right sidebar)
+
+- **Status:** ⬜
+- **Description:**
+  - Shows when a node is selected
+  - Auto-generated form based on step type
+  - LLM_ASK: model dropdown, system prompt textarea, user prompt textarea
+  - RUN_TOOL: engine dropdown → tool dropdown (fetched from `GetMCPTools`) → auto-generated param form from `inputSchema`
+  - CONDITION: expression input
+  - All text fields support `{{...}}` autocomplete with available variables/step outputs
+
+### Task 8.5 — Build variables panel
+
+- **Status:** ⬜
+- **Description:**
+  - Top bar or collapsible section
+  - Add/edit/delete workflow-level variables
+  - Each variable: name, type, default value, description
+
+### Task 8.6 — Build run controls
+
+- **Status:** ⬜
+- **Description:**
+  - "Run Now" button → calls `RunWorkflow` → shows live progress
+  - Step nodes light up green (success), red (error), yellow (in-progress), gray (pending)
+  - Click completed node → see input/output in a modal or panel
+  - "Schedule" button → opens cron expression builder → calls `ScheduleJob`
+
+### Task 8.7 — Build execution history panel
+
+- **Status:** ⬜
+- **Description:**
+  - Bottom drawer or tab
+  - Table: execution ID, status, duration, triggered by, timestamp
+  - Click row → opens run detail view (step-by-step breakdown)
+
+---
+
+## Phase 9: Advanced Features (Deferred)
+
+### Task 9.1 — Workflow-as-MCP-tool (Composability)
+
+- **Status:** ⬜
+- **Description:**
+  - Allow a WORKFLOW project to expose itself as an MCP tool
+  - Auto-generate `py_mcp.json` with a tool entry based on workflow variables as input schema
+  - Implementation calls `RunWorkflow` internally
+  - Enables nesting: one workflow calling another via `LLM_AGENT` step
+
+### Task 9.2 — `HUMAN_INPUT` step type
+
+- **Status:** ⬜
+- **Description:**
+  - Suspends workflow execution
+  - Stores execution state to disk
+  - Presents a form to the user in the UI
+  - On submit → resumes execution from the suspended step
+  - Requires: execution state serialization/deserialization
+
+### Task 9.3 — Workflow versioning
+
+- **Status:** ⬜
+- **Description:**
+  - Track version history of `workflow.json`
+  - Allow reverting to a previous version
+  - Show diff between versions
+  - Can leverage git-backed projects or manual versioning
+
+### Task 9.4 — Workflow templates / marketplace
+
+- **Status:** ⬜
+- **Description:**
+  - Pre-built workflow templates that users can clone
+  - "Start from template" in the create workflow flow
+  - Templates stored as project exports
+
+### Task 9.5 — Parallel step execution
+
+- **Status:** ⬜
+- **Description:**
+  - When a step has multiple `next` targets with no dependencies between them, execute in parallel
+  - Requires thread-safe `WorkflowContext`
+  - Join/merge step to wait for all parallel branches
+
+### Task 9.6 — RAG composite step
+
+- **Status:** ⬜
+- **Description:**
+  - A convenience composite step type that combines Vector Search → LLM Ask in a single node
+  - Config: `vectorEngineId`, `searchQuery`, `topK`, `modelId`, `systemPrompt`
+  - Under the hood: runs `VectorDatabaseQuery` tool, then passes results into an LLM ask
+  - Simplifies the most common multi-step pattern into a single drag-and-drop node
+  - Can be built as a handler that internally chains `RunToolStepHandler` + `LLMAskStepHandler`
+
+### Task 9.7 — Database engine MCP tools
+
+- **Status:** ⬜
+- **Description:**
+  - Build standard MCP tools for DATABASE engine type (similar to VECTOR/STORAGE/FUNCTION)
+  - Tools: `QueryDatabase`, `GetDatabaseSchema`, `GetDatabaseTables`, etc.
+  - Add DATABASE to `MakeEngineMCPReactor.STANDARD_ENGINE_TOOLS` map
+  - Once available, DATABASE engines become usable in workflow `RUN_TOOL` steps
+
+---
+
+## Testing Plan
+
+### Unit Tests
+
+| Test | Status |
+|---|---|
+| `WorkflowDefinition` parsing from JSON | ⬜ |
+| `WorkflowDefinition` validation (cycles, missing refs, orphans) | ⬜ |
+| `WorkflowTemplateEngine` — variable resolution | ⬜ |
+| `WorkflowTemplateEngine` — step output resolution | ⬜ |
+| `WorkflowTemplateEngine` — nested field access | ⬜ |
+| `StaticStepHandler` | ⬜ |
+| `ConditionStepHandler` — true/false branching | ⬜ |
+| `WorkflowExecutor` — linear workflow (3 steps) | ⬜ |
+| `WorkflowExecutor` — branching workflow (if/else) | ⬜ |
+| `WorkflowExecutor` — maxSteps enforcement | ⬜ |
+| `WorkflowExecutor` — timeout enforcement | ⬜ |
+| `WorkflowExecutor` — error handling (onError=stop) | ⬜ |
+
+### Integration Tests
+
+| Test | Status |
+|---|---|
+| Create WORKFLOW project → verify folder structure | ⬜ |
+| Save and load `workflow.json` via asset APIs | ⬜ |
+| `RunWorkflowReactor` — simple linear workflow | ⬜ |
+| `RunWorkflowReactor` — workflow with LLM_ASK step | ⬜ |
+| `RunWorkflowReactor` — workflow with RUN_TOOL step | ⬜ |
+| Schedule workflow via `ScheduleJobReactor` | ⬜ |
+| Execution logging — verify log file written | ⬜ |
+| Security — user without access cannot run workflow | ⬜ |
+
+---
+
+## Dependencies & Risks
+
+| Risk | Mitigation |
+|---|---|
+| `Room.ask()` is tightly coupled to the playground FE flow | Extract headless execution path; the `AskPlaygroundReactor` already does most of this inline |
+| Quartz scheduler passes user credentials — workflow steps accessing other engines need proper auth | Reuse `RunPixelJobFromDB`'s credential-passing pattern |
+| Large workflow executions could produce big log files | Implement retention policy (Task 6.2) |
+| Complex template expressions (nested, fallback) could be fragile | Start with simple variable/output resolution, add complexity incrementally |
+| react-flow or canvas library choice affects feature scope | Evaluate react-flow, elkjs, dagre for layout capabilities before committing |
+
+---
+
+## Quick Start (Phase 1-4 Minimum Viable Feature)
+
+For the earliest working version, implement only these tasks:
+
+1. ⬜ Task 1.1 — `WORKFLOW` enum
+2. ⬜ Task 1.2 — `CreateProjectReactor` update
+3. ⬜ Task 1.3 — `WorkflowDefinition`
+4. ⬜ Task 1.4 — `WorkflowStep`
+5. ⬜ Task 1.5 — `WorkflowContext`
+6. ⬜ Task 1.6 — `StepResult`
+7. ⬜ Task 2.1 — `WorkflowTemplateEngine`
+8. ⬜ Task 3.1 — `IWorkflowStepHandler`
+9. ⬜ Task 3.2 — `WorkflowStepHandlerRegistry`
+10. ⬜ Task 3.3 — `StaticStepHandler`
+11. ⬜ Task 3.5 — `RunToolStepHandler`
+12. ⬜ Task 3.6 — `LLMAskStepHandler`
+13. ⬜ Task 3.7 — `ConditionStepHandler`
+14. ⬜ Task 4.1 — `WorkflowExecutor`
+15. ⬜ Task 4.2 — DAG validation
+16. ⬜ Task 5.1 — `RunWorkflowReactor`
+17. ⬜ Task 5.2 — Register in `ReactorFactory`
+
+This gives you a **fully functional headless workflow engine** that can be invoked via Pixel:
+```
+RunWorkflow(project=["uuid"], variables=[{"database": "db-uuid"}]);
+```

--- a/src/prerna/engine/api/IEvalEngine.java
+++ b/src/prerna/engine/api/IEvalEngine.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.engine.api;
+
+import java.util.List;
+
+import prerna.reactor.agent.eval.AgentEvalContext;
+import prerna.reactor.agent.eval.EvalResult;
+import prerna.reactor.agent.eval.EvalSpec;
+
+/**
+ * Engine interface for evaluating agent execution traces.
+ *
+ * <p>Eval engines are meta-system components — they assess execution <em>after the fact</em>.
+ * They are NOT tools that agents call during execution. This separation implements the
+ * article's core principle: <strong>agents execute, meta-systems learn</strong>.
+ *
+ * <p>Contrast with {@link IFunctionEngine} (callable tools during agent execution) and
+ * {@link IGuardrailReactorFunctionEngine} (content-level safety filtering during execution).
+ * Eval engines belong to {@code CATALOG_TYPE.EVAL} — a distinct engine type with its own
+ * security namespace, .smss config structure, and discovery path.
+ *
+ * <h3>Usage</h3>
+ * <pre>
+ * // Via Pixel:
+ * RunEval(traceId=["abc123"], evalEngineId=["eval_task_success_default"])
+ * RunEvalSuite(traceId=["abc123"], evalEngineIds=["eval1", "eval2"])
+ * </pre>
+ *
+ * <h3>Implementation Notes</h3>
+ * <ul>
+ *   <li>Implement {@link #open(java.util.Properties)} to parse eval criteria from .smss config.
+ *   <li>Eval criteria belong in config, not prompts — they must be version-controlled and auditable.
+ *   <li>Do not call {@link IModelEngine} inside an eval engine — evaluation should be deterministic.
+ *       LLM-as-judge evaluators can be built but must be explicitly typed as {@code LLM_JUDGE} subtype.
+ * </ul>
+ *
+ * <p><strong>Phase 2 — not yet registered in {@code CATALOG_TYPE}.</strong> Full lifecycle
+ * (Utility dispatch, SecurityEngineUtils, engine folder layout) is tracked in the Phase 2 backlog.
+ *
+ * @see AgentEvalContext
+ * @see EvalResult
+ * @see EvalSpec
+ */
+public interface IEvalEngine extends IEngine {
+
+    /**
+     * Evaluates a single agent execution trace.
+     *
+     * @param evalContext immutable context carrying input, trace, room/model IDs, and task spec
+     * @return evaluation result with pass/fail determinations and failure details
+     */
+    EvalResult evaluate(AgentEvalContext evalContext);
+
+    /**
+     * Returns the eval specification — what this engine checks and how it scores.
+     *
+     * @return eval spec (never null after {@link #open} is called)
+     */
+    EvalSpec getEvalSpec();
+
+    /**
+     * Evaluates a batch of traces. Default implementation delegates to {@link #evaluate} serially;
+     * override for parallel or vectorized evaluation.
+     *
+     * @param contexts list of eval contexts
+     * @return list of results in the same order as input contexts
+     */
+    default List<EvalResult> evaluateBatch(List<AgentEvalContext> contexts) {
+        return contexts.stream()
+                .map(this::evaluate)
+                .collect(java.util.stream.Collectors.toList());
+    }
+}

--- a/src/prerna/engine/impl/model/inferencetracking/AgentTraceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/AgentTraceLogsUtils.java
@@ -1,0 +1,580 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.engine.impl.model.inferencetracking;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.ToNumberPolicy;
+
+import prerna.engine.api.IRDBMSEngine;
+import prerna.reactor.agent.AgentHarnessResult;
+import prerna.reactor.agent.AgentHarnessResult.DecisionStep;
+import prerna.reactor.agent.AgentHarnessResult.ToolCallRecord;
+import prerna.util.ConnectionUtils;
+import prerna.util.SystemEngineRegistry;
+
+/**
+ * Utility for persisting agent decision traces to the model-inference tracking database.
+ *
+ * <p>Follows the same pattern as {@link ModelInferenceLogsUtils}:
+ * <ul>
+ *   <li>Uses {@link SystemEngineRegistry#getModelInferenceLogsDb()} as the backing store.
+ *   <li>Respects the model engine's content-retention policy — when {@code keepInputOutput} is
+ *       {@code false}, only metadata (IDs, counts, timing) is stored; no content or tool results.
+ *   <li>Schema is registered in {@link ModelInferenceLogsOwlCreator} and created automatically
+ *       by {@link ModelInferenceLogsUtils#initModelInferenceLogsDatabase()} at server startup.
+ * </ul>
+ *
+ * <p>Callers should invoke {@link #logTrace} from a background thread (e.g.
+ * {@code CompletableFuture.runAsync}) with all content retention decisions made before dispatch.
+ * Only immutable scalar values should cross thread boundaries.
+ */
+public final class AgentTraceLogsUtils {
+
+    private static final Logger classLogger = LogManager.getLogger(AgentTraceLogsUtils.class);
+
+    private static final Gson GSON = new GsonBuilder()
+            .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+            .disableHtmlEscaping()
+            .create();
+
+    // ── Table and column names ────────────────────────────────────────────────
+
+    public static final String TABLE_AGENT_TRACE      = "AGENT_TRACE";
+    public static final String TABLE_AGENT_TRACE_STEP = "AGENT_TRACE_STEP";
+
+    // AGENT_TRACE columns
+    private static final String COL_TRACE_ID           = "TRACE_ID";
+    private static final String COL_ROOM_ID            = "ROOM_ID";
+    private static final String COL_USER_ID            = "USER_ID";
+    private static final String COL_MODEL_ENGINE_ID    = "MODEL_ENGINE_ID";
+    private static final String COL_START_TIME         = "START_TIME";
+    private static final String COL_END_TIME           = "END_TIME";
+    private static final String COL_ITERATIONS         = "ITERATIONS";
+    private static final String COL_REFLECTIONS_USED   = "REFLECTIONS_USED";
+    private static final String COL_TERMINATION_REASON = "TERMINATION_REASON";
+    private static final String COL_METRICS_JSON       = "METRICS_JSON";
+    private static final String COL_TOOL_CALL_COUNT    = "TOOL_CALL_COUNT";
+
+    // AGENT_TRACE_STEP columns
+    private static final String COL_STEP_INDEX          = "STEP_INDEX";
+    private static final String COL_RESPONSE_TYPE       = "RESPONSE_TYPE";
+    private static final String COL_INPUT_MESSAGE_ID    = "INPUT_MESSAGE_ID";
+    private static final String COL_RESPONSE_MESSAGE_ID = "RESPONSE_MESSAGE_ID";
+    private static final String COL_TOOL_CALLS_JSON     = "TOOL_CALLS_JSON";
+    private static final String COL_GUARDRAILS_JSON     = "GUARDRAILS_JSON";
+    private static final String COL_TOKEN_COUNT         = "TOKEN_COUNT";
+    private static final String COL_STEP_TIMESTAMP      = "STEP_TIMESTAMP";
+
+    private AgentTraceLogsUtils() { }
+
+    // ── Trace persistence ─────────────────────────────────────────────────────
+
+    /**
+     * Persists an agent trace to the model-inference tracking database.
+     *
+     * <p>Content retention is caller-controlled: pass the result of
+     * {@code modelEngine.keepInputOutput()} as {@code keepContent}. This must be resolved on
+     * the calling thread before dispatching to a background thread, since the model engine
+     * object should not be accessed from multiple threads.
+     *
+     * <p>This method is safe to call from a background thread as long as the parameters are
+     * immutable scalars or already-serialized data.
+     *
+     * @param result      the completed agent run result (must have non-null traceId)
+     * @param userId      user who initiated the run (for security scoping queries)
+     * @param keepContent whether the model engine permits content logging
+     */
+    public static void logTrace(AgentHarnessResult result, String userId, boolean keepContent) {
+        String traceId = result.getTraceId();
+        if (traceId == null) {
+            classLogger.debug("AgentTraceLogsUtils.logTrace: result has no traceId; skipping.");
+            return;
+        }
+
+        IRDBMSEngine db = SystemEngineRegistry.getModelInferenceLogsDb();
+        if (db == null) {
+            classLogger.warn("AgentTraceLogsUtils.logTrace: model inference logs DB not available; trace {} dropped.", traceId);
+            return;
+        }
+
+        Connection conn = null;
+        try {
+            conn = db.getConnection();
+            insertTraceRecord(db, conn, result, userId);
+            if (result.getSteps() != null) {
+                for (DecisionStep step : result.getSteps()) {
+                    insertStepRecord(db, conn, traceId, step, keepContent);
+                }
+            }
+            if (!conn.getAutoCommit()) conn.commit();
+            classLogger.debug("AgentTraceLogsUtils.logTrace: persisted trace {} ({} steps).",
+                    traceId, result.getSteps() != null ? result.getSteps().size() : 0);
+        } catch (Exception e) {
+            classLogger.error("AgentTraceLogsUtils.logTrace: failed to persist trace {}.", traceId, e);
+            if (conn != null) {
+                try { conn.rollback(); } catch (SQLException ignored) { }
+            }
+        } finally {
+            ConnectionUtils.closeAllConnectionsIfPooling(db, conn, null, null);
+        }
+    }
+
+    private static void insertTraceRecord(IRDBMSEngine db, Connection conn,
+            AgentHarnessResult result, String userId) throws SQLException, java.io.UnsupportedEncodingException {
+        String sql = "INSERT INTO " + TABLE_AGENT_TRACE + " ("
+                + COL_TRACE_ID + ", " + COL_ROOM_ID + ", " + COL_USER_ID + ", "
+                + COL_MODEL_ENGINE_ID + ", " + COL_START_TIME + ", " + COL_END_TIME + ", "
+                + COL_ITERATIONS + ", " + COL_REFLECTIONS_USED + ", "
+                + COL_TERMINATION_REASON + ", " + COL_METRICS_JSON + ", " + COL_TOOL_CALL_COUNT
+                + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        PreparedStatement ps = null;
+        try {
+            ps = conn.prepareStatement(sql);
+            int index = 1;
+            ps.setString(index++, result.getTraceId());
+            ps.setString(index++, result.getRoomId());
+            ps.setString(index++, userId);
+            ps.setString(index++, result.getModelEngineId());
+            ps.setTimestamp(index++, result.getStartTime() != null
+                    ? Timestamp.from(result.getStartTime()) : null);
+            ps.setTimestamp(index++, result.getEndTime() != null
+                    ? Timestamp.from(result.getEndTime()) : null);
+            ps.setInt(index++, result.getIterations());
+            ps.setInt(index++, result.getReflectionsUsed());
+            ps.setString(index++, result.getTerminationReason());
+            String metricsJson = result.getMetrics() != null ? GSON.toJson(result.getMetrics()) : null;
+            db.getQueryUtil().handleInsertionOfClob(ps, metricsJson, index++, GSON);
+            ps.setInt(index++, result.getToolCallRecords() != null
+                    ? result.getToolCallRecords().size() : 0);
+            ps.executeUpdate();
+        } finally {
+            ConnectionUtils.closeAllConnectionsIfPooling(null, ps);
+        }
+    }
+
+    private static void insertStepRecord(IRDBMSEngine db, Connection conn,
+            String traceId, DecisionStep step, boolean keepContent) throws SQLException, java.io.UnsupportedEncodingException {
+        String sql = "INSERT INTO " + TABLE_AGENT_TRACE_STEP + " ("
+                + COL_TRACE_ID + ", " + COL_STEP_INDEX + ", " + COL_RESPONSE_TYPE + ", "
+                + COL_INPUT_MESSAGE_ID + ", " + COL_RESPONSE_MESSAGE_ID + ", "
+                + COL_TOOL_CALLS_JSON + ", " + COL_GUARDRAILS_JSON + ", "
+                + COL_TOKEN_COUNT + ", " + COL_STEP_TIMESTAMP
+                + ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        PreparedStatement ps = null;
+        try {
+            ps = conn.prepareStatement(sql);
+            int index = 1;
+            ps.setString(index++, traceId);
+            ps.setInt(index++, step.getStepIndex());
+            ps.setString(index++, step.getModelResponseType() != null
+                    ? step.getModelResponseType().name() : null);
+            // Message IDs are always stored — they are references, not content
+            ps.setString(index++, step.getInputMessageId());
+            ps.setString(index++, step.getResponseMessageId());
+            // Tool call details only if content logging is enabled
+            String toolCallsJson;
+            if (keepContent) {
+                toolCallsJson = serializeToolCalls(step.getToolCalls());
+            } else {
+                // Store count only, not the full results (which may contain sensitive content)
+                int count = step.getToolCalls() != null ? step.getToolCalls().size() : 0;
+                toolCallsJson = GSON.toJson(Collections.singletonMap("count", count));
+            }
+            db.getQueryUtil().handleInsertionOfClob(ps, toolCallsJson, index++, GSON);
+            String guardrailsJson = step.getGuardrailsFired() != null
+                    ? GSON.toJson(step.getGuardrailsFired()) : null;
+            db.getQueryUtil().handleInsertionOfClob(ps, guardrailsJson, index++, GSON);
+            ps.setLong(index++, step.getTokenCount());
+            ps.setTimestamp(index++, step.getTimestamp() != null
+                    ? Timestamp.from(step.getTimestamp()) : null);
+            ps.executeUpdate();
+        } finally {
+            ConnectionUtils.closeAllConnectionsIfPooling(null, ps);
+        }
+    }
+
+    private static String serializeToolCalls(List<ToolCallRecord> toolCalls) {
+        if (toolCalls == null || toolCalls.isEmpty()) return "[]";
+        var list = toolCalls.stream()
+                .map(tc -> java.util.Map.of(
+                        "toolName",   tc.getToolName()   != null ? tc.getToolName()   : "",
+                        "toolCallId", tc.getToolCallId() != null ? tc.getToolCallId() : "",
+                        "durationMs", tc.getDurationMs(),
+                        "success",    tc.isSuccess(),
+                        "result",     tc.getResult()     != null ? tc.getResult()     : ""))
+                .collect(java.util.stream.Collectors.toList());
+        return GSON.toJson(list);
+    }
+
+    // ── Query helpers ─────────────────────────────────────────────────────────
+
+    /**
+     * Returns a lightweight summary of traces for the given room, ordered by start time
+     * descending. Does NOT return step details — use {@link #getTrace} for a full trace.
+     *
+     * @param roomId the room to query
+     * @param limit  maximum rows to return
+     * @return list of trace summary maps (traceId, startTime, endTime, iterations, terminationReason)
+     */
+    public static List<Map<String, Object>> listTraces(String roomId, int limit) {
+        IRDBMSEngine db = SystemEngineRegistry.getModelInferenceLogsDb();
+        if (db == null) return Collections.emptyList();
+
+        List<Map<String, Object>> results = new ArrayList<>();
+        String sql = "SELECT " + COL_TRACE_ID + ", " + COL_ROOM_ID + ", " + COL_MODEL_ENGINE_ID
+                + ", " + COL_START_TIME + ", " + COL_END_TIME + ", " + COL_ITERATIONS
+                + ", " + COL_REFLECTIONS_USED + ", " + COL_TERMINATION_REASON + ", " + COL_TOOL_CALL_COUNT
+                + " FROM " + TABLE_AGENT_TRACE
+                + " WHERE " + COL_ROOM_ID + " = ?"
+                + " ORDER BY " + COL_START_TIME + " DESC";
+
+        Connection conn = null;
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        try {
+            conn = db.getConnection();
+            ps = conn.prepareStatement(sql);
+            ps.setString(1, roomId);
+            if (limit > 0) {
+                ps.setMaxRows(limit);
+            }
+            rs = ps.executeQuery();
+            while (rs.next()) {
+                Map<String, Object> row = new LinkedHashMap<>();
+                row.put("traceId",           rs.getString(COL_TRACE_ID));
+                row.put("roomId",            rs.getString(COL_ROOM_ID));
+                row.put("modelEngineId",     rs.getString(COL_MODEL_ENGINE_ID));
+                row.put("startTime",         rs.getTimestamp(COL_START_TIME));
+                row.put("endTime",           rs.getTimestamp(COL_END_TIME));
+                row.put("iterations",        rs.getInt(COL_ITERATIONS));
+                row.put("reflectionsUsed",   rs.getInt(COL_REFLECTIONS_USED));
+                row.put("terminationReason", rs.getString(COL_TERMINATION_REASON));
+                row.put("toolCallCount",     rs.getInt(COL_TOOL_CALL_COUNT));
+                results.add(row);
+            }
+        } catch (Exception e) {
+            classLogger.error("AgentTraceLogsUtils.listTraces: failed for roomId={}.", roomId, e);
+        } finally {
+            ConnectionUtils.closeAllConnectionsIfPooling(db, conn, ps, rs);
+        }
+        return results;
+    }
+
+    /**
+     * Returns the full trace record (header + steps) for the given trace ID.
+     *
+     * @param traceId the trace to retrieve
+     * @return map with "header" and "steps" keys, or empty map if not found
+     */
+    public static Map<String, Object> getTrace(String traceId) {
+        IRDBMSEngine db = SystemEngineRegistry.getModelInferenceLogsDb();
+        if (db == null) return Collections.emptyMap();
+
+        Map<String, Object> trace = new LinkedHashMap<>();
+        Connection conn = null;
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        try {
+            conn = db.getConnection();
+
+            // Header — explicit column projection; ps.setMaxRows(1) avoids full scan on duplicates
+            String headerSql = "SELECT "
+                    + COL_TRACE_ID + ", " + COL_ROOM_ID + ", " + COL_USER_ID + ", "
+                    + COL_MODEL_ENGINE_ID + ", " + COL_START_TIME + ", " + COL_END_TIME + ", "
+                    + COL_ITERATIONS + ", " + COL_REFLECTIONS_USED + ", "
+                    + COL_TERMINATION_REASON + ", " + COL_METRICS_JSON + ", " + COL_TOOL_CALL_COUNT
+                    + " FROM " + TABLE_AGENT_TRACE
+                    + " WHERE " + COL_TRACE_ID + " = ?";
+            ps = conn.prepareStatement(headerSql);
+            ps.setString(1, traceId);
+            ps.setMaxRows(1);
+            rs = ps.executeQuery();
+            if (rs.next()) {
+                Map<String, Object> header = new LinkedHashMap<>();
+                header.put("traceId",           rs.getString(COL_TRACE_ID));
+                header.put("roomId",            rs.getString(COL_ROOM_ID));
+                header.put("userId",            rs.getString(COL_USER_ID));
+                header.put("modelEngineId",     rs.getString(COL_MODEL_ENGINE_ID));
+                header.put("startTime",         rs.getTimestamp(COL_START_TIME));
+                header.put("endTime",           rs.getTimestamp(COL_END_TIME));
+                header.put("iterations",        rs.getInt(COL_ITERATIONS));
+                header.put("reflectionsUsed",   rs.getInt(COL_REFLECTIONS_USED));
+                header.put("terminationReason", rs.getString(COL_TERMINATION_REASON));
+                header.put("metricsJson",       rs.getString(COL_METRICS_JSON));
+                header.put("toolCallCount",     rs.getInt(COL_TOOL_CALL_COUNT));
+                trace.put("header", header);
+            }
+            ConnectionUtils.closeAllConnectionsIfPooling(null, ps, rs);
+            ps = null;
+            rs = null;
+
+            // Steps — explicit column projection
+            String stepSql = "SELECT "
+                    + COL_TRACE_ID + ", " + COL_STEP_INDEX + ", " + COL_RESPONSE_TYPE + ", "
+                    + COL_INPUT_MESSAGE_ID + ", " + COL_RESPONSE_MESSAGE_ID + ", "
+                    + COL_TOOL_CALLS_JSON + ", " + COL_GUARDRAILS_JSON + ", "
+                    + COL_TOKEN_COUNT + ", " + COL_STEP_TIMESTAMP
+                    + " FROM " + TABLE_AGENT_TRACE_STEP
+                    + " WHERE " + COL_TRACE_ID + " = ?"
+                    + " ORDER BY " + COL_STEP_INDEX + " ASC";
+            ps = conn.prepareStatement(stepSql);
+            ps.setString(1, traceId);
+            rs = ps.executeQuery();
+            List<Map<String, Object>> steps = new ArrayList<>();
+            while (rs.next()) {
+                Map<String, Object> step = new LinkedHashMap<>();
+                step.put("stepIndex",         rs.getInt(COL_STEP_INDEX));
+                step.put("responseType",      rs.getString(COL_RESPONSE_TYPE));
+                step.put("inputMessageId",    rs.getString(COL_INPUT_MESSAGE_ID));
+                step.put("responseMessageId", rs.getString(COL_RESPONSE_MESSAGE_ID));
+                step.put("toolCallsJson",     rs.getString(COL_TOOL_CALLS_JSON));
+                step.put("guardrailsJson",    rs.getString(COL_GUARDRAILS_JSON));
+                step.put("tokenCount",        rs.getLong(COL_TOKEN_COUNT));
+                step.put("stepTimestamp",     rs.getTimestamp(COL_STEP_TIMESTAMP));
+                steps.add(step);
+            }
+            trace.put("steps", steps);
+        } catch (Exception e) {
+            classLogger.error("AgentTraceLogsUtils.getTrace: failed for traceId={}.", traceId, e);
+        } finally {
+            ConnectionUtils.closeAllConnectionsIfPooling(db, conn, ps, rs);
+        }
+        return trace;
+    }
+
+    /**
+     * Lists trace summaries across ALL rooms. Intended for admin dashboards only.
+     * Callers are responsible for enforcing the admin security check before invoking this.
+     *
+     * @param limit max rows (0 = no limit, capped by caller at MAX_LIMIT)
+     * @return list of trace summary maps ordered by start time descending
+     */
+    public static List<Map<String, Object>> listAllTraces(int limit) {
+        IRDBMSEngine db = SystemEngineRegistry.getModelInferenceLogsDb();
+        if (db == null) return Collections.emptyList();
+
+        List<Map<String, Object>> results = new ArrayList<>();
+        String sql = "SELECT " + COL_TRACE_ID + ", " + COL_ROOM_ID + ", " + COL_USER_ID + ", "
+                + COL_MODEL_ENGINE_ID + ", " + COL_START_TIME + ", " + COL_END_TIME + ", "
+                + COL_ITERATIONS + ", " + COL_REFLECTIONS_USED + ", "
+                + COL_TERMINATION_REASON + ", " + COL_TOOL_CALL_COUNT
+                + " FROM " + TABLE_AGENT_TRACE
+                + " ORDER BY " + COL_START_TIME + " DESC";
+
+        Connection conn = null;
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        try {
+            conn = db.getConnection();
+            ps = conn.prepareStatement(sql);
+            if (limit > 0) {
+                ps.setMaxRows(limit);
+            }
+            rs = ps.executeQuery();
+            while (rs.next()) {
+                Map<String, Object> row = new LinkedHashMap<>();
+                row.put("traceId",           rs.getString(COL_TRACE_ID));
+                row.put("roomId",            rs.getString(COL_ROOM_ID));
+                row.put("userId",            rs.getString(COL_USER_ID));
+                row.put("modelEngineId",     rs.getString(COL_MODEL_ENGINE_ID));
+                row.put("startTime",         rs.getTimestamp(COL_START_TIME));
+                row.put("endTime",           rs.getTimestamp(COL_END_TIME));
+                row.put("iterations",        rs.getInt(COL_ITERATIONS));
+                row.put("reflectionsUsed",   rs.getInt(COL_REFLECTIONS_USED));
+                row.put("terminationReason", rs.getString(COL_TERMINATION_REASON));
+                row.put("toolCallCount",     rs.getInt(COL_TOOL_CALL_COUNT));
+                results.add(row);
+            }
+        } catch (Exception e) {
+            classLogger.error("AgentTraceLogsUtils.listAllTraces: failed.", e);
+        } finally {
+            ConnectionUtils.closeAllConnectionsIfPooling(db, conn, ps, rs);
+        }
+        return results;
+    }
+
+    /**
+     * Computes aggregate dashboard metrics across all rooms.
+     * Intended for admin use only — callers must enforce the security check.
+     *
+     * <p>Returns a map with:
+     * <ul>
+     *   <li>{@code totalRuns}         — all-time count
+     *   <li>{@code runsLast24h}       — runs started in the last 24 hours
+     *   <li>{@code avgIterations}     — average agent iterations (excluding null end-times)
+     *   <li>{@code avgDurationMs}     — average run duration in milliseconds
+     *   <li>{@code successRate}       — fraction of runs with terminationReason = 'text_response'
+     *   <li>{@code totalToolCalls}    — sum of TOOL_CALL_COUNT
+     *   <li>{@code topModels}         — list of {modelEngineId, runCount} ordered by runCount desc
+     *   <li>{@code runsByDay}         — list of {date (yyyy-MM-dd), count} for the last 7 days
+     * </ul>
+     */
+    public static Map<String, Object> getMetrics() {
+        IRDBMSEngine db = SystemEngineRegistry.getModelInferenceLogsDb();
+        Map<String, Object> metrics = new LinkedHashMap<>();
+        if (db == null) {
+            metrics.put("error", "ModelInferenceLogs database not available");
+            return metrics;
+        }
+
+        Connection conn = null;
+        PreparedStatement ps = null;
+        ResultSet rs = null;
+        try {
+            conn = db.getConnection();
+
+            // ── 1. Overall aggregates ──────────────────────────────────────────
+            String aggSql = "SELECT COUNT(*) AS total_runs,"
+                    + " SUM(CASE WHEN TERMINATION_REASON = 'text_response' THEN 1 ELSE 0 END) AS success_count,"
+                    + " AVG(ITERATIONS) AS avg_iterations,"
+                    + " SUM(TOOL_CALL_COUNT) AS total_tool_calls"
+                    + " FROM " + TABLE_AGENT_TRACE;
+            ps = conn.prepareStatement(aggSql);
+            rs = ps.executeQuery();
+            long totalRuns = 0;
+            long successCount = 0;
+            double avgIterations = 0;
+            long totalToolCalls = 0;
+            if (rs.next()) {
+                totalRuns      = rs.getLong("total_runs");
+                successCount   = rs.getLong("success_count");
+                avgIterations  = rs.getDouble("avg_iterations");
+                totalToolCalls = rs.getLong("total_tool_calls");
+            }
+            ConnectionUtils.closeAllConnectionsIfPooling(null, ps, rs);
+            ps = null; rs = null;
+
+            // ── 2. Average duration (Java-side to stay DB-agnostic) ───────────
+            String durSql = "SELECT " + COL_START_TIME + ", " + COL_END_TIME
+                    + " FROM " + TABLE_AGENT_TRACE
+                    + " WHERE " + COL_END_TIME + " IS NOT NULL";
+            ps = conn.prepareStatement(durSql);
+            rs = ps.executeQuery();
+            long durationSum = 0;
+            long durationCount = 0;
+            while (rs.next()) {
+                Timestamp start = rs.getTimestamp(COL_START_TIME);
+                Timestamp end   = rs.getTimestamp(COL_END_TIME);
+                if (start != null && end != null) {
+                    durationSum += (end.getTime() - start.getTime());
+                    durationCount++;
+                }
+            }
+            long avgDurationMs = durationCount > 0 ? durationSum / durationCount : 0;
+            ConnectionUtils.closeAllConnectionsIfPooling(null, ps, rs);
+            ps = null; rs = null;
+
+            // ── 3. Runs in last 24 hours ──────────────────────────────────────
+            long cutoff24h = System.currentTimeMillis() - (24L * 60 * 60 * 1000);
+            String recentSql = "SELECT COUNT(*) FROM " + TABLE_AGENT_TRACE
+                    + " WHERE " + COL_START_TIME + " >= ?";
+            ps = conn.prepareStatement(recentSql);
+            ps.setTimestamp(1, new Timestamp(cutoff24h));
+            rs = ps.executeQuery();
+            long runsLast24h = rs.next() ? rs.getLong(1) : 0;
+            ConnectionUtils.closeAllConnectionsIfPooling(null, ps, rs);
+            ps = null; rs = null;
+
+            // ── 4. Top models ─────────────────────────────────────────────────
+            String modelSql = "SELECT " + COL_MODEL_ENGINE_ID + ", COUNT(*) AS run_count"
+                    + " FROM " + TABLE_AGENT_TRACE
+                    + " GROUP BY " + COL_MODEL_ENGINE_ID
+                    + " ORDER BY run_count DESC";
+            ps = conn.prepareStatement(modelSql);
+            ps.setMaxRows(10);
+            rs = ps.executeQuery();
+            List<Map<String, Object>> topModels = new ArrayList<>();
+            while (rs.next()) {
+                Map<String, Object> m = new LinkedHashMap<>();
+                m.put("modelEngineId", rs.getString(COL_MODEL_ENGINE_ID));
+                m.put("runCount",      rs.getLong("run_count"));
+                topModels.add(m);
+            }
+            ConnectionUtils.closeAllConnectionsIfPooling(null, ps, rs);
+            ps = null; rs = null;
+
+            // ── 5. Runs by day — last 7 days (Java-side bucketing) ───────────
+            long cutoff7d = System.currentTimeMillis() - (7L * 24 * 60 * 60 * 1000);
+            String daysSql = "SELECT " + COL_START_TIME
+                    + " FROM " + TABLE_AGENT_TRACE
+                    + " WHERE " + COL_START_TIME + " >= ?";
+            ps = conn.prepareStatement(daysSql);
+            ps.setTimestamp(1, new Timestamp(cutoff7d));
+            rs = ps.executeQuery();
+            // Bucket by ISO date string
+            java.util.TreeMap<String, Integer> dayCounts = new java.util.TreeMap<>();
+            java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat("yyyy-MM-dd");
+            while (rs.next()) {
+                Timestamp ts = rs.getTimestamp(COL_START_TIME);
+                if (ts != null) {
+                    String day = sdf.format(new java.util.Date(ts.getTime()));
+                    dayCounts.merge(day, 1, Integer::sum);
+                }
+            }
+            List<Map<String, Object>> runsByDay = new ArrayList<>();
+            for (Map.Entry<String, Integer> entry : dayCounts.entrySet()) {
+                Map<String, Object> d = new LinkedHashMap<>();
+                d.put("date",  entry.getKey());
+                d.put("count", entry.getValue());
+                runsByDay.add(d);
+            }
+
+            // ── Assemble result ───────────────────────────────────────────────
+            metrics.put("totalRuns",      totalRuns);
+            metrics.put("runsLast24h",    runsLast24h);
+            metrics.put("avgIterations",  Math.round(avgIterations * 10.0) / 10.0);
+            metrics.put("avgDurationMs",  avgDurationMs);
+            metrics.put("successRate",    totalRuns > 0 ? Math.round((double) successCount / totalRuns * 1000.0) / 10.0 : 0.0);
+            metrics.put("totalToolCalls", totalToolCalls);
+            metrics.put("topModels",      topModels);
+            metrics.put("runsByDay",      runsByDay);
+
+        } catch (Exception e) {
+            classLogger.error("AgentTraceLogsUtils.getMetrics: failed.", e);
+            metrics.put("error", e.getMessage());
+        } finally {
+            ConnectionUtils.closeAllConnectionsIfPooling(db, conn, ps, rs);
+        }
+        return metrics;
+    }
+}

--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsOwlCreator.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsOwlCreator.java
@@ -47,6 +47,8 @@ public class ModelInferenceLogsOwlCreator {
 	private List<Pair<String, String>> feedbackColumns = null;
 	private List<Pair<String, String>> workspaceColumns = null;
 	private List<Pair<String, String>> workspaceResourceColumns = null;
+	private List<Pair<String, String>> agentTraceColumns = null;
+	private List<Pair<String, String>> agentTraceStepColumns = null;
 
 	// pairs table name with table's primary keys 
 	private List<Pair<String, Pair<List<String>, List<String>>>> primaryKeys = null;
@@ -66,6 +68,8 @@ public class ModelInferenceLogsOwlCreator {
 		conceptsRequired.add("FEEDBACK");
 		conceptsRequired.add("WORKSPACE");
 		conceptsRequired.add("WORKSPACE_RESOURCE");
+		conceptsRequired.add("AGENT_TRACE");
+		conceptsRequired.add("AGENT_TRACE_STEP");
 	}
 	
 	private IRDBMSEngine modelInferenceDb;
@@ -180,14 +184,42 @@ public class ModelInferenceLogsOwlCreator {
 				Pair.with("RESOURCE_TYPE", "VARCHAR(255)"),
 				Pair.with("RESOURCE_SUBTYPE", "VARCHAR(255)")
 			);
-		
+
+		this.agentTraceColumns = Arrays.asList(
+				Pair.with("TRACE_ID",           "VARCHAR(255)"),
+				Pair.with("ROOM_ID",            "VARCHAR(255)"),
+				Pair.with("USER_ID",            "VARCHAR(255)"),
+				Pair.with("MODEL_ENGINE_ID",    "VARCHAR(255)"),
+				Pair.with("START_TIME",         TIMESTAMP_DATATYPE_NAME),
+				Pair.with("END_TIME",           TIMESTAMP_DATATYPE_NAME),
+				Pair.with("ITERATIONS",         INTEGER_DATATYPE_NAME),
+				Pair.with("REFLECTIONS_USED",   INTEGER_DATATYPE_NAME),
+				Pair.with("TERMINATION_REASON", "VARCHAR(255)"),
+				Pair.with("METRICS_JSON",       CLOB_DATATYPE_NAME),
+				Pair.with("TOOL_CALL_COUNT",    INTEGER_DATATYPE_NAME)
+			);
+
+		this.agentTraceStepColumns = Arrays.asList(
+				Pair.with("TRACE_ID",            "VARCHAR(255)"),
+				Pair.with("STEP_INDEX",          INTEGER_DATATYPE_NAME),
+				Pair.with("RESPONSE_TYPE",       "VARCHAR(64)"),
+				Pair.with("INPUT_MESSAGE_ID",    "VARCHAR(255)"),
+				Pair.with("RESPONSE_MESSAGE_ID", "VARCHAR(255)"),
+				Pair.with("TOOL_CALLS_JSON",     CLOB_DATATYPE_NAME),
+				Pair.with("GUARDRAILS_JSON",     CLOB_DATATYPE_NAME),
+				Pair.with("TOKEN_COUNT",         INTEGER_DATATYPE_NAME),
+				Pair.with("STEP_TIMESTAMP",      TIMESTAMP_DATATYPE_NAME)
+			);
+
 		this.allSchemas = Arrays.asList(
 				Pair.with("AGENT", agentColumns),
 				Pair.with("ROOM", roomColumns),
 				Pair.with("MESSAGE", messageColumns),
 				Pair.with("FEEDBACK", feedbackColumns),
 				Pair.with("WORKSPACE", workspaceColumns),
-				Pair.with("WORKSPACE_RESOURCE", workspaceResourceColumns)
+				Pair.with("WORKSPACE_RESOURCE", workspaceResourceColumns),
+				Pair.with("AGENT_TRACE", agentTraceColumns),
+				Pair.with("AGENT_TRACE_STEP", agentTraceStepColumns)
 			);
 	}
 	

--- a/src/prerna/project/api/IProject.java
+++ b/src/prerna/project/api/IProject.java
@@ -56,9 +56,11 @@ public interface IProject extends IEngine, IMCP {
 	String DEPENDENCIES_FILE_SUFFIX = "_dependencies.json";
 	String BLOCK_FILE_NAME = "blocks.json";
 	String NOTEBOOK_FOLDER = ".notebooks";
+	String WORKFLOW_FOLDER = "workflow";
+	String WORKFLOW_FILE_NAME = "workflow.json";
 
 	enum PROJECT_TYPE {
-		BLOCKS, CODE, WORKSPACE, INSIGHTS
+		BLOCKS, CODE, WORKSPACE, INSIGHTS, WORKFLOW
 	};
 
 	/**

--- a/src/prerna/reactor/ReactorFactory.java
+++ b/src/prerna/reactor/ReactorFactory.java
@@ -410,6 +410,7 @@ import prerna.reactor.workflow.GetWorkflowStatusReactor;
 import prerna.reactor.workflow.ModifyInsightDatasourceReactor;
 import prerna.reactor.workflow.RunWorkflowReactor;
 import prerna.reactor.workflow.SaveWorkflowReactor;
+import prerna.reactor.agent.trace.AgentSummaryMetricsReactor;
 import prerna.reactor.workspace.DeleteUserAssetReactor;
 import prerna.reactor.workspace.MoveUserAssetReactor;
 import prerna.reactor.workspace.NewDirReactor;
@@ -1097,6 +1098,7 @@ public class ReactorFactory {
 		reactorHash.put("ResumeJobTrigger", ResumeJobTriggerReactor.class);
 		// Workflow Engine
 		reactorHash.put("RunWorkflow", RunWorkflowReactor.class);
+		reactorHash.put("AgentSummaryMetrics", AgentSummaryMetricsReactor.class);
 		reactorHash.put("SaveWorkflow", SaveWorkflowReactor.class);
 		reactorHash.put("GetWorkflowStatus", GetWorkflowStatusReactor.class);
 		// Recommendations

--- a/src/prerna/reactor/ReactorFactory.java
+++ b/src/prerna/reactor/ReactorFactory.java
@@ -406,7 +406,10 @@ import prerna.reactor.utils.SendEmailReactor;
 import prerna.reactor.utils.VariableExistsReactor;
 import prerna.reactor.workflow.GetInsightDatasourcesReactor;
 import prerna.reactor.workflow.GetOptimizedRecipeReactor;
+import prerna.reactor.workflow.GetWorkflowStatusReactor;
 import prerna.reactor.workflow.ModifyInsightDatasourceReactor;
+import prerna.reactor.workflow.RunWorkflowReactor;
+import prerna.reactor.workflow.SaveWorkflowReactor;
 import prerna.reactor.workspace.DeleteUserAssetReactor;
 import prerna.reactor.workspace.MoveUserAssetReactor;
 import prerna.reactor.workspace.NewDirReactor;
@@ -1092,6 +1095,10 @@ public class ReactorFactory {
 		reactorHash.put("PauseJobTrigger", PauseJobTriggerReactor.class);
 		reactorHash.put("ListAllJobs", ListAllJobsReactor.class);
 		reactorHash.put("ResumeJobTrigger", ResumeJobTriggerReactor.class);
+		// Workflow Engine
+		reactorHash.put("RunWorkflow", RunWorkflowReactor.class);
+		reactorHash.put("SaveWorkflow", SaveWorkflowReactor.class);
+		reactorHash.put("GetWorkflowStatus", GetWorkflowStatusReactor.class);
 		// Recommendations
 		reactorHash.put("DatabaseRecommendations", DatabaseRecommendationsReactor.class);
 		reactorHash.put("VizRecommendations", VizRecommendationsReactor.class);

--- a/src/prerna/reactor/agent/AgentHarnessResult.java
+++ b/src/prerna/reactor/agent/AgentHarnessResult.java
@@ -27,8 +27,15 @@
  *******************************************************************************/
 package prerna.reactor.agent;
 
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import prerna.engine.impl.model.message.MessageType;
 
 /**
  * Immutable result returned by {@link IAgentHarness#execute}.
@@ -39,9 +46,13 @@ import java.util.List;
  *   <li>The total number of agentic tool-call rounds performed.
  *   <li>A per-tool-call trace ({@link ToolCallRecord}) with the tool name, call ID,
  *       result content, wall-clock duration, and success/failure status.
+ *   <li>Optional full decision trace (traceId, steps, timing, terminationReason) populated
+ *       by harnesses that support tracing. Use {@link #builder()} to construct with trace data.
  * </ul>
  */
 public final class AgentHarnessResult {
+
+    // ── Core fields (always populated) ────────────────────────────────────────
 
     /** Final {@code RESPONSE_TEXT} content produced by the model. Never null; may be empty. */
     private final String finalText;
@@ -55,40 +66,225 @@ public final class AgentHarnessResult {
     /** Number of reflection rounds actually executed (0 if reflection was disabled). */
     private final int reflectionsUsed;
 
-    /** Backward-compatible constructor — sets {@code reflectionsUsed = 0}. */
+    // ── Trace fields (nullable — backward compatible) ─────────────────────────
+
+    /** UUID assigned at the start of this agent run. Null if harness does not populate it. */
+    private final String traceId;
+
+    /** Room ID this run was associated with. Null if not populated. */
+    private final String roomId;
+
+    /** Engine ID of the model used. Null if not populated. */
+    private final String modelEngineId;
+
+    /** Wall-clock start time of the full agent run. Null if not populated. */
+    private final Instant startTime;
+
+    /** Wall-clock end time of the full agent run (set in finally block). Null if not populated. */
+    private final Instant endTime;
+
+    /**
+     * Step-by-step trace of each tool-call round. Only observable artifacts — no provider-specific
+     * fields like reasoning tokens. Null if harness does not populate it.
+     */
+    private final List<DecisionStep> steps;
+
+    /** Aggregate metrics (cost, tokens, latency). Null if not populated. */
+    private final Map<String, Object> metrics;
+
+    /**
+     * Why the agent loop ended: {@code "SUCCESS"}, {@code "MAX_ITERATIONS"}, or
+     * {@code "EXCEPTION:<message>"}. Null if not populated.
+     */
+    private final String terminationReason;
+
+    // ── Backward-compatible constructors ──────────────────────────────────────
+
+    /** Backward-compatible constructor — sets {@code reflectionsUsed = 0} and all trace fields null. */
     public AgentHarnessResult(String finalText, int iterations, List<ToolCallRecord> toolCallRecords) {
         this(finalText, iterations, toolCallRecords, 0);
     }
 
+    /** Backward-compatible constructor — sets all trace fields null. */
     public AgentHarnessResult(String finalText, int iterations, List<ToolCallRecord> toolCallRecords,
                               int reflectionsUsed) {
-        this.finalText        = finalText != null ? finalText : "";
-        this.iterations       = iterations;
-        this.toolCallRecords  = Collections.unmodifiableList(toolCallRecords);
-        this.reflectionsUsed  = reflectionsUsed;
+        this.finalText         = finalText != null ? finalText : "";
+        this.iterations        = iterations;
+        this.toolCallRecords   = Collections.unmodifiableList(toolCallRecords);
+        this.reflectionsUsed   = reflectionsUsed;
+        this.traceId           = null;
+        this.roomId            = null;
+        this.modelEngineId     = null;
+        this.startTime         = null;
+        this.endTime           = null;
+        this.steps             = null;
+        this.metrics           = null;
+        this.terminationReason = null;
     }
+
+    private AgentHarnessResult(Builder b) {
+        this.finalText         = b.finalText != null ? b.finalText : "";
+        this.iterations        = b.iterations;
+        this.toolCallRecords   = Collections.unmodifiableList(b.toolCallRecords);
+        this.reflectionsUsed   = b.reflectionsUsed;
+        this.traceId           = b.traceId;
+        this.roomId            = b.roomId;
+        this.modelEngineId     = b.modelEngineId;
+        this.startTime         = b.startTime;
+        this.endTime           = b.endTime;
+        this.steps             = b.steps != null
+                ? Collections.unmodifiableList(b.steps) : null;
+        this.metrics           = b.metrics != null
+                ? Collections.unmodifiableMap(b.metrics) : null;
+        this.terminationReason = b.terminationReason;
+    }
+
+    // ── Core accessors ────────────────────────────────────────────────────────
 
     /** Final text content of the model's {@code RESPONSE_TEXT} message. */
-    public String getFinalText() {
-        return finalText;
-    }
+    public String getFinalText() { return finalText; }
 
     /** Number of tool-call rounds the harness completed before obtaining the final text. */
-    public int getIterations() {
-        return iterations;
-    }
+    public int getIterations() { return iterations; }
 
     /** Number of reflection rounds executed (0 if {@code maxReflections} was 0). */
-    public int getReflectionsUsed() {
-        return reflectionsUsed;
-    }
+    public int getReflectionsUsed() { return reflectionsUsed; }
 
     /** Ordered list of all tool calls made during this run. */
-    public List<ToolCallRecord> getToolCallRecords() {
-        return toolCallRecords;
+    public List<ToolCallRecord> getToolCallRecords() { return toolCallRecords; }
+
+    // ── Trace accessors ───────────────────────────────────────────────────────
+
+    /** UUID for this run. Null if this result was created via the legacy constructors. */
+    public String getTraceId() { return traceId; }
+
+    /** Room ID for this run. Null if not populated. */
+    public String getRoomId() { return roomId; }
+
+    /** Model engine ID used during this run. Null if not populated. */
+    public String getModelEngineId() { return modelEngineId; }
+
+    /** Run start time. Null if not populated. */
+    public Instant getStartTime() { return startTime; }
+
+    /** Run end time (always set, even on failure). Null if not populated. */
+    public Instant getEndTime() { return endTime; }
+
+    /** Per-step decision trace. Null if not populated. */
+    public List<DecisionStep> getSteps() { return steps; }
+
+    /** Aggregate metrics map. Null if not populated. */
+    public Map<String, Object> getMetrics() { return metrics; }
+
+    /**
+     * Why the run ended. {@code "SUCCESS"}, {@code "MAX_ITERATIONS"}, or
+     * {@code "EXCEPTION:<message>"}. Null if not populated.
+     */
+    public String getTerminationReason() { return terminationReason; }
+
+    // ── Builder ───────────────────────────────────────────────────────────────
+
+    public static Builder builder() { return new Builder(); }
+
+    public static final class Builder {
+        private String               finalText         = "";
+        private int                  iterations        = 0;
+        private List<ToolCallRecord> toolCallRecords   = new ArrayList<>();
+        private int                  reflectionsUsed   = 0;
+        private String               traceId           = UUID.randomUUID().toString();
+        private String               roomId;
+        private String               modelEngineId;
+        private Instant              startTime;
+        private Instant              endTime;
+        private List<DecisionStep>   steps             = new ArrayList<>();
+        private Map<String, Object>  metrics           = new HashMap<>();
+        private String               terminationReason;
+
+        public Builder finalText(String v)               { this.finalText = v;         return this; }
+        public Builder iterations(int v)                 { this.iterations = v;        return this; }
+        public Builder toolCallRecords(List<ToolCallRecord> v) { this.toolCallRecords = v != null ? v : new ArrayList<>(); return this; }
+        public Builder reflectionsUsed(int v)            { this.reflectionsUsed = v;   return this; }
+        public Builder traceId(String v)                 { this.traceId = v;           return this; }
+        public Builder roomId(String v)                  { this.roomId = v;            return this; }
+        public Builder modelEngineId(String v)           { this.modelEngineId = v;     return this; }
+        public Builder startTime(Instant v)              { this.startTime = v;         return this; }
+        public Builder endTime(Instant v)                { this.endTime = v;           return this; }
+        public Builder addStep(DecisionStep step)        { this.steps.add(step);       return this; }
+        public Builder steps(List<DecisionStep> v)       { this.steps = v != null ? v : new ArrayList<>(); return this; }
+        public Builder metric(String key, Object value)  { this.metrics.put(key, value); return this; }
+        public Builder metrics(Map<String, Object> v)    { this.metrics = v != null ? v : new HashMap<>(); return this; }
+        public Builder terminationReason(String v)       { this.terminationReason = v; return this; }
+
+        public AgentHarnessResult build() { return new AgentHarnessResult(this); }
     }
 
-    // ToolCallRecord
+    // ── DecisionStep ─────────────────────────────────────────────────────────
+
+    /**
+     * One iteration of the agent loop — observable artifacts only.
+     *
+     * <p>No provider-specific fields (e.g. no reasoning tokens — Anthropic-only and a data-leak
+     * path). We trace message IDs (references, not content), tool call records, guardrails fired,
+     * token counts, and timing — uniform across all {@link IAgentHarness} implementations.
+     */
+    public static final class DecisionStep {
+        private final int                  stepIndex;
+        private final MessageType          modelResponseType;
+        private final String               inputMessageId;
+        private final String               responseMessageId;
+        private final List<ToolCallRecord> toolCalls;
+        private final List<String>         guardrailsFired;
+        private final long                 tokenCount;
+        private final Instant              timestamp;
+
+        private DecisionStep(StepBuilder b) {
+            this.stepIndex         = b.stepIndex;
+            this.modelResponseType = b.modelResponseType;
+            this.inputMessageId    = b.inputMessageId;
+            this.responseMessageId = b.responseMessageId;
+            this.toolCalls         = b.toolCalls != null
+                    ? Collections.unmodifiableList(b.toolCalls) : Collections.emptyList();
+            this.guardrailsFired   = b.guardrailsFired != null
+                    ? Collections.unmodifiableList(b.guardrailsFired) : Collections.emptyList();
+            this.tokenCount        = b.tokenCount;
+            this.timestamp         = b.timestamp != null ? b.timestamp : Instant.now();
+        }
+
+        public int getStepIndex()                { return stepIndex; }
+        public MessageType getModelResponseType(){ return modelResponseType; }
+        public String getInputMessageId()        { return inputMessageId; }
+        public String getResponseMessageId()     { return responseMessageId; }
+        public List<ToolCallRecord> getToolCalls(){ return toolCalls; }
+        public List<String> getGuardrailsFired() { return guardrailsFired; }
+        public long getTokenCount()              { return tokenCount; }
+        public Instant getTimestamp()            { return timestamp; }
+
+        public static StepBuilder builder()      { return new StepBuilder(); }
+
+        public static final class StepBuilder {
+            private int                  stepIndex;
+            private MessageType          modelResponseType;
+            private String               inputMessageId;
+            private String               responseMessageId;
+            private List<ToolCallRecord> toolCalls      = new ArrayList<>();
+            private List<String>         guardrailsFired = new ArrayList<>();
+            private long                 tokenCount;
+            private Instant              timestamp;
+
+            public StepBuilder stepIndex(int v)                    { this.stepIndex = v;           return this; }
+            public StepBuilder modelResponseType(MessageType v)    { this.modelResponseType = v;   return this; }
+            public StepBuilder inputMessageId(String v)            { this.inputMessageId = v;      return this; }
+            public StepBuilder responseMessageId(String v)         { this.responseMessageId = v;   return this; }
+            public StepBuilder toolCalls(List<ToolCallRecord> v)   { this.toolCalls = v;           return this; }
+            public StepBuilder addGuardrailFired(String v)         { this.guardrailsFired.add(v);  return this; }
+            public StepBuilder tokenCount(long v)                  { this.tokenCount = v;          return this; }
+            public StepBuilder timestamp(Instant v)                { this.timestamp = v;           return this; }
+
+            public DecisionStep build()                            { return new DecisionStep(this); }
+        }
+    }
+
+    // ── ToolCallRecord ────────────────────────────────────────────────────────
 
     /**
      * Immutable record of a single MCP tool invocation inside the agentic loop.

--- a/src/prerna/reactor/agent/RoomAgentHarness.java
+++ b/src/prerna/reactor/agent/RoomAgentHarness.java
@@ -27,6 +27,7 @@
  *******************************************************************************/
 package prerna.reactor.agent;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -40,6 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import prerna.engine.impl.model.inferencetracking.AgentTraceLogsUtils;
 import prerna.engine.api.IEngine;
 import prerna.engine.api.IMCP;
 import prerna.engine.impl.MCPFactory;
@@ -74,7 +76,7 @@ import prerna.util.Utility;
  */
 public class RoomAgentHarness implements IAgentHarness {
 
-    private static final Logger logger = LogManager.getLogger(RoomAgentHarness.class);
+    private static final Logger classLogger = LogManager.getLogger(RoomAgentHarness.class);
 
     /** Registry name used by {@link AgentHarnessRegistry}. */
     public static final String NAME = "room_loop";
@@ -121,57 +123,113 @@ public class RoomAgentHarness implements IAgentHarness {
         Map<String, Object> paramMap       = new HashMap<>(ctx.getParamMap());
 
         List<AgentHarnessResult.ToolCallRecord> toolCallRecords = new ArrayList<>();
+        List<AgentHarnessResult.DecisionStep>   decisionSteps   = new ArrayList<>();
         AtomicInteger iterationsCounter = new AtomicInteger(0);
 
-        // 1. Initial ask
-        String systemPrompt = room.getEffectiveSystemPrompt();
-        InputMessage firstMsg = InputMessage.builder(room)
-                .withSystemPrompt(systemPrompt)
-                .withText(ctx.getInput())
-                .withModelType(ctx.getModelEngine().getModelType())
-                .withParamMap(paramMap)
-                .build();
+        // Resolve content-logging policy on the calling thread so it can safely cross
+        // thread boundaries when we dispatch trace persistence asynchronously.
+        String  modelEngineId  = ctx.getModelEngine() != null ? ctx.getModelEngine().getEngineId() : null;
+        boolean keepContent;
+        try {
+            keepContent = ctx.getModelEngine() != null && ctx.getModelEngine().keepInputOutput();
+        } catch (Exception e) {
+            keepContent = false;
+        }
 
-        logger.info("RoomAgentHarness: initial ask room={} model={} inputLength={}",
-                room.getId(), ctx.getModelEngine().getEngineId(), ctx.getInput().length());
-        ResponseMessage response = room.ask(firstMsg, ctx.getModelEngine(), null);
+        // Build the trace — populated incrementally and always emitted (even on failure).
+        AgentHarnessResult.Builder traceBuilder = AgentHarnessResult.builder()
+                .roomId(room.getId())
+                .modelEngineId(modelEngineId)
+                .startTime(Instant.now());
 
-        // 2. Tool loop
-        response = driveToolLoop(response, iterationsCounter, paramMap, toolCallRecords, ctx);
+        String terminationReason = "SUCCESS";
 
-        // 3. Reflection rounds
-        int reflectionsUsed = 0;
-        while (reflectionsUsed < maxReflections
-                && response != null
-                && response.getMessageType() == MessageType.RESPONSE_TEXT) {
-
-            reflectionsUsed++;
-            logger.info("RoomAgentHarness: reflection round {}/{}", reflectionsUsed, maxReflections);
-
-            InputMessage reflectionMsg = InputMessage.builder(room)
+        try {
+            // 1. Initial ask
+            String systemPrompt = room.getEffectiveSystemPrompt();
+            InputMessage firstMsg = InputMessage.builder(room)
                     .withSystemPrompt(systemPrompt)
-                    .withText(REFLECTION_PROMPT)
+                    .withText(ctx.getInput())
                     .withModelType(ctx.getModelEngine().getModelType())
-                    .withParamMap(new HashMap<>(paramMap))
+                    .withParamMap(paramMap)
                     .build();
 
-            response = room.ask(reflectionMsg, ctx.getModelEngine(), null);
+            classLogger.info("RoomAgentHarness: initial ask room={} model={} inputLength={}",
+                    room.getId(), ctx.getModelEngine().getEngineId(), ctx.getInput().length());
+            ResponseMessage response = room.ask(firstMsg, ctx.getModelEngine(), null);
 
-            if (response != null && response.getMessageType() == MessageType.RESPONSE_TOOL) {
-                response = driveToolLoop(response, iterationsCounter, paramMap, toolCallRecords, ctx);
+            // 2. Tool loop
+            response = driveToolLoop(response, iterationsCounter, paramMap, toolCallRecords, decisionSteps, ctx);
+
+            // 3. Reflection rounds
+            int reflectionsUsed = 0;
+            while (reflectionsUsed < maxReflections
+                    && response != null
+                    && response.getMessageType() == MessageType.RESPONSE_TEXT) {
+
+                reflectionsUsed++;
+                classLogger.info("RoomAgentHarness: reflection round {}/{}", reflectionsUsed, maxReflections);
+
+                InputMessage reflectionMsg = InputMessage.builder(room)
+                        .withSystemPrompt(systemPrompt)
+                        .withText(REFLECTION_PROMPT)
+                        .withModelType(ctx.getModelEngine().getModelType())
+                        .withParamMap(new HashMap<>(paramMap))
+                        .build();
+
+                response = room.ask(reflectionMsg, ctx.getModelEngine(), null);
+
+                if (response != null && response.getMessageType() == MessageType.RESPONSE_TOOL) {
+                    response = driveToolLoop(response, iterationsCounter, paramMap, toolCallRecords, decisionSteps, ctx);
+                }
             }
-        }
 
-        // 4. Iteration cap check
-        if (response != null && response.getMessageType() == MessageType.RESPONSE_TOOL) {
-            logger.warn("RoomAgentHarness: maxIterations ({}) reached without RESPONSE_TEXT",
-                    ctx.getMaxIterations());
-            throw new AgentMaxIterationsException(ctx.getMaxIterations());
-        }
+            // 4. Iteration cap check
+            if (response != null && response.getMessageType() == MessageType.RESPONSE_TOOL) {
+                terminationReason = "MAX_ITERATIONS";
+                classLogger.warn("RoomAgentHarness: maxIterations ({}) reached without RESPONSE_TEXT",
+                        ctx.getMaxIterations());
+                throw new AgentMaxIterationsException(ctx.getMaxIterations());
+            }
 
-        // 5. Return result
-        String content = (response != null) ? response.getContent() : null;
-        return new AgentHarnessResult(content, iterationsCounter.get(), toolCallRecords, reflectionsUsed);
+            // 5. Build result with trace
+            String content = (response != null) ? response.getContent() : null;
+            return traceBuilder
+                    .finalText(content)
+                    .iterations(iterationsCounter.get())
+                    .toolCallRecords(toolCallRecords)
+                    .reflectionsUsed(reflectionsUsed)
+                    .steps(decisionSteps)
+                    .terminationReason(terminationReason)
+                    .endTime(Instant.now())
+                    .build();
+
+        } catch (AgentMaxIterationsException e) {
+            // Already set terminationReason = "MAX_ITERATIONS" above; rethrow for caller.
+            throw e;
+        } catch (Exception e) {
+            terminationReason = "EXCEPTION:" + e.getMessage();
+            throw e;
+        } finally {
+            // Always persist the trace (even partial / failed runs) — failures are the most
+            // valuable runs to debug. Capture all scalars here; do not pass mutable objects.
+            final AgentHarnessResult traceResult = traceBuilder
+                    .endTime(Instant.now())
+                    .terminationReason(terminationReason)
+                    .toolCallRecords(toolCallRecords)
+                    .steps(decisionSteps)
+                    .build();
+            final String  capturedUserId      = ctx.getUserId();
+            final boolean capturedKeepContent = keepContent;
+            CompletableFuture.runAsync(() -> {
+                try {
+                    AgentTraceLogsUtils.logTrace(traceResult, capturedUserId, capturedKeepContent);
+                } catch (Exception ex) {
+                    classLogger.warn("RoomAgentHarness: async trace persistence failed for trace={}",
+                            traceResult.getTraceId(), ex);
+                }
+            });
+        }
     }
 
     /**
@@ -182,6 +240,7 @@ public class RoomAgentHarness implements IAgentHarness {
      * Single-tool responses use the fast path without thread overhead.
      *
      * @param iterationsCounter accumulates iteration count across multiple driveToolLoop calls
+     * @param decisionSteps     accumulator for {@link AgentHarnessResult.DecisionStep} records
      */
     @SuppressWarnings("unchecked")
     private ResponseMessage driveToolLoop(
@@ -189,6 +248,7 @@ public class RoomAgentHarness implements IAgentHarness {
             AtomicInteger iterationsCounter,
             Map<String, Object> paramMap,
             List<AgentHarnessResult.ToolCallRecord> toolCallRecords,
+            List<AgentHarnessResult.DecisionStep> decisionSteps,
             AgentRunContext ctx) throws Exception {
 
         Room room          = ctx.getRoom();
@@ -202,6 +262,9 @@ public class RoomAgentHarness implements IAgentHarness {
 
             String parentMessageId = response.getMessageId();
             List<Map<String, Object>> toolCalls = response.getToolResponses();
+
+            // Capture pre-iteration tail to compute DecisionStep.toolCalls delta below.
+            int preIterToolCallSize = toolCallRecords.size();
 
             AskModelEngineResponse<?> nextModelResponse = null;
 
@@ -217,7 +280,7 @@ public class RoomAgentHarness implements IAgentHarness {
                 // Room.addToolExecutionResult() is synchronized and only triggers the next model
                 // call once every tool ID in the batch has been answered, so concurrent
                 // submissions from multiple threads are safe.
-                logger.info("RoomAgentHarness executing {} tools in parallel iter={}",
+                classLogger.info("RoomAgentHarness executing {} tools in parallel iter={}",
                         toolCalls.size(), iterations);
                 ExecutorService pool = Executors.newFixedThreadPool(toolCalls.size());
                 try {
@@ -240,7 +303,7 @@ public class RoomAgentHarness implements IAgentHarness {
                             toolCallRecords.add(r.record);
                             if (r.modelResponse != null) nextModelResponse = r.modelResponse;
                         } catch (ExecutionException e) {
-                            logger.error("RoomAgentHarness: tool execution threw unexpectedly", e.getCause());
+                            classLogger.error("RoomAgentHarness: tool execution threw unexpectedly", e.getCause());
                         }
                     }
                 } finally {
@@ -253,13 +316,24 @@ public class RoomAgentHarness implements IAgentHarness {
                 if (lastMsg instanceof ResponseMessage) {
                     response = (ResponseMessage) lastMsg;
                 } else {
-                    logger.warn("RoomAgentHarness: unexpected last message type: {}",
+                    classLogger.warn("RoomAgentHarness: unexpected last message type: {}",
                             lastMsg == null ? "null" : lastMsg.getClass().getName());
                     break;
                 }
             } else {
                 break;
             }
+
+            // Record a DecisionStep for this tool-call round (observable artifacts only).
+            // Compute delta: tool call records added during this iteration only.
+            List<AgentHarnessResult.ToolCallRecord> stepRecords =
+                    new ArrayList<>(toolCallRecords.subList(preIterToolCallSize, toolCallRecords.size()));
+            decisionSteps.add(AgentHarnessResult.DecisionStep.builder()
+                    .stepIndex(iterations)
+                    .modelResponseType(MessageType.RESPONSE_TOOL)
+                    .responseMessageId(parentMessageId)
+                    .toolCalls(stepRecords)
+                    .build());
         }
 
         return response;
@@ -302,12 +376,12 @@ public class RoomAgentHarness implements IAgentHarness {
     private ToolExecResult executeOneTool(ParsedToolCall tc, int iter, Map<String, Object> paramMap,
                                           String parentMessageId, AgentRunContext ctx) {
         Room room = ctx.getRoom();
-        logger.info("RoomAgentHarness executing tool: name={} callId={} iter={}",
+        classLogger.info("RoomAgentHarness executing tool: name={} callId={} iter={}",
                 tc.rawToolName, tc.toolCallId, iter);
         long startMs = System.currentTimeMillis();
         ToolExecOutcome outcome = executeToolSafely(tc.rawToolName, tc.toolParams, ctx);
         long durationMs = System.currentTimeMillis() - startMs;
-        logger.info("RoomAgentHarness tool result: name={} durationMs={} success={}",
+        classLogger.info("RoomAgentHarness tool result: name={} durationMs={} success={}",
                 tc.rawToolName, durationMs, outcome.success);
 
         AgentHarnessResult.ToolCallRecord record = new AgentHarnessResult.ToolCallRecord(
@@ -341,7 +415,7 @@ public class RoomAgentHarness implements IAgentHarness {
         if (parsed == null) {
             String msg = "Tool execution error: cannot parse engine/project id from tool name '"
                     + rawToolName + "'";
-            logger.warn("RoomAgentHarness: {}", msg);
+            classLogger.warn("RoomAgentHarness: {}", msg);
             return new ToolExecOutcome(msg, false);
         }
         String engineId = parsed[0];
@@ -353,7 +427,7 @@ public class RoomAgentHarness implements IAgentHarness {
             return new ToolExecOutcome(result, success);
         } catch (Exception e) {
             String msg = "Tool execution error: " + e.getMessage();
-            logger.warn("RoomAgentHarness: uncaught exception from tool '{}': {}", rawToolName, e.getMessage(), e);
+            classLogger.warn("RoomAgentHarness: uncaught exception from tool '{}'", rawToolName, e);
             return new ToolExecOutcome(msg, false);
         }
     }

--- a/src/prerna/reactor/agent/eval/AgentEvalContext.java
+++ b/src/prerna/reactor/agent/eval/AgentEvalContext.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); ...
+ *******************************************************************************/
+package prerna.reactor.agent.eval;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import prerna.reactor.agent.AgentHarnessResult;
+
+/**
+ * Immutable context object passed to {@link prerna.engine.api.IEvalEngine#evaluate}.
+ *
+ * <p>Eval engines must NOT reach into globals or the database to get context — everything
+ * they need is in this object. This makes eval engines testable in isolation and prevents
+ * security bypasses.
+ *
+ * <p>Built via {@link #builder()}.
+ */
+public final class AgentEvalContext {
+
+    private final String               traceId;
+    private final String               roomId;
+    private final String               modelEngineId;
+    private final String               userId;
+    private final String               originalInput;
+    private final AgentHarnessResult   result;
+    private final Map<String, Object>  taskSpec;
+    private final List<AgentHarnessResult.DecisionStep> steps;
+
+    private AgentEvalContext(Builder b) {
+        this.traceId       = b.traceId;
+        this.roomId        = b.roomId;
+        this.modelEngineId = b.modelEngineId;
+        this.userId        = b.userId;
+        this.originalInput = b.originalInput;
+        this.result        = b.result;
+        this.taskSpec      = b.taskSpec != null
+                ? Collections.unmodifiableMap(b.taskSpec) : Collections.emptyMap();
+        this.steps         = b.steps != null
+                ? Collections.unmodifiableList(b.steps) : Collections.emptyList();
+    }
+
+    public String getTraceId()       { return traceId; }
+    public String getRoomId()        { return roomId; }
+    public String getModelEngineId() { return modelEngineId; }
+    public String getUserId()        { return userId; }
+    /** The original user input that started the agent run. */
+    public String getOriginalInput() { return originalInput; }
+    /** The full agent run result including tool call records. */
+    public AgentHarnessResult getResult() { return result; }
+    /** Task spec from Room options, if provided. Empty map if not set. */
+    public Map<String, Object> getTaskSpec() { return taskSpec; }
+    /** Normalized step trace (same as result.getSteps(), for convenience). */
+    public List<AgentHarnessResult.DecisionStep> getSteps() { return steps; }
+
+    public static Builder builder() { return new Builder(); }
+
+    public static final class Builder {
+        private String               traceId;
+        private String               roomId;
+        private String               modelEngineId;
+        private String               userId;
+        private String               originalInput;
+        private AgentHarnessResult   result;
+        private Map<String, Object>  taskSpec;
+        private List<AgentHarnessResult.DecisionStep> steps;
+
+        public Builder traceId(String v)       { this.traceId = v;       return this; }
+        public Builder roomId(String v)        { this.roomId = v;        return this; }
+        public Builder modelEngineId(String v) { this.modelEngineId = v; return this; }
+        public Builder userId(String v)        { this.userId = v;        return this; }
+        public Builder originalInput(String v) { this.originalInput = v; return this; }
+        public Builder result(AgentHarnessResult v) { this.result = v;   return this; }
+        public Builder taskSpec(Map<String, Object> v) { this.taskSpec = v; return this; }
+        public Builder steps(List<AgentHarnessResult.DecisionStep> v) { this.steps = v; return this; }
+
+        public AgentEvalContext build() {
+            if (traceId == null) throw new IllegalStateException("traceId is required");
+            if (result == null)  throw new IllegalStateException("result is required");
+            return new AgentEvalContext(this);
+        }
+    }
+
+    /** Convenience factory — derives all fields directly from a traced result. */
+    public static AgentEvalContext fromResult(AgentHarnessResult result, String originalInput,
+            Map<String, Object> taskSpec) {
+        return builder()
+                .traceId(result.getTraceId())
+                .roomId(result.getRoomId())
+                .modelEngineId(result.getModelEngineId())
+                .originalInput(originalInput)
+                .result(result)
+                .taskSpec(taskSpec)
+                .steps(result.getSteps())
+                .build();
+    }
+}

--- a/src/prerna/reactor/agent/eval/EvalResult.java
+++ b/src/prerna/reactor/agent/eval/EvalResult.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); ...
+ *******************************************************************************/
+package prerna.reactor.agent.eval;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Result of running an {@link prerna.engine.api.IEvalEngine} against a single agent trace.
+ */
+public final class EvalResult {
+
+    public enum Status { PASS, FAIL, ERROR }
+
+    /** A single failure finding from an eval engine. */
+    public static final class Failure {
+        private final String code;
+        private final String message;
+        public Failure(String code, String message) { this.code = code; this.message = message; }
+        public String getCode()    { return code;    }
+        public String getMessage() { return message; }
+        @Override public String toString() { return code + ": " + message; }
+    }
+
+    private final String        traceId;
+    private final String        evalEngineId;
+    private final Status        status;
+    private final List<Failure> failures;
+    private final double        score;
+    /** Non-null when {@code status == Status.ERROR}. */
+    private final String        errorCause;
+
+    private EvalResult(Builder b) {
+        this.traceId      = b.traceId;
+        this.evalEngineId = b.evalEngineId;
+        this.failures     = Collections.unmodifiableList(b.failures);
+        this.status       = b.errored ? Status.ERROR : (b.failures.isEmpty() ? Status.PASS : Status.FAIL);
+        this.score        = b.score;
+        this.errorCause   = b.errorCause;
+    }
+
+    public String getTraceId()        { return traceId; }
+    public String getEvalEngineId()   { return evalEngineId; }
+    public Status getStatus()         { return status; }
+    public boolean isPassed()         { return status == Status.PASS; }
+    public List<Failure> getFailures(){ return failures; }
+    /** Normalized score 0.0–1.0. Meaning is eval-engine-specific. 1.0 = full pass. */
+    public double getScore()          { return score; }
+    /** Non-null when status is {@code ERROR}. Contains the exception or error message. */
+    public String getErrorCause()     { return errorCause; }
+
+    public static Builder builder(String traceId, String evalEngineId) {
+        return new Builder(traceId, evalEngineId);
+    }
+
+    public static final class Builder {
+        private final String        traceId;
+        private final String        evalEngineId;
+        private final List<Failure> failures = new ArrayList<>();
+        private double              score    = 1.0;
+        private boolean             errored  = false;
+        private String              errorCause;
+
+        private Builder(String traceId, String evalEngineId) {
+            this.traceId = traceId;
+            this.evalEngineId = evalEngineId;
+        }
+
+        public Builder addFailure(String code, String message) {
+            this.failures.add(new Failure(code, message));
+            this.score = 0.0;
+            return this;
+        }
+        public Builder score(double v) { this.score = v; return this; }
+
+        /** Marks this result as an evaluation error (e.g. the eval engine itself threw). */
+        public Builder error(String cause) {
+            this.errored    = true;
+            this.errorCause = cause;
+            this.score      = 0.0;
+            return this;
+        }
+
+        public EvalResult build() { return new EvalResult(this); }
+    }
+}

--- a/src/prerna/reactor/agent/eval/EvalSpec.java
+++ b/src/prerna/reactor/agent/eval/EvalSpec.java
@@ -1,0 +1,87 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); ...
+ *******************************************************************************/
+package prerna.reactor.agent.eval;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Describes what an {@link prerna.engine.api.IEvalEngine} checks and how it scores.
+ * Loaded from .smss config in {@link prerna.engine.api.IEvalEngine#open}.
+ */
+public final class EvalSpec {
+
+    private final String       evalEngineId;
+    private final String       evalType;
+    private final List<String> requiredOutcomes;
+    private final List<String> forbiddenActions;
+    private final int          maxAllowedIterations;
+    private final long         maxAllowedDurationSeconds;
+
+    private EvalSpec(Builder b) {
+        this.evalEngineId             = b.evalEngineId;
+        this.evalType                 = b.evalType;
+        this.requiredOutcomes         = Collections.unmodifiableList(b.requiredOutcomes);
+        this.forbiddenActions         = Collections.unmodifiableList(b.forbiddenActions);
+        this.maxAllowedIterations     = b.maxAllowedIterations;
+        this.maxAllowedDurationSeconds = b.maxAllowedDurationSeconds;
+    }
+
+    public String       getEvalEngineId()              { return evalEngineId; }
+    public String       getEvalType()                  { return evalType; }
+    public List<String> getRequiredOutcomes()          { return requiredOutcomes; }
+    public List<String> getForbiddenActions()          { return forbiddenActions; }
+    public int          getMaxAllowedIterations()      { return maxAllowedIterations; }
+    public long         getMaxAllowedDurationSeconds() { return maxAllowedDurationSeconds; }
+
+    public static Builder builder(String evalEngineId) { return new Builder(evalEngineId); }
+
+    public static final class Builder {
+        private final String   evalEngineId;
+        private String         evalType                  = "TASK_SUCCESS";
+        private List<String>   requiredOutcomes          = Collections.emptyList();
+        private List<String>   forbiddenActions          = Collections.emptyList();
+        private int            maxAllowedIterations      = 30;
+        private long           maxAllowedDurationSeconds = 120;
+
+        private Builder(String evalEngineId) { this.evalEngineId = evalEngineId; }
+
+        public Builder evalType(String v)                       { this.evalType = v; return this; }
+        public Builder requiredOutcomes(List<String> v)         { this.requiredOutcomes = v; return this; }
+        public Builder forbiddenActions(List<String> v)         { this.forbiddenActions = v; return this; }
+        public Builder maxAllowedIterations(int v)              { this.maxAllowedIterations = v; return this; }
+        public Builder maxAllowedDurationSeconds(long v)        { this.maxAllowedDurationSeconds = v; return this; }
+
+        public EvalSpec build() { return new EvalSpec(this); }
+    }
+}

--- a/src/prerna/reactor/agent/policy/IAgentPolicy.java
+++ b/src/prerna/reactor/agent/policy/IAgentPolicy.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); ...
+ *******************************************************************************/
+package prerna.reactor.agent.policy;
+
+import prerna.reactor.agent.AgentHarnessResult;
+import prerna.reactor.agent.AgentRunContext;
+
+/**
+ * Agent-level policy enforcement — distinct from content-level guardrails.
+ *
+ * <p>This interface governs task-level execution: whether a run is allowed to start, whether
+ * it should continue, and whether its outputs are acceptable.
+ *
+ * <p>Do NOT conflate with {@link prerna.engine.api.IGuardrailReactorFunctionEngine}, which
+ * handles content-level safety (prompt injection, PII, toxic content) during execution.
+ * Agent policy operates at the task and budget level, not the content level.
+ *
+ * <h3>Lifecycle</h3>
+ * <pre>
+ * 1. preRunCheck  — before the harness starts (permissions, resource budgets)
+ * 2. iterationCheck — each tool-call round (budget remaining, deadline)
+ * 3. postRunCheck — after harness completes (actions taken, output compliance)
+ * </pre>
+ *
+ * <p><strong>Phase 3 scaffold — implementations pending.</strong>
+ * See {@code ProjectAgentPolicy} and {@code PolicyAgentHarness} in the backlog.
+ */
+public interface IAgentPolicy {
+
+    /**
+     * Pre-run check: should this agent run be allowed to start?
+     *
+     * @param ctx fully-resolved run context
+     * @return policy decision (ALLOW, BLOCK, or ESCALATE_TO_HUMAN)
+     */
+    PolicyDecision preRunCheck(AgentRunContext ctx);
+
+    /**
+     * Per-iteration check: should the agent continue to the next tool-call round?
+     *
+     * @param ctx              run context
+     * @param currentIteration iteration number (1-based)
+     * @return policy decision
+     */
+    PolicyDecision iterationCheck(AgentRunContext ctx, int currentIteration);
+
+    /**
+     * Post-run check: was the completed run acceptable?
+     *
+     * @param ctx    run context
+     * @param result completed harness result
+     * @return policy decision (ALLOW logs the run; BLOCK flags it for audit)
+     */
+    PolicyDecision postRunCheck(AgentRunContext ctx, AgentHarnessResult result);
+}

--- a/src/prerna/reactor/agent/policy/PolicyDecision.java
+++ b/src/prerna/reactor/agent/policy/PolicyDecision.java
@@ -25,28 +25,48 @@
  * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * 	GNU General Public License for more details.
  *******************************************************************************/
-package prerna.reactor.workflow.engine.handlers;
-
-import java.util.Map;
-
-import prerna.om.Insight;
-import prerna.reactor.workflow.engine.StepResult;
-import prerna.reactor.workflow.engine.WorkflowContext;
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); ...
+ *******************************************************************************/
+package prerna.reactor.agent.policy;
 
 /**
- * Simplest handler — returns a static value from config.
- * Useful for injecting constants, default values, or test data into a workflow.
- * 
- * Config:
- *   value — the value to output (any type)
+ * Result of an {@link IAgentPolicy} check — what should happen and why.
  */
-public class StaticStepHandler implements IWorkflowStepHandler {
+public final class PolicyDecision {
 
-	@Override
-	public StepResult execute(String stepId, Map<String, Object> config,
-			WorkflowContext context, Insight insight) {
-		long start = System.currentTimeMillis();
-		Object value = config.get("value");
-		return StepResult.success(stepId, value, System.currentTimeMillis() - start);
-	}
+    public enum PolicyAction { ALLOW, BLOCK, ESCALATE_TO_HUMAN }
+
+    private final boolean      allowed;
+    private final String       reason;
+    private final PolicyAction action;
+
+    private PolicyDecision(boolean allowed, String reason, PolicyAction action) {
+        this.allowed = allowed;
+        this.reason  = reason;
+        this.action  = action;
+    }
+
+    public boolean      isAllowed() { return allowed; }
+    public String       getReason() { return reason;  }
+    public PolicyAction getAction() { return action;  }
+
+    public static PolicyDecision allow() {
+        return new PolicyDecision(true, null, PolicyAction.ALLOW);
+    }
+
+    public static PolicyDecision block(String reason) {
+        return new PolicyDecision(false, reason, PolicyAction.BLOCK);
+    }
+
+    public static PolicyDecision escalate(String reason) {
+        return new PolicyDecision(false, reason, PolicyAction.ESCALATE_TO_HUMAN);
+    }
+
+    @Override
+    public String toString() {
+        return "PolicyDecision{action=" + action + ", reason=" + reason + '}';
+    }
 }

--- a/src/prerna/reactor/agent/trace/AgentSummaryMetricsReactor.java
+++ b/src/prerna/reactor/agent/trace/AgentSummaryMetricsReactor.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.agent.trace;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.User;
+import prerna.auth.utils.SecurityAdminUtils;
+import prerna.engine.impl.model.inferencetracking.AgentTraceLogsUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.execptions.SemossPixelException;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+/**
+ * Returns aggregate dashboard metrics across all agent runs. Admin-only.
+ *
+ * <p>Pixel: {@code AgentSummaryMetrics();}
+ *
+ * <p>Returns a map with:
+ * <ul>
+ *   <li>{@code totalRuns}       — all-time run count
+ *   <li>{@code runsLast24h}     — runs in the last 24 hours
+ *   <li>{@code avgIterations}   — average agent iterations per run
+ *   <li>{@code avgDurationMs}   — average run duration in milliseconds
+ *   <li>{@code successRate}     — % of runs that terminated with a text response
+ *   <li>{@code totalToolCalls}  — sum of all tool calls made
+ *   <li>{@code topModels}       — [{modelEngineId, runCount}] top 10 by usage
+ *   <li>{@code runsByDay}       — [{date, count}] for the last 7 days
+ * </ul>
+ */
+public class AgentSummaryMetricsReactor extends AbstractReactor {
+
+    private static final Logger classLogger = LogManager.getLogger(AgentSummaryMetricsReactor.class);
+
+    public AgentSummaryMetricsReactor() {
+        this.keysToGet  = new String[] {};
+        this.keyRequired = new int[] {};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+
+        User user = this.insight.getUser();
+        if (user == null) {
+            throw new SemossPixelException(NounMetadata.getErrorNounMessage("You are not properly logged in"));
+        }
+        if (!SecurityAdminUtils.userIsAdmin(user)) {
+            throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+                    "AgentSummaryMetrics is restricted to admin users"));
+        }
+
+        Map<String, Object> metrics = AgentTraceLogsUtils.getMetrics();
+
+        classLogger.info("AgentSummaryMetricsReactor: returning metrics (totalRuns={})",
+                metrics.get("totalRuns"));
+
+        return new NounMetadata(metrics, PixelDataType.CUSTOM_DATA_STRUCTURE, PixelOperationType.OPERATION);
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Returns aggregate agent observability metrics across all rooms. Admin only.";
+    }
+}

--- a/src/prerna/reactor/agent/trace/GetAgentTraceReactor.java
+++ b/src/prerna/reactor/agent/trace/GetAgentTraceReactor.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.agent.trace;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.User;
+import prerna.auth.utils.SecurityAdminUtils;
+import prerna.engine.impl.model.inferencetracking.AgentTraceLogsUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+/**
+ * Returns the full decision trace for a given trace ID.
+ *
+ * <p>Pixel: {@code GetAgentTrace(traceId=["abc123"])}
+ *
+ * <p>Security: the trace record contains a {@code userId} column. This reactor verifies the
+ * requesting user matches the stored userId before returning trace content. Admins may access
+ * any trace.
+ */
+public class GetAgentTraceReactor extends AbstractReactor {
+
+    private static final Logger classLogger = LogManager.getLogger(GetAgentTraceReactor.class);
+
+    private static final String KEY_TRACE_ID = "traceId";
+
+    public GetAgentTraceReactor() {
+        this.keysToGet  = new String[] { KEY_TRACE_ID };
+        this.keyRequired = new int[] { 1 };
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+
+        String traceId = this.keyValue.get(KEY_TRACE_ID);
+        if (traceId == null || traceId.trim().isEmpty()) {
+            throw new IllegalArgumentException("traceId is required");
+        }
+
+        Map<String, Object> trace = AgentTraceLogsUtils.getTrace(traceId);
+
+        if (!trace.containsKey("header")) {
+            throw new IllegalArgumentException("No trace found with id: " + traceId);
+        }
+
+        // Security: verify requesting user owns this trace or is an admin.
+        User user = this.insight.getUser();
+        if (user == null || user.getPrimaryLoginToken() == null) {
+            throw new IllegalArgumentException("User not authenticated");
+        }
+        String requestingUserId = user.getPrimaryLoginToken().getId();
+
+        Map<String, Object> header = (Map<String, Object>) trace.get("header");
+        if (header != null) {
+            String traceUserId = (String) header.get("userId");
+            boolean isAdmin = SecurityAdminUtils.userIsAdmin(user);
+            if (!isAdmin && traceUserId != null && !traceUserId.equals(requestingUserId)) {
+                throw new IllegalArgumentException("Access denied to trace: " + traceId);
+            }
+            // Do not expose userId in the returned payload
+            header.remove("userId");
+        }
+
+        classLogger.info("GetAgentTraceReactor: returned trace {} for user {}", traceId, requestingUserId);
+        return new NounMetadata(trace, PixelDataType.MAP, PixelOperationType.OPERATION);
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Returns the full decision trace for a given agent trace ID. "
+                + "Requires the requesting user to own the trace or be an admin.";
+    }
+}

--- a/src/prerna/reactor/agent/trace/ListAgentTracesReactor.java
+++ b/src/prerna/reactor/agent/trace/ListAgentTracesReactor.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.agent.trace;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.User;
+import prerna.auth.utils.SecurityAdminUtils;
+import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.RoomUtils;
+import prerna.engine.impl.model.inferencetracking.AgentTraceLogsUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+/**
+ * Lists agent trace summaries for a given room.
+ *
+ * <p>Pixel: {@code ListAgentTraces(roomId=["room1"], limit=[50])}
+ *
+ * <p>Security: the requesting user must own or have access to the specified room, OR be an admin
+ * to list across all rooms. Trace summaries do not include content — only IDs, timing, iteration
+ * counts, and termination reasons.
+ */
+public class ListAgentTracesReactor extends AbstractReactor {
+
+    private static final Logger classLogger = LogManager.getLogger(ListAgentTracesReactor.class);
+
+    private static final int DEFAULT_LIMIT = 50;
+    private static final int MAX_LIMIT     = 500;
+
+    public ListAgentTracesReactor() {
+        this.keysToGet  = new String[] { ReactorKeysEnum.ROOM_ID.getKey(), ReactorKeysEnum.LIMIT.getKey() };
+        this.keyRequired = new int[] { 0, 0 };
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+
+        User user = this.insight.getUser();
+        String roomId = this.keyValue.get(ReactorKeysEnum.ROOM_ID.getKey());
+
+        int limit = DEFAULT_LIMIT;
+        String limitStr = this.keyValue.get(ReactorKeysEnum.LIMIT.getKey());
+        if (limitStr != null && !limitStr.isEmpty()) {
+            try {
+                limit = Math.min(Integer.parseInt(limitStr), MAX_LIMIT);
+            } catch (NumberFormatException e) {
+                classLogger.warn("ListAgentTracesReactor: invalid limit value '{}', using default.", limitStr);
+            }
+        }
+
+        List<Map<String, Object>> traces;
+
+        if (roomId == null || roomId.trim().isEmpty()) {
+            // No roomId — admin-only: return traces across all rooms
+            if (user == null || !SecurityAdminUtils.userIsAdmin(user)) {
+                throw new IllegalArgumentException(
+                        "roomId is required, or the caller must be an admin to list all traces");
+            }
+            traces = AgentTraceLogsUtils.listAllTraces(limit);
+            classLogger.info("ListAgentTracesReactor: admin all-rooms query returned {} traces (limit={})",
+                    traces.size(), limit);
+        } else {
+            // Room-scoped: verify user access
+            Room room = RoomUtils.getOrLoadRoom(roomId, this.insight);
+            if (room == null) {
+                throw new IllegalArgumentException("Room not found: " + roomId);
+            }
+            traces = AgentTraceLogsUtils.listTraces(roomId, limit);
+            classLogger.info("ListAgentTracesReactor: returned {} traces for room {} (limit={})",
+                    traces.size(), roomId, limit);
+        }
+
+        return new NounMetadata(traces, PixelDataType.CUSTOM_DATA_STRUCTURE, PixelOperationType.OPERATION);
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Lists agent trace summaries for a given room, ordered by most recent first. "
+                + "Returns metadata only — no tool call content. Use GetAgentTrace for a full trace.";
+    }
+}

--- a/src/prerna/reactor/project/CreateProjectReactor.java
+++ b/src/prerna/reactor/project/CreateProjectReactor.java
@@ -27,13 +27,22 @@
  *******************************************************************************/
 package prerna.reactor.project;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Vector;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
+import com.google.gson.GsonBuilder;
 
 import prerna.auth.User;
 import prerna.auth.utils.AbstractSecurityUtils;
 import prerna.auth.utils.SecurityAdminUtils;
+import prerna.cluster.util.ClusterUtil;
 import prerna.project.api.IProject;
 import prerna.project.impl.ProjectHelper;
 import prerna.reactor.AbstractReactor;
@@ -42,11 +51,15 @@ import prerna.sablecc2.om.PixelOperationType;
 import prerna.sablecc2.om.ReactorKeysEnum;
 import prerna.sablecc2.om.execptions.SemossPixelException;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.util.AssetUtility;
 import prerna.util.UploadUtilities;
 import prerna.util.Utility;
+import prerna.util.git.GitRepoUtils;
+import prerna.util.gson.GsonUtility;
 
 public class CreateProjectReactor extends AbstractReactor {
 
+	private static final Logger classLogger = LogManager.getLogger(CreateProjectReactor.class);
 	private static final String CLASS_NAME = CreateProjectReactor.class.getName();
 
 	/*
@@ -101,17 +114,14 @@ public class CreateProjectReactor extends AbstractReactor {
 
 		boolean hasPortal = Boolean.parseBoolean(this.keyValue.get(this.keysToGet[index++]) + "");
 
-		// project type is new
-		// if has portal
-		// will assume code if not provided
-		// else will assume it is insight
-		// TODO: potentially remove hasportal entirely
-		if (hasPortal) {
-			if (projectTypeStr == null || (projectTypeStr = projectTypeStr.trim()).isEmpty()) {
-				projectType = IProject.PROJECT_TYPE.CODE;
-			} else {
-				projectType = IProject.PROJECT_TYPE.valueOf(projectTypeStr);
-			}
+		// Determine project type:
+		// 1. If an explicit projectType is provided, use it (via enum valueOf)
+		// 2. If no type but hasPortal, default to CODE
+		// 3. Otherwise default to INSIGHTS
+		if (projectTypeStr != null && !(projectTypeStr = projectTypeStr.trim()).isEmpty()) {
+			projectType = IProject.PROJECT_TYPE.valueOf(projectTypeStr);
+		} else if (hasPortal) {
+			projectType = IProject.PROJECT_TYPE.CODE;
 		} else {
 			projectType = IProject.PROJECT_TYPE.INSIGHTS;
 		}
@@ -122,6 +132,11 @@ public class CreateProjectReactor extends AbstractReactor {
 		IProject project = ProjectHelper.generateNewProject(projectName, projectType, global, hasPortal, portalName,
 				gitProvider, gitCloneUrl, this.insight.getUser(), logger);
 
+		// Scaffold workflow project with default workflow.json
+		if (projectType == IProject.PROJECT_TYPE.WORKFLOW) {
+			scaffoldWorkflowProject(project, this.insight.getUser(), logger);
+		}
+
 		Map<String, Object> retMap = UploadUtilities.getProjectReturnData(this.insight.getUser(),
 				project.getProjectId());
 		NounMetadata retNoun = new NounMetadata(retMap, PixelDataType.UPLOAD_RETURN_MAP,
@@ -130,6 +145,69 @@ public class CreateProjectReactor extends AbstractReactor {
 			retNoun.addAdditionalReturn(warning);
 		}
 		return retNoun;
+	}
+
+	/**
+	 * Creates the workflow directory structure and default workflow.json for a new WORKFLOW project.
+	 * 
+	 * @param project  the newly created project
+	 * @param user     the user creating the project
+	 * @param logger   logger instance
+	 */
+	private void scaffoldWorkflowProject(IProject project, User user, Logger logger) {
+		String projectId = project.getProjectId();
+		String assetFolder = AssetUtility.getProjectAssetsFolder(projectId);
+
+		// Create the workflow directory under assets
+		File workflowDir = new File(assetFolder + "/" + IProject.WORKFLOW_FOLDER);
+		if (!workflowDir.exists()) {
+			workflowDir.mkdirs();
+		}
+
+		// Create the executions directory for storing run history
+		File executionsDir = new File(workflowDir, "executions");
+		if (!executionsDir.exists()) {
+			executionsDir.mkdirs();
+		}
+
+		// Build the default empty workflow.json scaffold
+		Map<String, Object> workflowJson = new HashMap<>();
+		workflowJson.put("workflowId", projectId);
+		workflowJson.put("name", project.getProjectName());
+		workflowJson.put("version", 1);
+		workflowJson.put("steps", new java.util.ArrayList<>());
+		workflowJson.put("variables", new HashMap<>());
+		workflowJson.put("trigger", null);
+
+		Map<String, Object> settings = new HashMap<>();
+		settings.put("maxSteps", 50);
+		settings.put("timeoutMs", 300000);
+		settings.put("onError", "stop");
+		workflowJson.put("settings", settings);
+
+		// Write the workflow.json file
+		File workflowFile = new File(workflowDir, IProject.WORKFLOW_FILE_NAME);
+		try {
+			GsonUtility.writeObjectToJsonFile(workflowFile,
+					new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create(), workflowJson);
+		} catch (IOException e) {
+			classLogger.error("Failed to write default workflow.json for project " + projectId, e);
+			throw new IllegalArgumentException(
+					"Project was created but could not write the workflow.json. Error = " + e.getMessage());
+		}
+
+		// Add the scaffold to git and commit
+		String projectVersionFolder = AssetUtility.getProjectVersionFolder(
+				project.getProjectName(), project.getProjectId());
+		List<String> files = new Vector<>();
+		files.add(workflowFile.getAbsolutePath());
+		GitRepoUtils.addSpecificFiles(projectVersionFolder, files);
+		GitRepoUtils.commitAddedFiles(projectVersionFolder, "Initial workflow scaffold", user);
+
+		if (ClusterUtil.IS_CLUSTER) {
+			logger.info("Syncing workflow project for cloud backup");
+			ClusterUtil.pushProjectFolder(project, projectVersionFolder);
+		}
 	}
 
 	@Override

--- a/src/prerna/reactor/project/CreateProjectReactor.java
+++ b/src/prerna/reactor/project/CreateProjectReactor.java
@@ -159,7 +159,7 @@ public class CreateProjectReactor extends AbstractReactor {
 		String assetFolder = AssetUtility.getProjectAssetsFolder(projectId);
 
 		// Create the workflow directory under assets
-		File workflowDir = new File(assetFolder + "/" + IProject.WORKFLOW_FOLDER);
+		File workflowDir = new File(assetFolder + File.separator + IProject.WORKFLOW_FOLDER);
 		if (!workflowDir.exists()) {
 			workflowDir.mkdirs();
 		}
@@ -191,7 +191,7 @@ public class CreateProjectReactor extends AbstractReactor {
 			GsonUtility.writeObjectToJsonFile(workflowFile,
 					new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create(), workflowJson);
 		} catch (IOException e) {
-			classLogger.error("Failed to write default workflow.json for project " + projectId, e);
+			classLogger.error("Failed to write default workflow.json for project {}", projectId, e);
 			throw new IllegalArgumentException(
 					"Project was created but could not write the workflow.json. Error = " + e.getMessage());
 		}

--- a/src/prerna/reactor/workflow/GetWorkflowStatusReactor.java
+++ b/src/prerna/reactor/workflow/GetWorkflowStatusReactor.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow;
 
 import java.io.File;
@@ -18,10 +45,11 @@ import prerna.auth.utils.SecurityProjectUtils;
 import prerna.project.api.IProject;
 import prerna.reactor.AbstractReactor;
 import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
 import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.execptions.SemossPixelException;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
 import prerna.util.AssetUtility;
-import prerna.util.Constants;
 import prerna.util.Utility;
 import prerna.util.gson.GsonUtility;
 
@@ -52,26 +80,30 @@ public class GetWorkflowStatusReactor extends AbstractReactor {
 
 		User user = this.insight.getUser();
 		if (user == null) {
-			throw new IllegalArgumentException("You are not properly logged in");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage("You are not properly logged in"));
 		}
 
 		// Resolve and validate project ID
 		String projectId = this.keyValue.get(this.keysToGet[0]);
 		if (projectId == null || projectId.isEmpty()) {
-			throw new IllegalArgumentException("Must input a project id");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage("Must input a project id"));
 		}
 		projectId = SecurityProjectUtils.testUserProjectIdForAlias(user, projectId);
 		if (!SecurityProjectUtils.userCanViewProject(user, projectId)) {
-			throw new IllegalArgumentException(
-					"Project does not exist or user does not have access to the project");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+					"Project does not exist or user does not have access to the project"));
 		}
 
 		// Load project and verify type
 		IProject project = Utility.getProject(projectId);
+		if (project == null) {
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+					"Project '" + projectId + "' could not be loaded"));
+		}
 		IProject.PROJECT_TYPE projectType = project.getProjectType();
 		if (projectType != IProject.PROJECT_TYPE.WORKFLOW) {
-			throw new IllegalArgumentException(
-					"Project '" + projectId + "' is not a WORKFLOW project (type=" + projectType + ")");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+					"Project '" + projectId + "' is not a WORKFLOW project (type=" + projectType + ")"));
 		}
 
 		// Pull latest if clustered
@@ -92,9 +124,9 @@ public class GetWorkflowStatusReactor extends AbstractReactor {
 						workflowFile,
 						new TypeToken<Map<String, Object>>() {}.getType());
 			} catch (IOException e) {
-				classLogger.error(Constants.STACKTRACE, e);
-				throw new IllegalArgumentException(
-						"Unable to read the workflow JSON file. Error = " + e.getMessage());
+				classLogger.error("Failed to read workflow.json for project {}", projectId, e);
+				throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+						"Unable to read the workflow JSON file. Error = " + e.getMessage()));
 			}
 		}
 
@@ -112,7 +144,7 @@ public class GetWorkflowStatusReactor extends AbstractReactor {
 		List<Map<String, Object>> executions = loadExecutionSummaries(executionsDir, 50);
 		returnMap.put("executions", executions);
 
-		return new NounMetadata(returnMap, PixelDataType.MAP);
+		return new NounMetadata(returnMap, PixelDataType.MAP, PixelOperationType.OPERATION);
 	}
 
 	/**
@@ -153,7 +185,7 @@ public class GetWorkflowStatusReactor extends AbstractReactor {
 				}
 				summaries.add(summary);
 			} catch (IOException e) {
-				classLogger.warn("Failed to read execution log file: {}", logFiles[i].getName());
+				classLogger.warn("Failed to read execution log file: {}", logFiles[i].getName(), e);
 			}
 		}
 

--- a/src/prerna/reactor/workflow/GetWorkflowStatusReactor.java
+++ b/src/prerna/reactor/workflow/GetWorkflowStatusReactor.java
@@ -1,0 +1,170 @@
+package prerna.reactor.workflow;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.reflect.TypeToken;
+
+import prerna.auth.User;
+import prerna.auth.utils.SecurityProjectUtils;
+import prerna.project.api.IProject;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.util.AssetUtility;
+import prerna.util.Constants;
+import prerna.util.Utility;
+import prerna.util.gson.GsonUtility;
+
+/**
+ * Returns the current workflow definition and project metadata for a WORKFLOW project.
+ * 
+ * Pixel: GetWorkflowStatus(project=["workflow-project-uuid"]);
+ * 
+ * Returns a map with:
+ *   projectId    — the resolved project ID
+ *   projectName  — the project name
+ *   projectType  — should be WORKFLOW
+ *   workflow      — the parsed workflow.json contents (or null if not yet saved)
+ */
+public class GetWorkflowStatusReactor extends AbstractReactor {
+
+	private static final Logger classLogger = LogManager.getLogger(GetWorkflowStatusReactor.class);
+
+	public GetWorkflowStatusReactor() {
+		this.keysToGet = new String[] { ReactorKeysEnum.PROJECT.getKey() };
+		this.keyRequired = new int[] { 1 };
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+
+		User user = this.insight.getUser();
+		if (user == null) {
+			throw new IllegalArgumentException("You are not properly logged in");
+		}
+
+		// Resolve and validate project ID
+		String projectId = this.keyValue.get(this.keysToGet[0]);
+		if (projectId == null || projectId.isEmpty()) {
+			throw new IllegalArgumentException("Must input a project id");
+		}
+		projectId = SecurityProjectUtils.testUserProjectIdForAlias(user, projectId);
+		if (!SecurityProjectUtils.userCanViewProject(user, projectId)) {
+			throw new IllegalArgumentException(
+					"Project does not exist or user does not have access to the project");
+		}
+
+		// Load project and verify type
+		IProject project = Utility.getProject(projectId);
+		IProject.PROJECT_TYPE projectType = project.getProjectType();
+		if (projectType != IProject.PROJECT_TYPE.WORKFLOW) {
+			throw new IllegalArgumentException(
+					"Project '" + projectId + "' is not a WORKFLOW project (type=" + projectType + ")");
+		}
+
+		// Pull latest if clustered
+		if (project.requirePublish(true)) {
+			classLogger.info("{} pulled from cloud", projectId);
+		}
+
+		// Read workflow.json
+		String assetFolder = AssetUtility.getProjectAssetsFolder(projectId);
+		File workflowFile = new File(assetFolder
+				+ File.separator + IProject.WORKFLOW_FOLDER
+				+ File.separator + IProject.WORKFLOW_FILE_NAME);
+
+		Map<String, Object> workflowJson = null;
+		if (workflowFile.exists() && workflowFile.isFile()) {
+			try {
+				workflowJson = (Map<String, Object>) GsonUtility.readJsonFileToObject(
+						workflowFile,
+						new TypeToken<Map<String, Object>>() {}.getType());
+			} catch (IOException e) {
+				classLogger.error(Constants.STACKTRACE, e);
+				throw new IllegalArgumentException(
+						"Unable to read the workflow JSON file. Error = " + e.getMessage());
+			}
+		}
+
+		// Build return map
+		Map<String, Object> returnMap = new LinkedHashMap<>();
+		returnMap.put("projectId", projectId);
+		returnMap.put("projectName", project.getProjectName());
+		returnMap.put("projectType", projectType.name());
+		returnMap.put("workflow", workflowJson);
+
+		// Include execution history summaries (latest first, capped at 50)
+		File executionsDir = new File(assetFolder
+				+ File.separator + IProject.WORKFLOW_FOLDER
+				+ File.separator + "executions");
+		List<Map<String, Object>> executions = loadExecutionSummaries(executionsDir, 50);
+		returnMap.put("executions", executions);
+
+		return new NounMetadata(returnMap, PixelDataType.MAP);
+	}
+
+	/**
+	 * Load execution log files and extract summary info from each.
+	 * Returns newest-first, capped at {@code limit} entries.
+	 */
+	private List<Map<String, Object>> loadExecutionSummaries(File executionsDir, int limit) {
+		List<Map<String, Object>> summaries = new ArrayList<>();
+		if (!executionsDir.exists() || !executionsDir.isDirectory()) {
+			return summaries;
+		}
+
+		File[] logFiles = executionsDir.listFiles((dir, name) -> name.endsWith(".json"));
+		if (logFiles == null || logFiles.length == 0) {
+			return summaries;
+		}
+
+		// Sort newest first (by last modified)
+		Arrays.sort(logFiles, (a, b) -> Long.compare(b.lastModified(), a.lastModified()));
+
+		int count = Math.min(logFiles.length, limit);
+		for (int i = 0; i < count; i++) {
+			try {
+				Map<String, Object> fullLog = (Map<String, Object>) GsonUtility.readJsonFileToObject(
+						logFiles[i],
+						new TypeToken<Map<String, Object>>() {}.getType());
+
+				// Extract summary fields only (not the full step results)
+				Map<String, Object> summary = new LinkedHashMap<>();
+				summary.put("executionId", fullLog.get("executionId"));
+				summary.put("status", fullLog.get("status"));
+				summary.put("durationMs", fullLog.get("durationMs"));
+				summary.put("triggeredBy", fullLog.get("triggeredBy"));
+				summary.put("startTimeMs", fullLog.get("startTimeMs"));
+				summary.put("endTimeMs", fullLog.get("endTimeMs"));
+				if (fullLog.containsKey("error")) {
+					summary.put("error", fullLog.get("error"));
+				}
+				summaries.add(summary);
+			} catch (IOException e) {
+				classLogger.warn("Failed to read execution log file: {}", logFiles[i].getName());
+			}
+		}
+
+		return summaries;
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (key.equals(ReactorKeysEnum.PROJECT.getKey())) {
+			return "The ID of the workflow project to get status for";
+		}
+		return super.getDescriptionForKey(key);
+	}
+}

--- a/src/prerna/reactor/workflow/RunWorkflowReactor.java
+++ b/src/prerna/reactor/workflow/RunWorkflowReactor.java
@@ -1,0 +1,115 @@
+package prerna.reactor.workflow;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.User;
+import prerna.auth.utils.SecurityProjectUtils;
+import prerna.project.api.IProject;
+import prerna.reactor.AbstractReactor;
+import prerna.reactor.workflow.engine.WorkflowExecutionResult;
+import prerna.reactor.workflow.engine.WorkflowExecutor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.util.Utility;
+
+/**
+ * Executes a workflow project and returns the execution result.
+ * 
+ * Pixel: RunWorkflow(project=["workflow-project-uuid"], variables=[{"key": "value"}]);
+ * 
+ * Keys:
+ *   project   — (required) the workflow project ID
+ *   variables — (optional) runtime variable overrides as a map
+ */
+public class RunWorkflowReactor extends AbstractReactor {
+
+	private static final Logger classLogger = LogManager.getLogger(RunWorkflowReactor.class);
+
+	public RunWorkflowReactor() {
+		this.keysToGet = new String[] {
+				ReactorKeysEnum.PROJECT.getKey(),
+				"variables",
+				"trigger"
+		};
+		this.keyRequired = new int[] { 1, 0, 0 };
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+
+		User user = this.insight.getUser();
+		if (user == null) {
+			throw new IllegalArgumentException("You are not properly logged in");
+		}
+
+		// Resolve and validate project ID
+		String projectId = this.keyValue.get(this.keysToGet[0]);
+		if (projectId == null || projectId.isEmpty()) {
+			throw new IllegalArgumentException("Must input a project id");
+		}
+		projectId = SecurityProjectUtils.testUserProjectIdForAlias(user, projectId);
+		if (!SecurityProjectUtils.userCanViewProject(user, projectId)) {
+			throw new IllegalArgumentException(
+					"Project does not exist or user does not have access to the project");
+		}
+
+		// Load project and verify it is a WORKFLOW type
+		IProject project = Utility.getProject(projectId);
+		IProject.PROJECT_TYPE projectType = project.getProjectType();
+		if (projectType != IProject.PROJECT_TYPE.WORKFLOW) {
+			throw new IllegalArgumentException(
+					"Project '" + projectId + "' is not a WORKFLOW project (type=" + projectType + ")");
+		}
+
+		// Pull latest if clustered
+		if (project.requirePublish(true)) {
+			classLogger.info("Project {} pulled from cloud before workflow execution", projectId);
+		}
+
+		// Get optional variable overrides
+		Map<String, Object> variables = (Map<String, Object>) getMap("variables");
+
+		// Determine trigger source (defaults to "manual")
+		String triggeredBy = this.keyValue.get("trigger");
+		if (triggeredBy == null || triggeredBy.isEmpty()) {
+			triggeredBy = "manual";
+		}
+
+		// Execute the workflow
+		WorkflowExecutor executor = new WorkflowExecutor();
+		WorkflowExecutionResult result = executor.execute(project, variables, this.insight, triggeredBy);
+
+		// Build return map
+		Map<String, Object> returnMap = new LinkedHashMap<>();
+		returnMap.put("executionId", result.getExecutionId());
+		returnMap.put("workflowId", result.getWorkflowId());
+		returnMap.put("status", result.getStatus().name());
+		returnMap.put("durationMs", result.getDurationMs());
+		returnMap.put("triggeredBy", result.getTriggeredBy());
+		returnMap.put("finalOutput", result.getFinalOutput());
+		if (result.getError() != null) {
+			returnMap.put("error", result.getError());
+		}
+
+		return new NounMetadata(returnMap, PixelDataType.MAP);
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (key.equals(ReactorKeysEnum.PROJECT.getKey())) {
+			return "The ID of the workflow project to execute";
+		} else if (key.equals("variables")) {
+			return "Optional runtime variable overrides as a JSON map";
+		} else if (key.equals("trigger")) {
+			return "Trigger source: 'manual' (default), 'schedule', 'webhook', or 'api'";
+		}
+		return super.getDescriptionForKey(key);
+	}
+}

--- a/src/prerna/reactor/workflow/RunWorkflowReactor.java
+++ b/src/prerna/reactor/workflow/RunWorkflowReactor.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow;
 
 import java.util.LinkedHashMap;
@@ -13,7 +40,9 @@ import prerna.reactor.AbstractReactor;
 import prerna.reactor.workflow.engine.WorkflowExecutionResult;
 import prerna.reactor.workflow.engine.WorkflowExecutor;
 import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
 import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.execptions.SemossPixelException;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
 import prerna.util.Utility;
 
@@ -46,26 +75,30 @@ public class RunWorkflowReactor extends AbstractReactor {
 
 		User user = this.insight.getUser();
 		if (user == null) {
-			throw new IllegalArgumentException("You are not properly logged in");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage("You are not properly logged in"));
 		}
 
 		// Resolve and validate project ID
 		String projectId = this.keyValue.get(this.keysToGet[0]);
 		if (projectId == null || projectId.isEmpty()) {
-			throw new IllegalArgumentException("Must input a project id");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage("Must input a project id"));
 		}
 		projectId = SecurityProjectUtils.testUserProjectIdForAlias(user, projectId);
 		if (!SecurityProjectUtils.userCanViewProject(user, projectId)) {
-			throw new IllegalArgumentException(
-					"Project does not exist or user does not have access to the project");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+					"Project does not exist or user does not have access to the project"));
 		}
 
 		// Load project and verify it is a WORKFLOW type
 		IProject project = Utility.getProject(projectId);
+		if (project == null) {
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+					"Project '" + projectId + "' could not be loaded"));
+		}
 		IProject.PROJECT_TYPE projectType = project.getProjectType();
 		if (projectType != IProject.PROJECT_TYPE.WORKFLOW) {
-			throw new IllegalArgumentException(
-					"Project '" + projectId + "' is not a WORKFLOW project (type=" + projectType + ")");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+					"Project '" + projectId + "' is not a WORKFLOW project (type=" + projectType + ")"));
 		}
 
 		// Pull latest if clustered
@@ -98,7 +131,7 @@ public class RunWorkflowReactor extends AbstractReactor {
 			returnMap.put("error", result.getError());
 		}
 
-		return new NounMetadata(returnMap, PixelDataType.MAP);
+		return new NounMetadata(returnMap, PixelDataType.MAP, PixelOperationType.OPERATION);
 	}
 
 	@Override

--- a/src/prerna/reactor/workflow/SaveWorkflowReactor.java
+++ b/src/prerna/reactor/workflow/SaveWorkflowReactor.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow;
 
 import java.io.File;
@@ -17,10 +44,11 @@ import prerna.reactor.AbstractReactor;
 import prerna.reactor.workflow.engine.WorkflowDefinition;
 import prerna.sablecc2.om.GenRowStruct;
 import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
 import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.execptions.SemossPixelException;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
 import prerna.util.AssetUtility;
-import prerna.util.Constants;
 import prerna.util.Utility;
 import prerna.util.git.GitRepoUtils;
 import prerna.util.gson.GsonUtility;
@@ -57,24 +85,24 @@ public class SaveWorkflowReactor extends AbstractReactor {
 
 		User user = this.insight.getUser();
 		if (user == null) {
-			throw new IllegalArgumentException("You are not properly logged in");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage("You are not properly logged in"));
 		}
 
 		// Resolve and validate project ID
 		String projectId = this.keyValue.get(this.keysToGet[0]);
 		if (projectId == null || projectId.isEmpty()) {
-			throw new IllegalArgumentException("Must input a project id");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage("Must input a project id"));
 		}
 		projectId = SecurityProjectUtils.testUserProjectIdForAlias(user, projectId);
 		if (!SecurityProjectUtils.userCanEditProject(user, projectId)) {
-			throw new IllegalArgumentException(
-					"Project does not exist or user does not have access to edit the project");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+					"Project does not exist or user does not have access to edit the project"));
 		}
 
 		// Get workflow JSON payload
 		Map<String, Object> workflowJson = getWorkflowJSON();
 		if (workflowJson == null || workflowJson.isEmpty()) {
-			throw new IllegalArgumentException("Must provide the workflow JSON");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage("Must provide the workflow JSON"));
 		}
 
 		// Optional commit message
@@ -87,10 +115,14 @@ public class SaveWorkflowReactor extends AbstractReactor {
 
 		// Load project and verify it is a WORKFLOW type
 		IProject project = Utility.getProject(projectId);
+		if (project == null) {
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+					"Project '" + projectId + "' could not be loaded"));
+		}
 		IProject.PROJECT_TYPE projectType = project.getProjectType();
 		if (projectType != IProject.PROJECT_TYPE.WORKFLOW) {
-			throw new IllegalArgumentException(
-					"Project '" + projectId + "' is not a WORKFLOW project (type=" + projectType + ")");
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+					"Project '" + projectId + "' is not a WORKFLOW project (type=" + projectType + ")"));
 		}
 
 		// Validate the workflow definition before persisting
@@ -99,8 +131,8 @@ public class SaveWorkflowReactor extends AbstractReactor {
 		WorkflowDefinition definition = WorkflowDefinition.parse(workflowJsonStr);
 		List<String> validationErrors = definition.validate();
 		if (!validationErrors.isEmpty()) {
-			throw new IllegalArgumentException(
-					"Workflow validation failed: " + String.join("; ", validationErrors));
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+					"Workflow validation failed: " + String.join("; ", validationErrors)));
 		}
 
 		// Write workflow.json to assets/workflow/workflow.json
@@ -119,9 +151,9 @@ public class SaveWorkflowReactor extends AbstractReactor {
 		try {
 			GsonUtility.writeObjectToJsonFile(workflowFile, GSON, workflowJson);
 		} catch (IOException e) {
-			classLogger.error(Constants.STACKTRACE, e);
-			throw new IllegalArgumentException(
-					"Unable to save the workflow JSON to the project folder. Error = " + e.getMessage());
+			classLogger.error("Failed to write workflow.json for project {}", projectId, e);
+			throw new SemossPixelException(NounMetadata.getErrorNounMessage(
+					"Unable to save the workflow JSON to the project folder. Error = " + e.getMessage()));
 		}
 
 		// Git add and commit
@@ -140,7 +172,7 @@ public class SaveWorkflowReactor extends AbstractReactor {
 
 		SecurityProjectUtils.updateProjectLastEditedDate(projectId);
 
-		return new NounMetadata(true, PixelDataType.BOOLEAN);
+		return new NounMetadata(true, PixelDataType.BOOLEAN, PixelOperationType.OPERATION);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/prerna/reactor/workflow/SaveWorkflowReactor.java
+++ b/src/prerna/reactor/workflow/SaveWorkflowReactor.java
@@ -1,0 +1,181 @@
+package prerna.reactor.workflow;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Vector;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.User;
+import prerna.auth.utils.SecurityProjectUtils;
+import prerna.cluster.util.ClusterUtil;
+import prerna.project.api.IProject;
+import prerna.reactor.AbstractReactor;
+import prerna.reactor.workflow.engine.WorkflowDefinition;
+import prerna.sablecc2.om.GenRowStruct;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.util.AssetUtility;
+import prerna.util.Constants;
+import prerna.util.Utility;
+import prerna.util.git.GitRepoUtils;
+import prerna.util.gson.GsonUtility;
+
+/**
+ * Saves or updates the workflow.json for a WORKFLOW project.
+ * 
+ * Pixel: SaveWorkflow(project=["workflow-project-uuid"], json=[{...}], comment=["optional commit message"]);
+ * 
+ * Keys:
+ *   project — (required) the workflow project ID
+ *   json    — (required) the workflow definition JSON (map)
+ *   comment — (optional) git commit message
+ */
+public class SaveWorkflowReactor extends AbstractReactor {
+
+	private static final Logger classLogger = LogManager.getLogger(SaveWorkflowReactor.class);
+
+	private static final String CLASS_NAME = SaveWorkflowReactor.class.getName();
+
+	public SaveWorkflowReactor() {
+		this.keysToGet = new String[] {
+				ReactorKeysEnum.PROJECT.getKey(),
+				ReactorKeysEnum.JSON.getKey(),
+				ReactorKeysEnum.COMMENT_KEY.getKey()
+		};
+		this.keyRequired = new int[] { 1, 1, 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		Logger logger = getLogger(CLASS_NAME);
+		organizeKeys();
+
+		User user = this.insight.getUser();
+		if (user == null) {
+			throw new IllegalArgumentException("You are not properly logged in");
+		}
+
+		// Resolve and validate project ID
+		String projectId = this.keyValue.get(this.keysToGet[0]);
+		if (projectId == null || projectId.isEmpty()) {
+			throw new IllegalArgumentException("Must input a project id");
+		}
+		projectId = SecurityProjectUtils.testUserProjectIdForAlias(user, projectId);
+		if (!SecurityProjectUtils.userCanEditProject(user, projectId)) {
+			throw new IllegalArgumentException(
+					"Project does not exist or user does not have access to edit the project");
+		}
+
+		// Get workflow JSON payload
+		Map<String, Object> workflowJson = getWorkflowJSON();
+		if (workflowJson == null || workflowJson.isEmpty()) {
+			throw new IllegalArgumentException("Must provide the workflow JSON");
+		}
+
+		// Optional commit message
+		String comment = this.keyValue.get(this.keysToGet[2]);
+		if (comment != null && !comment.isEmpty()) {
+			comment = Utility.decodeURIComponent(comment);
+		} else {
+			comment = "Update workflow definition";
+		}
+
+		// Load project and verify it is a WORKFLOW type
+		IProject project = Utility.getProject(projectId);
+		IProject.PROJECT_TYPE projectType = project.getProjectType();
+		if (projectType != IProject.PROJECT_TYPE.WORKFLOW) {
+			throw new IllegalArgumentException(
+					"Project '" + projectId + "' is not a WORKFLOW project (type=" + projectType + ")");
+		}
+
+		// Validate the workflow definition before persisting
+		// This catches dangling references, orphaned steps, cycles, duplicate IDs, etc.
+		String workflowJsonStr = GSON.toJson(workflowJson);
+		WorkflowDefinition definition = WorkflowDefinition.parse(workflowJsonStr);
+		List<String> validationErrors = definition.validate();
+		if (!validationErrors.isEmpty()) {
+			throw new IllegalArgumentException(
+					"Workflow validation failed: " + String.join("; ", validationErrors));
+		}
+
+		// Write workflow.json to assets/workflow/workflow.json
+		String assetFolder = AssetUtility.getProjectAssetsFolder(projectId);
+		String workflowDir = assetFolder + File.separator + IProject.WORKFLOW_FOLDER;
+		File workflowDirFile = new File(workflowDir);
+		if (!workflowDirFile.exists()) {
+			workflowDirFile.mkdirs();
+		}
+
+		File workflowFile = new File(workflowDir + File.separator + IProject.WORKFLOW_FILE_NAME);
+		if (workflowFile.exists() && workflowFile.isFile()) {
+			workflowFile.delete();
+		}
+
+		try {
+			GsonUtility.writeObjectToJsonFile(workflowFile, GSON, workflowJson);
+		} catch (IOException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException(
+					"Unable to save the workflow JSON to the project folder. Error = " + e.getMessage());
+		}
+
+		// Git add and commit
+		List<String> files = new Vector<>();
+		files.add(workflowFile.getAbsolutePath());
+		String projectVersionFolder = AssetUtility.getProjectVersionFolder(
+				project.getProjectName(), projectId);
+		GitRepoUtils.addSpecificFiles(projectVersionFolder, files);
+		GitRepoUtils.commitAddedFiles(projectVersionFolder, comment, user);
+
+		// Cluster sync
+		if (ClusterUtil.IS_CLUSTER) {
+			logger.info("Syncing workflow project for cloud backup");
+			ClusterUtil.pushProjectFolder(project, projectVersionFolder);
+		}
+
+		SecurityProjectUtils.updateProjectLastEditedDate(projectId);
+
+		return new NounMetadata(true, PixelDataType.BOOLEAN);
+	}
+
+	@SuppressWarnings("unchecked")
+	private Map<String, Object> getWorkflowJSON() {
+		GenRowStruct mapGrs = this.store.getGenRowStruct(ReactorKeysEnum.JSON.getKey());
+		if (mapGrs != null && !mapGrs.isEmpty()) {
+			List<NounMetadata> mapInputs = mapGrs.getNounsOfType(PixelDataType.MAP);
+			if (mapInputs != null && !mapInputs.isEmpty()) {
+				return (Map<String, Object>) mapInputs.get(0).getValue();
+			}
+
+			List<NounMetadata> encodedStrGrs = mapGrs.getNounsOfType(PixelDataType.CONST_STRING);
+			if (encodedStrGrs != null && !encodedStrGrs.isEmpty()) {
+				String encodedStr = (String) encodedStrGrs.get(0).getValue();
+				String mapStr = Utility.decodeURIComponent(encodedStr);
+				return GSON.fromJson(mapStr, Map.class);
+			}
+		}
+		List<NounMetadata> mapInputs = this.curRow.getNounsOfType(PixelDataType.MAP);
+		if (mapInputs != null && !mapInputs.isEmpty()) {
+			return (Map<String, Object>) mapInputs.get(0).getValue();
+		}
+
+		return null;
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (key.equals(ReactorKeysEnum.PROJECT.getKey())) {
+			return "The ID of the workflow project";
+		} else if (key.equals(ReactorKeysEnum.JSON.getKey())) {
+			return "The workflow definition JSON to save";
+		} else if (key.equals(ReactorKeysEnum.COMMENT_KEY.getKey())) {
+			return "Optional git commit message";
+		}
+		return super.getDescriptionForKey(key);
+	}
+}

--- a/src/prerna/reactor/workflow/engine/StepExecutionLog.java
+++ b/src/prerna/reactor/workflow/engine/StepExecutionLog.java
@@ -1,0 +1,27 @@
+package prerna.reactor.workflow.engine;
+
+/**
+ * A single log entry recording the execution of one step.
+ */
+public class StepExecutionLog {
+
+	private final String stepId;
+	private final String stepType;
+	private final StepResult.Status status;
+	private final long durationMs;
+	private final long timestamp;
+
+	public StepExecutionLog(String stepId, String stepType, StepResult.Status status, long durationMs) {
+		this.stepId = stepId;
+		this.stepType = stepType;
+		this.status = status;
+		this.durationMs = durationMs;
+		this.timestamp = System.currentTimeMillis();
+	}
+
+	public String getStepId() { return stepId; }
+	public String getStepType() { return stepType; }
+	public StepResult.Status getStatus() { return status; }
+	public long getDurationMs() { return durationMs; }
+	public long getTimestamp() { return timestamp; }
+}

--- a/src/prerna/reactor/workflow/engine/StepExecutionLog.java
+++ b/src/prerna/reactor/workflow/engine/StepExecutionLog.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine;
 
 /**

--- a/src/prerna/reactor/workflow/engine/StepResult.java
+++ b/src/prerna/reactor/workflow/engine/StepResult.java
@@ -1,0 +1,66 @@
+package prerna.reactor.workflow.engine;
+
+/**
+ * Result of a single step execution.
+ */
+public class StepResult {
+
+	private String stepId;
+	private Status status;
+	private Object output;
+	private java.util.Map<String, Object> metadata = new java.util.HashMap<>();
+	private String error;
+	private long durationMs;
+
+	public enum Status {
+		SUCCESS, ERROR, SKIPPED
+	}
+
+	// ── Factory helpers ─────────────────────────────────────────────────
+
+	public static StepResult success(String stepId, Object output, long durationMs) {
+		StepResult r = new StepResult();
+		r.stepId = stepId;
+		r.status = Status.SUCCESS;
+		r.output = output;
+		r.durationMs = durationMs;
+		return r;
+	}
+
+	public static StepResult error(String stepId, String errorMsg, long durationMs) {
+		StepResult r = new StepResult();
+		r.stepId = stepId;
+		r.status = Status.ERROR;
+		r.error = errorMsg;
+		r.durationMs = durationMs;
+		return r;
+	}
+
+	public static StepResult skipped(String stepId) {
+		StepResult r = new StepResult();
+		r.stepId = stepId;
+		r.status = Status.SKIPPED;
+		r.durationMs = 0;
+		return r;
+	}
+
+	// ── Getters / Setters ───────────────────────────────────────────────
+
+	public String getStepId() { return stepId; }
+	public void setStepId(String stepId) { this.stepId = stepId; }
+
+	public Status getStatus() { return status; }
+	public void setStatus(Status status) { this.status = status; }
+
+	public Object getOutput() { return output; }
+	public void setOutput(Object output) { this.output = output; }
+
+	public java.util.Map<String, Object> getMetadata() { return metadata; }
+	public void setMetadata(java.util.Map<String, Object> metadata) { this.metadata = metadata; }
+
+	public String getError() { return error; }
+	public void setError(String error) { this.error = error; }
+
+	public long getDurationMs() { return durationMs; }
+	public void setDurationMs(long durationMs) { this.durationMs = durationMs; }
+}

--- a/src/prerna/reactor/workflow/engine/StepResult.java
+++ b/src/prerna/reactor/workflow/engine/StepResult.java
@@ -1,4 +1,34 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine;
+
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Result of a single step execution.
@@ -8,7 +38,7 @@ public class StepResult {
 	private String stepId;
 	private Status status;
 	private Object output;
-	private java.util.Map<String, Object> metadata = new java.util.HashMap<>();
+	private Map<String, Object> metadata = new HashMap<>();
 	private String error;
 	private long durationMs;
 
@@ -55,8 +85,8 @@ public class StepResult {
 	public Object getOutput() { return output; }
 	public void setOutput(Object output) { this.output = output; }
 
-	public java.util.Map<String, Object> getMetadata() { return metadata; }
-	public void setMetadata(java.util.Map<String, Object> metadata) { this.metadata = metadata; }
+	public Map<String, Object> getMetadata() { return metadata; }
+	public void setMetadata(Map<String, Object> metadata) { this.metadata = metadata; }
 
 	public String getError() { return error; }
 	public void setError(String error) { this.error = error; }

--- a/src/prerna/reactor/workflow/engine/WorkflowContext.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowContext.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine;
 
 import java.util.ArrayList;

--- a/src/prerna/reactor/workflow/engine/WorkflowContext.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowContext.java
@@ -1,0 +1,74 @@
+package prerna.reactor.workflow.engine;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Holds runtime state during workflow execution.
+ * Passed through to each step handler so they can read prior results and variables.
+ */
+public class WorkflowContext {
+
+	private final Map<String, Object> variables = new HashMap<>();
+	private final Map<String, StepResult> stepResults = new HashMap<>();
+	private final List<StepExecutionLog> executionLog = new ArrayList<>();
+	private final long startTimeMs;
+	private int stepsExecuted = 0;
+
+	public WorkflowContext() {
+		this.startTimeMs = System.currentTimeMillis();
+	}
+
+	public WorkflowContext(Map<String, Object> initialVariables) {
+		this();
+		if (initialVariables != null) {
+			this.variables.putAll(initialVariables);
+		}
+	}
+
+	// ── Result tracking ─────────────────────────────────────────────────
+
+	public void putResult(String stepId, StepResult result) {
+		stepResults.put(stepId, result);
+		stepsExecuted++;
+	}
+
+	public StepResult getResult(String stepId) {
+		return stepResults.get(stepId);
+	}
+
+	public boolean hasResult(String stepId) {
+		return stepResults.containsKey(stepId);
+	}
+
+	public void addLogEntry(String stepId, String stepType, StepResult.Status status, long durationMs) {
+		executionLog.add(new StepExecutionLog(stepId, stepType, status, durationMs));
+	}
+
+	// ── Variable access ─────────────────────────────────────────────────
+
+	public Object getVariable(String name) {
+		return variables.get(name);
+	}
+
+	public void setVariable(String name, Object value) {
+		variables.put(name, value);
+	}
+
+	// ── Getters ─────────────────────────────────────────────────────────
+
+	public Map<String, Object> getVariables() { return variables; }
+	public Map<String, StepResult> getStepResults() { return stepResults; }
+	public List<StepExecutionLog> getExecutionLog() { return executionLog; }
+	public long getStartTimeMs() { return startTimeMs; }
+	public int getStepsExecuted() { return stepsExecuted; }
+
+	/**
+	 * Returns elapsed time since the workflow started.
+	 */
+	public long getElapsedMs() {
+		return System.currentTimeMillis() - startTimeMs;
+	}
+}

--- a/src/prerna/reactor/workflow/engine/WorkflowDefinition.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowDefinition.java
@@ -1,0 +1,233 @@
+package prerna.reactor.workflow.engine;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * Represents a parsed workflow.json definition.
+ * This is the top-level POJO for the workflow engine.
+ */
+public class WorkflowDefinition {
+
+	private String workflowId;
+	private String name;
+	private int version;
+	private List<WorkflowStep> steps = new ArrayList<>();
+	private Map<String, Object> variables = new HashMap<>();
+	private Map<String, Object> trigger;
+	private WorkflowSettings settings = new WorkflowSettings();
+
+	// ── Factory methods ─────────────────────────────────────────────────
+
+	private static final Gson GSON = new GsonBuilder()
+			.setPrettyPrinting()
+			.disableHtmlEscaping()
+			.create();
+
+	/**
+	 * Parse a workflow definition from a JSON string.
+	 */
+	public static WorkflowDefinition parse(String json) {
+		return GSON.fromJson(json, WorkflowDefinition.class);
+	}
+
+	/**
+	 * Parse a workflow definition from a file.
+	 */
+	public static WorkflowDefinition fromFile(File file) throws IOException {
+		try (FileReader reader = new FileReader(file)) {
+			return GSON.fromJson(reader, WorkflowDefinition.class);
+		}
+	}
+
+	/**
+	 * Serialize this definition back to JSON.
+	 */
+	public String toJson() {
+		return GSON.toJson(this);
+	}
+
+	// ── Validation ──────────────────────────────────────────────────────
+
+	/**
+	 * Validates the workflow definition for structural correctness.
+	 * 
+	 * @return list of validation error messages (empty if valid)
+	 */
+	public List<String> validate() {
+		List<String> errors = new ArrayList<>();
+
+		if (steps == null || steps.isEmpty()) {
+			errors.add("Workflow must contain at least one step");
+			return errors;
+		}
+
+		// Collect all step IDs
+		Set<String> stepIds = new HashSet<>();
+		for (WorkflowStep step : steps) {
+			if (step.getStepId() == null || step.getStepId().isEmpty()) {
+				errors.add("Step is missing a stepId");
+				continue;
+			}
+			if (!stepIds.add(step.getStepId())) {
+				errors.add("Duplicate stepId: " + step.getStepId());
+			}
+		}
+
+		// Validate references and detect cycles
+		Set<String> referencedIds = new HashSet<>();
+		for (WorkflowStep step : steps) {
+			if (step.getStepId() == null) continue;
+
+			// Validate 'next' references
+			if (step.getNext() != null) {
+				for (String nextId : step.getNext()) {
+					if (!stepIds.contains(nextId)) {
+						errors.add("Step '" + step.getStepId() + "' references unknown step: " + nextId);
+					}
+					referencedIds.add(nextId);
+				}
+			}
+
+			// Validate 'ifTrue'/'ifFalse' references (CONDITION steps)
+			if (step.getIfTrue() != null) {
+				for (String id : step.getIfTrue()) {
+					if (!stepIds.contains(id)) {
+						errors.add("Step '" + step.getStepId() + "' ifTrue references unknown step: " + id);
+					}
+					referencedIds.add(id);
+				}
+			}
+			if (step.getIfFalse() != null) {
+				for (String id : step.getIfFalse()) {
+					if (!stepIds.contains(id)) {
+						errors.add("Step '" + step.getStepId() + "' ifFalse references unknown step: " + id);
+					}
+					referencedIds.add(id);
+				}
+			}
+		}
+
+		// Check for entry points (steps with no incoming edges)
+		Set<String> entrySteps = new HashSet<>(stepIds);
+		entrySteps.removeAll(referencedIds);
+		if (entrySteps.isEmpty()) {
+			errors.add("No entry steps found — possible circular reference (all steps are referenced by other steps)");
+		}
+
+		// Cycle detection via DFS
+		if (errors.isEmpty()) {
+			Map<String, WorkflowStep> stepMap = getStepMap();
+			Set<String> visited = new HashSet<>();
+			Set<String> inStack = new HashSet<>();
+			for (String entryId : entrySteps) {
+				if (hasCycle(entryId, stepMap, visited, inStack)) {
+					errors.add("Circular reference detected in workflow");
+					break;
+				}
+			}
+
+			// Orphan detection — steps not reachable from any entry point
+			if (errors.isEmpty() && visited.size() < stepIds.size()) {
+				Set<String> orphans = new HashSet<>(stepIds);
+				orphans.removeAll(visited);
+				for (String orphanId : orphans) {
+					errors.add("Step '" + orphanId + "' is unreachable from any entry point");
+				}
+			}
+		}
+
+		return errors;
+	}
+
+	/**
+	 * DFS cycle detection helper.
+	 */
+	private boolean hasCycle(String stepId, Map<String, WorkflowStep> stepMap,
+			Set<String> visited, Set<String> inStack) {
+		if (inStack.contains(stepId)) return true;
+		if (visited.contains(stepId)) return false;
+
+		visited.add(stepId);
+		inStack.add(stepId);
+
+		WorkflowStep step = stepMap.get(stepId);
+		if (step != null) {
+			List<String> successors = step.getAllSuccessorIds();
+			for (String nextId : successors) {
+				if (hasCycle(nextId, stepMap, visited, inStack)) {
+					return true;
+				}
+			}
+		}
+
+		inStack.remove(stepId);
+		return false;
+	}
+
+	// ── Convenience methods ─────────────────────────────────────────────
+
+	/**
+	 * Returns a map of stepId -> WorkflowStep for quick lookup.
+	 */
+	public Map<String, WorkflowStep> getStepMap() {
+		Map<String, WorkflowStep> map = new HashMap<>();
+		if (steps != null) {
+			for (WorkflowStep step : steps) {
+				if (step.getStepId() != null) {
+					map.put(step.getStepId(), step);
+				}
+			}
+		}
+		return map;
+	}
+
+	/**
+	 * Returns the step IDs that have no incoming edges (entry points).
+	 */
+	public List<String> getEntryStepIds() {
+		Set<String> allIds = new HashSet<>();
+		Set<String> referenced = new HashSet<>();
+		for (WorkflowStep step : steps) {
+			allIds.add(step.getStepId());
+			if (step.getNext() != null) referenced.addAll(step.getNext());
+			if (step.getIfTrue() != null) referenced.addAll(step.getIfTrue());
+			if (step.getIfFalse() != null) referenced.addAll(step.getIfFalse());
+		}
+		allIds.removeAll(referenced);
+		return new ArrayList<>(allIds);
+	}
+
+	// ── Getters / Setters ───────────────────────────────────────────────
+
+	public String getWorkflowId() { return workflowId; }
+	public void setWorkflowId(String workflowId) { this.workflowId = workflowId; }
+
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; }
+
+	public int getVersion() { return version; }
+	public void setVersion(int version) { this.version = version; }
+
+	public List<WorkflowStep> getSteps() { return steps; }
+	public void setSteps(List<WorkflowStep> steps) { this.steps = steps; }
+
+	public Map<String, Object> getVariables() { return variables; }
+	public void setVariables(Map<String, Object> variables) { this.variables = variables; }
+
+	public Map<String, Object> getTrigger() { return trigger; }
+	public void setTrigger(Map<String, Object> trigger) { this.trigger = trigger; }
+
+	public WorkflowSettings getSettings() { return settings; }
+	public void setSettings(WorkflowSettings settings) { this.settings = settings; }
+}

--- a/src/prerna/reactor/workflow/engine/WorkflowDefinition.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowDefinition.java
@@ -1,8 +1,37 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine;
 
 import java.io.File;
-import java.io.FileReader;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -45,7 +74,7 @@ public class WorkflowDefinition {
 	 * Parse a workflow definition from a file.
 	 */
 	public static WorkflowDefinition fromFile(File file) throws IOException {
-		try (FileReader reader = new FileReader(file)) {
+		try (InputStreamReader reader = new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)) {
 			return GSON.fromJson(reader, WorkflowDefinition.class);
 		}
 	}

--- a/src/prerna/reactor/workflow/engine/WorkflowExecutionResult.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowExecutionResult.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine;
 
 import java.util.Map;

--- a/src/prerna/reactor/workflow/engine/WorkflowExecutionResult.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowExecutionResult.java
@@ -1,0 +1,84 @@
+package prerna.reactor.workflow.engine;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Final result of a complete workflow execution.
+ */
+public class WorkflowExecutionResult {
+
+	private String executionId;
+	private String workflowId;
+	private Status status;
+	private long startTimeMs;
+	private long endTimeMs;
+	private long durationMs;
+	private String triggeredBy;
+	private Map<String, StepResult> stepResults;
+	private Object finalOutput;
+	private String error;
+
+	public enum Status {
+		SUCCESS, ERROR, TIMEOUT
+	}
+
+	// ── Factory helpers ─────────────────────────────────────────────────
+
+	public static WorkflowExecutionResult from(WorkflowContext context, String workflowId, String triggeredBy) {
+		WorkflowExecutionResult result = new WorkflowExecutionResult();
+		result.executionId = UUID.randomUUID().toString();
+		result.workflowId = workflowId;
+		result.startTimeMs = context.getStartTimeMs();
+		result.endTimeMs = System.currentTimeMillis();
+		result.durationMs = result.endTimeMs - result.startTimeMs;
+		result.triggeredBy = triggeredBy;
+		result.stepResults = context.getStepResults();
+
+		// Determine overall status from step results
+		boolean hasError = context.getStepResults().values().stream()
+				.anyMatch(r -> r.getStatus() == StepResult.Status.ERROR);
+		result.status = hasError ? Status.ERROR : Status.SUCCESS;
+
+		return result;
+	}
+
+	public static WorkflowExecutionResult timeout(WorkflowContext context, String workflowId, String triggeredBy) {
+		WorkflowExecutionResult result = from(context, workflowId, triggeredBy);
+		result.status = Status.TIMEOUT;
+		result.error = "Workflow exceeded timeout of " + context.getElapsedMs() + "ms";
+		return result;
+	}
+
+	// ── Getters / Setters ───────────────────────────────────────────────
+
+	public String getExecutionId() { return executionId; }
+	public void setExecutionId(String executionId) { this.executionId = executionId; }
+
+	public String getWorkflowId() { return workflowId; }
+	public void setWorkflowId(String workflowId) { this.workflowId = workflowId; }
+
+	public Status getStatus() { return status; }
+	public void setStatus(Status status) { this.status = status; }
+
+	public long getStartTimeMs() { return startTimeMs; }
+	public void setStartTimeMs(long startTimeMs) { this.startTimeMs = startTimeMs; }
+
+	public long getEndTimeMs() { return endTimeMs; }
+	public void setEndTimeMs(long endTimeMs) { this.endTimeMs = endTimeMs; }
+
+	public long getDurationMs() { return durationMs; }
+	public void setDurationMs(long durationMs) { this.durationMs = durationMs; }
+
+	public String getTriggeredBy() { return triggeredBy; }
+	public void setTriggeredBy(String triggeredBy) { this.triggeredBy = triggeredBy; }
+
+	public Map<String, StepResult> getStepResults() { return stepResults; }
+	public void setStepResults(Map<String, StepResult> stepResults) { this.stepResults = stepResults; }
+
+	public Object getFinalOutput() { return finalOutput; }
+	public void setFinalOutput(Object finalOutput) { this.finalOutput = finalOutput; }
+
+	public String getError() { return error; }
+	public void setError(String error) { this.error = error; }
+}

--- a/src/prerna/reactor/workflow/engine/WorkflowExecutor.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowExecutor.java
@@ -1,0 +1,374 @@
+package prerna.reactor.workflow.engine;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import prerna.om.Insight;
+import prerna.project.api.IProject;
+import prerna.reactor.workflow.engine.handlers.IWorkflowStepHandler;
+import prerna.reactor.workflow.engine.handlers.WorkflowStepHandlerRegistry;
+import prerna.util.AssetUtility;
+import prerna.util.gson.GsonUtility;
+
+/**
+ * The core DAG executor that walks a workflow definition and orchestrates
+ * step execution. Entry point for all workflow runs — manual, scheduled, or triggered.
+ *
+ * Execution algorithm:
+ *   1. Load and parse workflow.json from the project's assets
+ *   2. Validate the DAG structure
+ *   3. Build an in-degree map to determine execution readiness
+ *   4. Seed the ready queue with entry steps (in-degree == 0)
+ *   5. While queue is not empty:
+ *      a. Dequeue a step
+ *      b. Resolve {{template}} expressions in its config via WorkflowTemplateEngine
+ *      c. Look up the handler from WorkflowStepHandlerRegistry
+ *      d. Execute the handler
+ *      e. Record the StepResult in the WorkflowContext
+ *      f. Determine successors (branch-aware for CONDITION steps)
+ *      g. Decrement in-degree for successors; enqueue those that reach 0
+ *   6. Enforce maxSteps and timeoutMs guardrails
+ *   7. Handle errors per settings.onError ("stop" or "skip")
+ *   8. Build and return WorkflowExecutionResult
+ */
+public class WorkflowExecutor {
+
+	private static final Logger classLogger = LogManager.getLogger(WorkflowExecutor.class);
+
+	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+	/** Maximum number of execution logs to retain per project. */
+	private static final int MAX_EXECUTION_LOGS = 100;
+
+	/** Subfolder under workflow/ for execution logs. */
+	private static final String EXECUTIONS_FOLDER = "executions";
+
+	/**
+	 * Execute a workflow project.
+	 *
+	 * @param project           the WORKFLOW project containing workflow.json
+	 * @param variableOverrides runtime variable overrides (merged with definition defaults)
+	 * @param insight           the current insight context
+	 * @param triggeredBy       who/what triggered this run (e.g., "manual", "schedule", "api")
+	 * @return the execution result
+	 */
+	public WorkflowExecutionResult execute(IProject project,
+			Map<String, Object> variableOverrides,
+			Insight insight, String triggeredBy) {
+
+		// ── 1. Load workflow.json ───────────────────────────────────────
+		String projectId = project.getProjectId();
+		String assetFolder = AssetUtility.getProjectAssetsFolder(projectId);
+		String executionsDir = assetFolder
+				+ File.separator + IProject.WORKFLOW_FOLDER
+				+ File.separator + EXECUTIONS_FOLDER;
+		File workflowFile = new File(assetFolder
+				+ File.separator + IProject.WORKFLOW_FOLDER
+				+ File.separator + IProject.WORKFLOW_FILE_NAME);
+
+		if (!workflowFile.exists()) {
+			throw new IllegalStateException(
+					"workflow.json not found for project " + projectId
+					+ " at path: " + workflowFile.getAbsolutePath());
+		}
+
+		WorkflowDefinition definition;
+		try {
+			definition = WorkflowDefinition.fromFile(workflowFile);
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to parse workflow.json: " + e.getMessage(), e);
+		}
+
+		// ── 2. Validate ────────────────────────────────────────────────
+		List<String> validationErrors = definition.validate();
+		if (!validationErrors.isEmpty()) {
+			throw new IllegalArgumentException(
+					"Workflow validation failed: " + String.join("; ", validationErrors));
+		}
+
+		// ── 3. Build context ───────────────────────────────────────────
+		Map<String, Object> mergedVars = new HashMap<>();
+		if (definition.getVariables() != null) {
+			mergedVars.putAll(definition.getVariables());
+		}
+		if (variableOverrides != null) {
+			mergedVars.putAll(variableOverrides);
+		}
+		WorkflowContext context = new WorkflowContext(mergedVars);
+
+		WorkflowSettings settings = definition.getSettings();
+		if (settings == null) {
+			settings = new WorkflowSettings();
+		}
+
+		// ── 4. Build adjacency structures ──────────────────────────────
+		Map<String, WorkflowStep> stepMap = definition.getStepMap();
+		Map<String, Integer> inDegree = buildInDegreeMap(definition);
+
+		// ── 5. Seed queue with entry steps ─────────────────────────────
+		Queue<String> readyQueue = new ArrayDeque<>();
+		for (Map.Entry<String, Integer> entry : inDegree.entrySet()) {
+			if (entry.getValue() == 0) {
+				readyQueue.add(entry.getKey());
+			}
+		}
+
+		String onError = settings.getOnError() != null ? settings.getOnError() : "stop";
+		Object lastOutput = null;
+
+		classLogger.info("Starting workflow '{}' with {} steps, {} entry points",
+				definition.getName(), stepMap.size(), readyQueue.size());
+
+		// ── 6. Execute loop ────────────────────────────────────────────
+		while (!readyQueue.isEmpty()) {
+			// Timeout check
+			if (context.getElapsedMs() > settings.getTimeoutMs()) {
+				classLogger.warn("Workflow '{}' timed out after {}ms",
+						definition.getName(), context.getElapsedMs());
+				WorkflowExecutionResult result = WorkflowExecutionResult.timeout(
+						context, definition.getWorkflowId(), triggeredBy);
+				result.setFinalOutput(lastOutput);
+				saveExecutionLog(result, executionsDir);
+				return result;
+			}
+
+			// Max steps check
+			if (context.getStepsExecuted() >= settings.getMaxSteps()) {
+				classLogger.warn("Workflow '{}' hit max steps limit of {}",
+						definition.getName(), settings.getMaxSteps());
+				WorkflowExecutionResult result = WorkflowExecutionResult.from(
+						context, definition.getWorkflowId(), triggeredBy);
+				result.setStatus(WorkflowExecutionResult.Status.ERROR);
+				result.setError("Max steps limit reached: " + settings.getMaxSteps());
+				result.setFinalOutput(lastOutput);
+				saveExecutionLog(result, executionsDir);
+				return result;
+			}
+
+			String stepId = readyQueue.poll();
+			WorkflowStep step = stepMap.get(stepId);
+			if (step == null) {
+				classLogger.warn("Step '{}' not found in step map, skipping", stepId);
+				continue;
+			}
+
+			// Skip if already executed (safety guard for join nodes)
+			if (context.hasResult(stepId)) {
+				continue;
+			}
+
+			classLogger.debug("Executing step '{}' (type={})", stepId, step.getType());
+
+			// Resolve templates in config
+			Map<String, Object> resolvedConfig = WorkflowTemplateEngine.resolveMap(
+					step.getConfig(), context);
+
+			// Also resolve input mappings and merge into config
+			if (step.getInputs() != null && !step.getInputs().isEmpty()) {
+				for (Map.Entry<String, String> inputEntry : step.getInputs().entrySet()) {
+					Object resolvedValue = WorkflowTemplateEngine.resolve(
+							inputEntry.getValue(), context);
+					resolvedConfig.put(inputEntry.getKey(), resolvedValue);
+				}
+			}
+
+			// Look up handler
+			String stepType = step.getType();
+			IWorkflowStepHandler handler = WorkflowStepHandlerRegistry.getHandler(stepType);
+			if (handler == null) {
+				StepResult errorResult = StepResult.error(stepId,
+						"No handler registered for step type: " + stepType, 0);
+				context.putResult(stepId, errorResult);
+				context.addLogEntry(stepId, stepType, StepResult.Status.ERROR, 0);
+
+				if ("stop".equalsIgnoreCase(onError)) {
+					return buildErrorResult(context, definition, triggeredBy,
+							"No handler for step type: " + stepType, lastOutput, executionsDir);
+				}
+				continue;
+			}
+
+			// Execute
+			StepResult stepResult;
+			try {
+				stepResult = handler.execute(stepId, resolvedConfig, context, insight);
+			} catch (Exception e) {
+				classLogger.error("Unhandled exception in step '{}'", stepId, e);
+				stepResult = StepResult.error(stepId,
+						"Unhandled exception: " + e.getMessage(), 0);
+			}
+
+			// Record result
+			context.putResult(stepId, stepResult);
+			context.addLogEntry(stepId, stepType, stepResult.getStatus(), stepResult.getDurationMs());
+
+			if (stepResult.getStatus() == StepResult.Status.SUCCESS) {
+				lastOutput = stepResult.getOutput();
+			}
+
+			classLogger.debug("Step '{}' completed: status={}, duration={}ms",
+					stepId, stepResult.getStatus(), stepResult.getDurationMs());
+
+			// Handle error
+			if (stepResult.getStatus() == StepResult.Status.ERROR) {
+				if ("stop".equalsIgnoreCase(onError)) {
+					return buildErrorResult(context, definition, triggeredBy,
+							"Step '" + stepId + "' failed: " + stepResult.getError(),
+							lastOutput, executionsDir);
+				}
+				// "skip" — don't enqueue successors, continue with other ready steps
+				classLogger.warn("Step '{}' errored but onError=skip, continuing", stepId);
+				continue;
+			}
+
+			// ── Determine successors ───────────────────────────────────
+			List<String> successors = getSuccessors(step, stepResult);
+			for (String successorId : successors) {
+				if (!stepMap.containsKey(successorId)) continue;
+				int remaining = inDegree.getOrDefault(successorId, 0) - 1;
+				inDegree.put(successorId, remaining);
+				if (remaining <= 0) {
+					readyQueue.add(successorId);
+				}
+			}
+		}
+
+		// ── 7. Build final result ──────────────────────────────────────
+		WorkflowExecutionResult result = WorkflowExecutionResult.from(
+				context, definition.getWorkflowId(), triggeredBy);
+		result.setFinalOutput(lastOutput);
+
+		classLogger.info("Workflow '{}' completed: status={}, duration={}ms, steps={}",
+				definition.getName(), result.getStatus(),
+				result.getDurationMs(), context.getStepsExecuted());
+
+		saveExecutionLog(result, executionsDir);
+		return result;
+	}
+
+	/**
+	 * Build an in-degree map from the workflow definition.
+	 * In-degree = number of predecessor steps that must complete before a step can run.
+	 * Entry steps have in-degree of 0.
+	 */
+	private Map<String, Integer> buildInDegreeMap(WorkflowDefinition definition) {
+		Map<String, Integer> inDegree = new HashMap<>();
+
+		// Initialize all steps to 0
+		for (WorkflowStep step : definition.getSteps()) {
+			inDegree.put(step.getStepId(), 0);
+		}
+
+		// Count incoming edges
+		for (WorkflowStep step : definition.getSteps()) {
+			for (String successorId : step.getAllSuccessorIds()) {
+				inDegree.merge(successorId, 1, Integer::sum);
+			}
+		}
+
+		return inDegree;
+	}
+
+	/**
+	 * Determine which successor steps to activate based on the step type and result.
+	 * For CONDITION steps, only the matching branch (ifTrue/ifFalse) is returned.
+	 * For all other steps, the normal 'next' list is returned.
+	 */
+	private List<String> getSuccessors(WorkflowStep step, StepResult result) {
+		WorkflowStep.STEP_TYPE type = step.getStepType();
+
+		if (type == WorkflowStep.STEP_TYPE.CONDITION) {
+			String branch = (String) result.getMetadata().get("branch");
+			if ("ifTrue".equals(branch) && step.getIfTrue() != null) {
+				return step.getIfTrue();
+			} else if ("ifFalse".equals(branch) && step.getIfFalse() != null) {
+				return step.getIfFalse();
+			}
+			// Fallback to next if branch metadata is missing
+			return step.getNext() != null ? step.getNext() : List.of();
+		}
+
+		// Non-condition steps: use "next"
+		return step.getNext() != null ? step.getNext() : List.of();
+	}
+
+	/**
+	 * Build an error execution result.
+	 */
+	/**
+	 * Build an error execution result and save the execution log.
+	 */
+	private WorkflowExecutionResult buildErrorResult(WorkflowContext context,
+			WorkflowDefinition definition, String triggeredBy,
+			String errorMessage, Object lastOutput, String executionsDir) {
+		WorkflowExecutionResult result = WorkflowExecutionResult.from(
+				context, definition.getWorkflowId(), triggeredBy);
+		result.setStatus(WorkflowExecutionResult.Status.ERROR);
+		result.setError(errorMessage);
+		result.setFinalOutput(lastOutput);
+		if (executionsDir != null) {
+			saveExecutionLog(result, executionsDir);
+		}
+		return result;
+	}
+
+	// ── Execution log persistence ──────────────────────────────────────
+
+	/**
+	 * Persist a WorkflowExecutionResult to the executions directory as
+	 * {executionId}.json. Also enforces retention cleanup.
+	 */
+	private void saveExecutionLog(WorkflowExecutionResult result, String executionsDir) {
+		try {
+			File dir = new File(executionsDir);
+			if (!dir.exists()) {
+				dir.mkdirs();
+			}
+
+			File logFile = new File(dir, result.getExecutionId() + ".json");
+			GsonUtility.writeObjectToJsonFile(logFile, GSON, result);
+			classLogger.debug("Saved execution log to {}", logFile.getAbsolutePath());
+
+			// Enforce retention — keep only the latest N logs
+			cleanupOldExecutions(dir);
+		} catch (IOException e) {
+			// Log but do not fail the workflow — execution log is best-effort
+			classLogger.warn("Failed to save execution log for {}: {}",
+					result.getExecutionId(), e.getMessage());
+		}
+	}
+
+	/**
+	 * Delete oldest execution log files if the count exceeds MAX_EXECUTION_LOGS.
+	 * Files are sorted by last-modified time; the oldest are removed first.
+	 */
+	private void cleanupOldExecutions(File executionsDir) {
+		File[] logFiles = executionsDir.listFiles((dir, name) -> name.endsWith(".json"));
+		if (logFiles == null || logFiles.length <= MAX_EXECUTION_LOGS) {
+			return;
+		}
+
+		// Sort ascending by last modified (oldest first)
+		Arrays.sort(logFiles, Comparator.comparingLong(File::lastModified));
+
+		int toDelete = logFiles.length - MAX_EXECUTION_LOGS;
+		for (int i = 0; i < toDelete; i++) {
+			if (logFiles[i].delete()) {
+				classLogger.debug("Deleted old execution log: {}", logFiles[i].getName());
+			}
+		}
+	}
+}

--- a/src/prerna/reactor/workflow/engine/WorkflowExecutor.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowExecutor.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine;
 
 import java.io.File;
@@ -244,6 +271,21 @@ public class WorkflowExecutor {
 					readyQueue.add(successorId);
 				}
 			}
+
+			// For CONDITION steps: the not-taken branch will never fire, so phantom-decrement
+			// its immediate successors to prevent join nodes from blocking indefinitely.
+			if (step.getStepType() == WorkflowStep.STEP_TYPE.CONDITION) {
+				List<String> notTaken = getNotTakenSuccessors(step, stepResult);
+				for (String skippedId : notTaken) {
+					if (!stepMap.containsKey(skippedId)) continue;
+					int remaining = inDegree.getOrDefault(skippedId, 0) - 1;
+					inDegree.put(skippedId, remaining);
+					if (remaining <= 0) {
+						classLogger.debug("Join node '{}' unblocked via phantom-decrement from skipped branch", skippedId);
+						readyQueue.add(skippedId);
+					}
+				}
+			}
 		}
 
 		// ── 7. Build final result ──────────────────────────────────────
@@ -306,8 +348,20 @@ public class WorkflowExecutor {
 	}
 
 	/**
-	 * Build an error execution result.
+	 * For CONDITION steps: return the immediate successors of the branch that was NOT taken.
+	 * These nodes will never be activated by the condition step, so the caller uses this to
+	 * apply a phantom in-degree decrement and unblock any downstream join nodes.
 	 */
+	private List<String> getNotTakenSuccessors(WorkflowStep step, StepResult result) {
+		String branch = (String) result.getMetadata().get("branch");
+		if ("ifTrue".equals(branch)) {
+			return step.getIfFalse() != null ? step.getIfFalse() : List.of();
+		} else if ("ifFalse".equals(branch)) {
+			return step.getIfTrue() != null ? step.getIfTrue() : List.of();
+		}
+		return List.of();
+	}
+
 	/**
 	 * Build an error execution result and save the execution log.
 	 */

--- a/src/prerna/reactor/workflow/engine/WorkflowSettings.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowSettings.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine;
 
 /**
@@ -7,7 +34,7 @@ public class WorkflowSettings {
 
 	private int maxSteps = 50;
 	private long timeoutMs = 300000;
-	private String onError = "stop"; // "stop" | "skip" | "retry"
+	private String onError = "stop"; // "stop" | "skip"
 
 	public int getMaxSteps() { return maxSteps; }
 	public void setMaxSteps(int maxSteps) { this.maxSteps = maxSteps; }

--- a/src/prerna/reactor/workflow/engine/WorkflowSettings.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowSettings.java
@@ -1,0 +1,20 @@
+package prerna.reactor.workflow.engine;
+
+/**
+ * Settings for a workflow execution — max steps, timeout, error handling.
+ */
+public class WorkflowSettings {
+
+	private int maxSteps = 50;
+	private long timeoutMs = 300000;
+	private String onError = "stop"; // "stop" | "skip" | "retry"
+
+	public int getMaxSteps() { return maxSteps; }
+	public void setMaxSteps(int maxSteps) { this.maxSteps = maxSteps; }
+
+	public long getTimeoutMs() { return timeoutMs; }
+	public void setTimeoutMs(long timeoutMs) { this.timeoutMs = timeoutMs; }
+
+	public String getOnError() { return onError; }
+	public void setOnError(String onError) { this.onError = onError; }
+}

--- a/src/prerna/reactor/workflow/engine/WorkflowStep.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowStep.java
@@ -1,0 +1,112 @@
+package prerna.reactor.workflow.engine;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents a single step (node) in a workflow DAG.
+ */
+public class WorkflowStep {
+
+	// ── Step type enum ──────────────────────────────────────────────────
+
+	public enum STEP_TYPE {
+		LLM_ASK,
+		LLM_AGENT,
+		RUN_TOOL,
+		RUN_PIXEL,
+		RUN_PYTHON,
+		CONDITION,
+		LOOP,
+		TRANSFORM,
+		STATIC,
+		HUMAN_INPUT,
+		GUARDRAIL,
+		OUTPUT
+	}
+
+	// ── Fields ──────────────────────────────────────────────────────────
+
+	private String stepId;
+	private String type;
+	private String name;
+	private String description;
+
+	/** UI position — ignored by the backend executor */
+	private Map<String, Object> position;
+
+	/** Type-specific configuration (model id, prompt, recipe, etc.) */
+	private Map<String, Object> config = new HashMap<>();
+
+	/** Input mappings using {{template}} expressions */
+	private Map<String, String> inputs = new HashMap<>();
+
+	/** Default successor step IDs */
+	private List<String> next;
+
+	/** Successor step IDs when condition evaluates to true (CONDITION type only) */
+	private List<String> ifTrue;
+
+	/** Successor step IDs when condition evaluates to false (CONDITION type only) */
+	private List<String> ifFalse;
+
+	// ── Convenience ─────────────────────────────────────────────────────
+
+	/**
+	 * Returns the parsed STEP_TYPE enum, or null if the type string is invalid.
+	 */
+	public STEP_TYPE getStepType() {
+		if (type == null) return null;
+		try {
+			return STEP_TYPE.valueOf(type);
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all successor step IDs (combines next, ifTrue, ifFalse).
+	 * Used by DAG validation and cycle detection.
+	 */
+	public List<String> getAllSuccessorIds() {
+		List<String> successors = new ArrayList<>();
+		if (next != null) successors.addAll(next);
+		if (ifTrue != null) successors.addAll(ifTrue);
+		if (ifFalse != null) successors.addAll(ifFalse);
+		return successors;
+	}
+
+	// ── Getters / Setters ───────────────────────────────────────────────
+
+	public String getStepId() { return stepId; }
+	public void setStepId(String stepId) { this.stepId = stepId; }
+
+	public String getType() { return type; }
+	public void setType(String type) { this.type = type; }
+
+	public String getName() { return name; }
+	public void setName(String name) { this.name = name; }
+
+	public String getDescription() { return description; }
+	public void setDescription(String description) { this.description = description; }
+
+	public Map<String, Object> getPosition() { return position; }
+	public void setPosition(Map<String, Object> position) { this.position = position; }
+
+	public Map<String, Object> getConfig() { return config; }
+	public void setConfig(Map<String, Object> config) { this.config = config; }
+
+	public Map<String, String> getInputs() { return inputs; }
+	public void setInputs(Map<String, String> inputs) { this.inputs = inputs; }
+
+	public List<String> getNext() { return next; }
+	public void setNext(List<String> next) { this.next = next; }
+
+	public List<String> getIfTrue() { return ifTrue; }
+	public void setIfTrue(List<String> ifTrue) { this.ifTrue = ifTrue; }
+
+	public List<String> getIfFalse() { return ifFalse; }
+	public void setIfFalse(List<String> ifFalse) { this.ifFalse = ifFalse; }
+}

--- a/src/prerna/reactor/workflow/engine/WorkflowStep.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowStep.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine;
 
 import java.util.ArrayList;

--- a/src/prerna/reactor/workflow/engine/WorkflowTemplateEngine.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowTemplateEngine.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine;
 
 import java.util.HashMap;
@@ -7,6 +34,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 /**
  * Resolves {{stepId.output}} references in step config values at runtime.
@@ -20,10 +48,12 @@ import com.google.gson.Gson;
  *   {{stepId.output.fieldName}}        → nested field access (dot-notation)
  *   {{stepId.metadata.fieldName}}      → metadata field access
  */
-public class WorkflowTemplateEngine {
+public final class WorkflowTemplateEngine {
 
 	private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{(.+?)\\}\\}");
-	private static final Gson GSON = new Gson();
+	private static final Gson GSON = new GsonBuilder().create();
+
+	private WorkflowTemplateEngine() {}
 
 	/**
 	 * Resolve all {{...}} expressions in a single string.

--- a/src/prerna/reactor/workflow/engine/WorkflowTemplateEngine.java
+++ b/src/prerna/reactor/workflow/engine/WorkflowTemplateEngine.java
@@ -1,0 +1,167 @@
+package prerna.reactor.workflow.engine;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.google.gson.Gson;
+
+/**
+ * Resolves {{stepId.output}} references in step config values at runtime.
+ * 
+ * This handles step-to-step data passing. Static values like engine IDs,
+ * prompts, and tool names are baked into the workflow.json by the frontend
+ * at design time and do not need resolution.
+ * 
+ * Supported patterns:
+ *   {{stepId.output}}                  → full output of a prior step
+ *   {{stepId.output.fieldName}}        → nested field access (dot-notation)
+ *   {{stepId.metadata.fieldName}}      → metadata field access
+ */
+public class WorkflowTemplateEngine {
+
+	private static final Pattern TEMPLATE_PATTERN = Pattern.compile("\\{\\{(.+?)\\}\\}");
+	private static final Gson GSON = new Gson();
+
+	/**
+	 * Resolve all {{...}} expressions in a single string.
+	 * If the entire string is one template expression and the resolved value
+	 * is not a String, the raw object is returned (preserves types like Map, List, Number).
+	 */
+	public static Object resolve(String template, WorkflowContext context) {
+		if (template == null) return null;
+
+		Matcher matcher = TEMPLATE_PATTERN.matcher(template);
+		if (!matcher.find()) {
+			return template;
+		}
+
+		// If the entire string is a single template expression, return the raw object
+		if (matcher.start() == 0 && matcher.end() == template.length()) {
+			return resolveExpression(matcher.group(1).trim(), context);
+		}
+
+		// Otherwise, do string interpolation
+		matcher.reset();
+		StringBuffer sb = new StringBuffer();
+		while (matcher.find()) {
+			Object value = resolveExpression(matcher.group(1).trim(), context);
+			String replacement = (value != null) ? stringify(value) : "";
+			matcher.appendReplacement(sb, Matcher.quoteReplacement(replacement));
+		}
+		matcher.appendTail(sb);
+		return sb.toString();
+	}
+
+	/**
+	 * Resolve all string values in a config map. Non-string values are passed through unchanged.
+	 * Returns a new map (does not mutate the original).
+	 */
+	@SuppressWarnings("unchecked")
+	public static Map<String, Object> resolveMap(Map<String, Object> configMap, WorkflowContext context) {
+		if (configMap == null) return null;
+
+		Map<String, Object> resolved = new HashMap<>();
+		for (Map.Entry<String, Object> entry : configMap.entrySet()) {
+			Object value = entry.getValue();
+			if (value instanceof String) {
+				resolved.put(entry.getKey(), resolve((String) value, context));
+			} else if (value instanceof Map) {
+				resolved.put(entry.getKey(), resolveMap((Map<String, Object>) value, context));
+			} else if (value instanceof List) {
+				resolved.put(entry.getKey(), resolveList((List<Object>) value, context));
+			} else {
+				resolved.put(entry.getKey(), value);
+			}
+		}
+		return resolved;
+	}
+
+	/**
+	 * Resolve all string values in a list. Returns a new list.
+	 */
+	@SuppressWarnings("unchecked")
+	private static List<Object> resolveList(List<Object> list, WorkflowContext context) {
+		List<Object> resolved = new java.util.ArrayList<>();
+		for (Object item : list) {
+			if (item instanceof String) {
+				resolved.add(resolve((String) item, context));
+			} else if (item instanceof Map) {
+				resolved.add(resolveMap((Map<String, Object>) item, context));
+			} else if (item instanceof List) {
+				resolved.add(resolveList((List<Object>) item, context));
+			} else {
+				resolved.add(item);
+			}
+		}
+		return resolved;
+	}
+
+	/**
+	 * Resolve a single expression like "stepId.output" or "stepId.output.field.nested".
+	 */
+	private static Object resolveExpression(String expression, WorkflowContext context) {
+		String[] parts = expression.split("\\.", 2);
+		if (parts.length < 2) return null;
+
+		String stepId = parts[0];
+		String path = parts[1];
+
+		StepResult result = context.getResult(stepId);
+		if (result == null) return null;
+
+		// "stepId.output" or "stepId.output.nested.field"
+		if (path.equals("output")) {
+			return result.getOutput();
+		}
+		if (path.startsWith("output.")) {
+			return traversePath(result.getOutput(), path.substring("output.".length()));
+		}
+
+		// "stepId.metadata.fieldName"
+		if (path.equals("metadata")) {
+			return result.getMetadata();
+		}
+		if (path.startsWith("metadata.")) {
+			return traversePath(result.getMetadata(), path.substring("metadata.".length()));
+		}
+
+		// "stepId.status", "stepId.error", "stepId.durationMs"
+		if (path.equals("status")) return result.getStatus() != null ? result.getStatus().name() : null;
+		if (path.equals("error")) return result.getError();
+		if (path.equals("durationMs")) return result.getDurationMs();
+
+		return null;
+	}
+
+	/**
+	 * Traverse a dot-separated path into an object (supports Map and nested Maps).
+	 */
+	@SuppressWarnings("unchecked")
+	private static Object traversePath(Object obj, String path) {
+		if (obj == null || path == null || path.isEmpty()) return obj;
+
+		String[] segments = path.split("\\.");
+		Object current = obj;
+		for (String segment : segments) {
+			if (current instanceof Map) {
+				current = ((Map<String, Object>) current).get(segment);
+			} else {
+				return null;
+			}
+			if (current == null) return null;
+		}
+		return current;
+	}
+
+	/**
+	 * Convert a value to a string for interpolation.
+	 */
+	private static String stringify(Object value) {
+		if (value instanceof String) return (String) value;
+		if (value instanceof Number || value instanceof Boolean) return value.toString();
+		return GSON.toJson(value);
+	}
+}

--- a/src/prerna/reactor/workflow/engine/handlers/ConditionStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/ConditionStepHandler.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine.handlers;
 
 import java.util.Map;

--- a/src/prerna/reactor/workflow/engine/handlers/ConditionStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/ConditionStepHandler.java
@@ -1,0 +1,104 @@
+package prerna.reactor.workflow.engine.handlers;
+
+import java.util.Map;
+
+import prerna.om.Insight;
+import prerna.reactor.workflow.engine.StepResult;
+import prerna.reactor.workflow.engine.WorkflowContext;
+
+/**
+ * Evaluates a condition expression and sets the branch direction in metadata.
+ * The WorkflowExecutor reads metadata.branch to decide ifTrue vs ifFalse successors.
+ * 
+ * Config:
+ *   left       — left operand (resolved value)
+ *   operator   — comparison operator: "==", "!=", ">", "<", ">=", "<=", "contains", "empty", "notEmpty"
+ *   right      — right operand (resolved value, not needed for "empty"/"notEmpty")
+ */
+public class ConditionStepHandler implements IWorkflowStepHandler {
+
+	@Override
+	public StepResult execute(String stepId, Map<String, Object> config,
+			WorkflowContext context, Insight insight) {
+		long start = System.currentTimeMillis();
+
+		Object left = config.get("left");
+		String operator = (String) config.get("operator");
+		Object right = config.get("right");
+
+		if (operator == null || operator.isEmpty()) {
+			return StepResult.error(stepId, "Condition step requires an 'operator' in config", 
+					System.currentTimeMillis() - start);
+		}
+
+		boolean result;
+		try {
+			result = evaluate(left, operator, right);
+		} catch (Exception e) {
+			return StepResult.error(stepId, "Condition evaluation failed: " + e.getMessage(),
+					System.currentTimeMillis() - start);
+		}
+
+		StepResult stepResult = StepResult.success(stepId, result, System.currentTimeMillis() - start);
+		stepResult.getMetadata().put("branch", result ? "ifTrue" : "ifFalse");
+		return stepResult;
+	}
+
+	private boolean evaluate(Object left, String operator, Object right) {
+		switch (operator.toLowerCase()) {
+			case "empty":
+				return isEmpty(left);
+			case "notempty":
+				return !isEmpty(left);
+			case "==":
+			case "equals":
+				return objEquals(left, right);
+			case "!=":
+			case "notequals":
+				return !objEquals(left, right);
+			case "contains":
+				return left != null && right != null && left.toString().contains(right.toString());
+			case ">":
+				return compareNumbers(left, right) > 0;
+			case "<":
+				return compareNumbers(left, right) < 0;
+			case ">=":
+				return compareNumbers(left, right) >= 0;
+			case "<=":
+				return compareNumbers(left, right) <= 0;
+			default:
+				throw new IllegalArgumentException("Unknown operator: " + operator);
+		}
+	}
+
+	private boolean isEmpty(Object value) {
+		if (value == null) return true;
+		if (value instanceof String) return ((String) value).isEmpty();
+		if (value instanceof java.util.Collection) return ((java.util.Collection<?>) value).isEmpty();
+		if (value instanceof Map) return ((Map<?, ?>) value).isEmpty();
+		return false;
+	}
+
+	private boolean objEquals(Object left, Object right) {
+		if (left == null && right == null) return true;
+		if (left == null || right == null) return false;
+		// Try numeric comparison first
+		try {
+			double l = toDouble(left);
+			double r = toDouble(right);
+			return Double.compare(l, r) == 0;
+		} catch (NumberFormatException e) {
+			// Fall through to string comparison
+		}
+		return left.toString().equals(right.toString());
+	}
+
+	private int compareNumbers(Object left, Object right) {
+		return Double.compare(toDouble(left), toDouble(right));
+	}
+
+	private double toDouble(Object value) {
+		if (value instanceof Number) return ((Number) value).doubleValue();
+		return Double.parseDouble(value.toString());
+	}
+}

--- a/src/prerna/reactor/workflow/engine/handlers/IWorkflowStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/IWorkflowStepHandler.java
@@ -1,0 +1,27 @@
+package prerna.reactor.workflow.engine.handlers;
+
+import java.util.Map;
+
+import prerna.om.Insight;
+import prerna.reactor.workflow.engine.StepResult;
+import prerna.reactor.workflow.engine.WorkflowContext;
+
+/**
+ * Interface for workflow step handlers.
+ * Each step type (LLM_ASK, RUN_TOOL, CONDITION, etc.) has a handler
+ * that knows how to execute that type of step.
+ */
+public interface IWorkflowStepHandler {
+
+	/**
+	 * Execute a workflow step.
+	 * 
+	 * @param stepId   the unique ID of the step being executed
+	 * @param config   the step's resolved configuration (templates already replaced)
+	 * @param context  the workflow runtime context (variables, prior step results)
+	 * @param insight  the SEMOSS insight for engine/resource access
+	 * @return the result of executing this step
+	 */
+	StepResult execute(String stepId, Map<String, Object> config,
+			WorkflowContext context, Insight insight);
+}

--- a/src/prerna/reactor/workflow/engine/handlers/IWorkflowStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/IWorkflowStepHandler.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine.handlers;
 
 import java.util.Map;

--- a/src/prerna/reactor/workflow/engine/handlers/LLMAgentStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/LLMAgentStepHandler.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine.handlers;
 
 import java.util.ArrayList;
@@ -8,9 +35,13 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.json.JSONArray;
 import org.json.JSONObject;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+import prerna.auth.utils.SecurityEngineUtils;
 import prerna.engine.api.IEngine;
 import prerna.engine.api.IMCP;
 import prerna.engine.api.IModelEngine;
@@ -41,6 +72,10 @@ import prerna.reactor.agent.mcp.MCPUtility;
 public class LLMAgentStepHandler implements IWorkflowStepHandler {
 
 	private static final Logger classLogger = LogManager.getLogger(LLMAgentStepHandler.class);
+	private static final Gson GSON = new GsonBuilder().create();
+	@SuppressWarnings("serial")
+	private static final java.lang.reflect.Type LIST_MAP_TYPE =
+			new TypeToken<List<Map<String, Object>>>() {}.getType();
 	private static final int DEFAULT_MAX_ITERATIONS = 10;
 
 	@SuppressWarnings("unchecked")
@@ -68,6 +103,10 @@ public class LLMAgentStepHandler implements IWorkflowStepHandler {
 		}
 
 		try {
+			if (!SecurityEngineUtils.userCanViewEngine(insight.getUser(), modelId)) {
+				return StepResult.error(stepId, "User does not have access to model engine: " + modelId,
+						System.currentTimeMillis() - start);
+			}
 			IModelEngine modelEngine = (IModelEngine) Utility.getEngine(modelId);
 			if (modelEngine == null) {
 				return StepResult.error(stepId, "Model engine not found: " + modelId,
@@ -79,6 +118,10 @@ public class LLMAgentStepHandler implements IWorkflowStepHandler {
 			Map<String, IMCP> toolNameToMcp = new HashMap<>();
 			if (toolEngineIds != null) {
 				for (String engineId : toolEngineIds) {
+					if (!SecurityEngineUtils.userCanViewEngine(insight.getUser(), engineId)) {
+						classLogger.warn("User does not have access to tool engine '{}', skipping", engineId);
+						continue;
+					}
 					IEngine engine = Utility.getEngine(engineId);
 					if (engine == null) {
 						engine = Utility.getProject(engineId);
@@ -106,8 +149,7 @@ public class LLMAgentStepHandler implements IWorkflowStepHandler {
 
 			InputMessage msg = InputMessage.builder(room)
 					.withSystemPrompt(systemPrompt)
-					.withInputUIPrompt(userPrompt)
-					.withInputPrompt(userPrompt)
+					.withText(userPrompt, userPrompt)
 					.withModelType(modelEngine.getModelType())
 					.withParamMap(paramMap)
 					.withTools(allTools)
@@ -184,20 +226,15 @@ public class LLMAgentStepHandler implements IWorkflowStepHandler {
 
 	/**
 	 * Load tool definitions from an engine in the List of Map format expected by InputMessage.withTools().
+	 * Converts via JSON string to avoid the lossy org.json toMap() conversion.
 	 */
 	private List<Map<String, Object>> getToolsFromEngine(IEngine engine, String engineId) {
 		JSONObject toolMap = MCPUtility.getAggregatedTools(engine);
 		JSONObject updatedToolMap = MCPUtility.appendEngineIdToToolsMethodName(engineId, toolMap);
 		if (updatedToolMap != null && updatedToolMap.has("tools")) {
-			JSONArray arr = updatedToolMap.getJSONArray("tools");
-			List<Map<String, Object>> result = new ArrayList<>();
-			for (int i = 0; i < arr.length(); i++) {
-				JSONObject toolObj = arr.optJSONObject(i);
-				if (toolObj != null) {
-					result.add(toolObj.toMap());
-				}
-			}
-			return result;
+			String toolsJson = updatedToolMap.getJSONArray("tools").toString();
+			List<Map<String, Object>> result = GSON.fromJson(toolsJson, LIST_MAP_TYPE);
+			return result != null ? result : Collections.emptyList();
 		}
 		return Collections.emptyList();
 	}

--- a/src/prerna/reactor/workflow/engine/handlers/LLMAgentStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/LLMAgentStepHandler.java
@@ -1,0 +1,204 @@
+package prerna.reactor.workflow.engine.handlers;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import prerna.engine.api.IEngine;
+import prerna.engine.api.IMCP;
+import prerna.engine.api.IModelEngine;
+import prerna.engine.impl.MCPFactory;
+import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.message.InputMessage;
+import prerna.engine.impl.model.message.MessageType;
+import prerna.engine.impl.model.message.ResponseMessage;
+import prerna.engine.impl.model.responses.AskModelEngineResponse;
+import prerna.om.Insight;
+import prerna.reactor.workflow.engine.StepResult;
+import prerna.reactor.workflow.engine.WorkflowContext;
+import prerna.util.Utility;
+import prerna.reactor.agent.mcp.MCPUtility;
+
+/**
+ * Full agentic LLM loop: sends a prompt with tools, handles tool calls iteratively
+ * until the model returns a text response or max iterations are reached.
+ * 
+ * Config:
+ *   modelId        - the model engine ID
+ *   systemPrompt   - system prompt (optional)
+ *   userPrompt     - the user message to send
+ *   toolEngineIds  - list of engine/project IDs whose MCP tools are available
+ *   paramMap       - optional model parameters (temperature, etc.)
+ *   maxIterations  - max tool-call rounds before forcing stop (default: 10)
+ */
+public class LLMAgentStepHandler implements IWorkflowStepHandler {
+
+	private static final Logger classLogger = LogManager.getLogger(LLMAgentStepHandler.class);
+	private static final int DEFAULT_MAX_ITERATIONS = 10;
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public StepResult execute(String stepId, Map<String, Object> config,
+			WorkflowContext context, Insight insight) {
+		long start = System.currentTimeMillis();
+
+		String modelId = (String) config.get("modelId");
+		String systemPrompt = (String) config.get("systemPrompt");
+		String userPrompt = (String) config.get("userPrompt");
+		List<String> toolEngineIds = (List<String>) config.get("toolEngineIds");
+		Map<String, Object> paramMap = (Map<String, Object>) config.get("paramMap");
+		int maxIterations = config.containsKey("maxIterations")
+				? ((Number) config.get("maxIterations")).intValue()
+				: DEFAULT_MAX_ITERATIONS;
+
+		if (modelId == null || modelId.isEmpty()) {
+			return StepResult.error(stepId, "LLM_AGENT step requires 'modelId' in config",
+					System.currentTimeMillis() - start);
+		}
+		if (userPrompt == null || userPrompt.isEmpty()) {
+			return StepResult.error(stepId, "LLM_AGENT step requires 'userPrompt' in config",
+					System.currentTimeMillis() - start);
+		}
+
+		try {
+			IModelEngine modelEngine = (IModelEngine) Utility.getEngine(modelId);
+			if (modelEngine == null) {
+				return StepResult.error(stepId, "Model engine not found: " + modelId,
+						System.currentTimeMillis() - start);
+			}
+
+			// Gather MCP tool definitions from all specified tool engines
+			List<Map<String, Object>> allTools = new ArrayList<>();
+			Map<String, IMCP> toolNameToMcp = new HashMap<>();
+			if (toolEngineIds != null) {
+				for (String engineId : toolEngineIds) {
+					IEngine engine = Utility.getEngine(engineId);
+					if (engine == null) {
+						engine = Utility.getProject(engineId);
+					}
+					if (engine != null) {
+						IMCP mcp = MCPFactory.build(engine);
+						List<Map<String, Object>> tools = getToolsFromEngine(engine, engineId);
+						for (Map<String, Object> tool : tools) {
+							Map<String, Object> fn = (Map<String, Object>) tool.get("function");
+							if (fn != null) {
+								String name = (String) fn.get("name");
+								if (name != null) {
+									toolNameToMcp.put(name, mcp);
+								}
+							}
+						}
+						allTools.addAll(tools);
+					}
+				}
+			}
+
+			// Create room and build initial message
+			Room room = new Room();
+			room.setInsight(insight);
+
+			InputMessage msg = InputMessage.builder(room)
+					.withSystemPrompt(systemPrompt)
+					.withInputUIPrompt(userPrompt)
+					.withInputPrompt(userPrompt)
+					.withModelType(modelEngine.getModelType())
+					.withParamMap(paramMap)
+					.withTools(allTools)
+					.build();
+
+			ResponseMessage response = room.ask(msg, modelEngine);
+			int iterations = 0;
+
+			// Agent loop: handle tool calls until text response or max iterations
+			while (response.getMessageType() == MessageType.RESPONSE_TOOL && iterations < maxIterations) {
+				iterations++;
+
+				List<Map<String, Object>> toolCalls = response.getToolResponses();
+				if (toolCalls == null || toolCalls.isEmpty()) break;
+
+				AskModelEngineResponse<?> lastAskResponse = null;
+
+				for (Map<String, Object> toolCall : toolCalls) {
+					String toolCallId = String.valueOf(toolCall.get("id"));
+					Map<String, Object> function = (Map<String, Object>) toolCall.get("function");
+					String toolName = (String) function.get("name");
+					Map<String, Object> toolParams = (Map<String, Object>) function.get("arguments");
+
+					// Execute the tool via the mapped MCP instance
+					Object toolOutput = null;
+					String toolStatus = "success";
+					IMCP mcp = toolNameToMcp.get(toolName);
+					if (mcp != null) {
+						try {
+							toolOutput = mcp.callTool(toolName, toolParams, insight);
+						} catch (Exception e) {
+							toolOutput = "Error: " + e.getMessage();
+							toolStatus = "error";
+						}
+					} else {
+						toolOutput = "No MCP handler found for tool: " + toolName;
+						toolStatus = "error";
+					}
+
+					String resultStr = toolOutput != null ? toolOutput.toString() : "No output";
+
+					// Feed tool result back to the room
+					lastAskResponse = room.addToolExecutionResult(
+							toolCallId, toolName, resultStr, toolParams,
+							paramMap, null, modelEngine, insight, toolStatus);
+				}
+
+				// addToolExecutionResult re-asks the model when all tool calls are fulfilled
+				if (lastAskResponse != null) {
+					response = ResponseMessage.Builder
+							.fromAskModelEngineResponse(lastAskResponse).build();
+				} else {
+					break;
+				}
+			}
+
+			if (response.getMessageType() == MessageType.RESPONSE_TEXT) {
+				String text = response.getContent();
+				StepResult result = StepResult.success(stepId, text, System.currentTimeMillis() - start);
+				result.getMetadata().put("iterations", iterations);
+				result.getMetadata().put("messageId", response.getMessageId());
+				return result;
+			} else {
+				return StepResult.error(stepId,
+						"Agent loop exhausted after " + maxIterations + " iterations without a text response",
+						System.currentTimeMillis() - start);
+			}
+		} catch (Exception e) {
+			classLogger.error("LLM_AGENT step '{}' failed", stepId, e);
+			return StepResult.error(stepId, "LLM agent failed: " + e.getMessage(),
+					System.currentTimeMillis() - start);
+		}
+	}
+
+	/**
+	 * Load tool definitions from an engine in the List of Map format expected by InputMessage.withTools().
+	 */
+	private List<Map<String, Object>> getToolsFromEngine(IEngine engine, String engineId) {
+		JSONObject toolMap = MCPUtility.getAggregatedTools(engine);
+		JSONObject updatedToolMap = MCPUtility.appendEngineIdToToolsMethodName(engineId, toolMap);
+		if (updatedToolMap != null && updatedToolMap.has("tools")) {
+			JSONArray arr = updatedToolMap.getJSONArray("tools");
+			List<Map<String, Object>> result = new ArrayList<>();
+			for (int i = 0; i < arr.length(); i++) {
+				JSONObject toolObj = arr.optJSONObject(i);
+				if (toolObj != null) {
+					result.add(toolObj.toMap());
+				}
+			}
+			return result;
+		}
+		return Collections.emptyList();
+	}
+}

--- a/src/prerna/reactor/workflow/engine/handlers/LLMAskStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/LLMAskStepHandler.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine.handlers;
 
 import java.util.Map;
@@ -5,6 +32,7 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import prerna.auth.utils.SecurityEngineUtils;
 import prerna.engine.api.IModelEngine;
 import prerna.engine.impl.model.Room;
 import prerna.engine.impl.model.message.InputMessage;
@@ -50,6 +78,10 @@ public class LLMAskStepHandler implements IWorkflowStepHandler {
 		}
 
 		try {
+			if (!SecurityEngineUtils.userCanViewEngine(insight.getUser(), modelId)) {
+				return StepResult.error(stepId, "User does not have access to model engine: " + modelId,
+						System.currentTimeMillis() - start);
+			}
 			IModelEngine modelEngine = (IModelEngine) Utility.getEngine(modelId);
 			if (modelEngine == null) {
 				return StepResult.error(stepId, "Model engine not found: " + modelId,
@@ -62,8 +94,7 @@ public class LLMAskStepHandler implements IWorkflowStepHandler {
 
 			InputMessage msg = InputMessage.builder(room)
 					.withSystemPrompt(systemPrompt)
-					.withInputUIPrompt(userPrompt)
-					.withInputPrompt(userPrompt)
+					.withText(userPrompt, userPrompt)
 					.withModelType(modelEngine.getModelType())
 					.withParamMap(paramMap)
 					.build();

--- a/src/prerna/reactor/workflow/engine/handlers/LLMAskStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/LLMAskStepHandler.java
@@ -1,0 +1,90 @@
+package prerna.reactor.workflow.engine.handlers;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.engine.api.IModelEngine;
+import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.message.InputMessage;
+import prerna.engine.impl.model.message.MessageType;
+import prerna.engine.impl.model.message.ResponseMessage;
+import prerna.om.Insight;
+import prerna.reactor.workflow.engine.StepResult;
+import prerna.reactor.workflow.engine.WorkflowContext;
+import prerna.util.Utility;
+
+/**
+ * Sends a single prompt to an LLM and returns the text response.
+ * No tool calling — for agentic behavior use LLM_AGENT instead.
+ * 
+ * Config:
+ *   modelId      — the model engine ID
+ *   systemPrompt — system prompt (optional)
+ *   userPrompt   — the user message to send
+ *   paramMap     — optional model parameters (temperature, etc.)
+ */
+public class LLMAskStepHandler implements IWorkflowStepHandler {
+
+	private static final Logger classLogger = LogManager.getLogger(LLMAskStepHandler.class);
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public StepResult execute(String stepId, Map<String, Object> config,
+			WorkflowContext context, Insight insight) {
+		long start = System.currentTimeMillis();
+
+		String modelId = (String) config.get("modelId");
+		String systemPrompt = (String) config.get("systemPrompt");
+		String userPrompt = (String) config.get("userPrompt");
+		Map<String, Object> paramMap = (Map<String, Object>) config.get("paramMap");
+
+		if (modelId == null || modelId.isEmpty()) {
+			return StepResult.error(stepId, "LLM_ASK step requires 'modelId' in config",
+					System.currentTimeMillis() - start);
+		}
+		if (userPrompt == null || userPrompt.isEmpty()) {
+			return StepResult.error(stepId, "LLM_ASK step requires 'userPrompt' in config",
+					System.currentTimeMillis() - start);
+		}
+
+		try {
+			IModelEngine modelEngine = (IModelEngine) Utility.getEngine(modelId);
+			if (modelEngine == null) {
+				return StepResult.error(stepId, "Model engine not found: " + modelId,
+						System.currentTimeMillis() - start);
+			}
+
+			// Create a transient room for this step
+			Room room = new Room();
+			room.setInsight(insight);
+
+			InputMessage msg = InputMessage.builder(room)
+					.withSystemPrompt(systemPrompt)
+					.withInputUIPrompt(userPrompt)
+					.withInputPrompt(userPrompt)
+					.withModelType(modelEngine.getModelType())
+					.withParamMap(paramMap)
+					.build();
+
+			ResponseMessage response = room.ask(msg, modelEngine);
+
+			if (response.getMessageType() == MessageType.RESPONSE_TEXT) {
+				String text = response.getContent();
+				StepResult result = StepResult.success(stepId, text, System.currentTimeMillis() - start);
+				result.getMetadata().put("messageId", response.getMessageId());
+				return result;
+			} else {
+				// Unexpected response type (e.g., tool call with no tools attached)
+				return StepResult.error(stepId,
+						"LLM returned unexpected response type: " + response.getMessageType(),
+						System.currentTimeMillis() - start);
+			}
+		} catch (Exception e) {
+			classLogger.error("LLM_ASK step '{}' failed", stepId, e);
+			return StepResult.error(stepId, "LLM ask failed: " + e.getMessage(),
+					System.currentTimeMillis() - start);
+		}
+	}
+}

--- a/src/prerna/reactor/workflow/engine/handlers/OutputStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/OutputStepHandler.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine.handlers;
 
 import java.util.Map;

--- a/src/prerna/reactor/workflow/engine/handlers/OutputStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/OutputStepHandler.java
@@ -1,0 +1,24 @@
+package prerna.reactor.workflow.engine.handlers;
+
+import java.util.Map;
+
+import prerna.om.Insight;
+import prerna.reactor.workflow.engine.StepResult;
+import prerna.reactor.workflow.engine.WorkflowContext;
+
+/**
+ * Terminal step that passes through its input as the workflow's final output.
+ * 
+ * Config:
+ *   value — the value to output (typically a template reference like {{prev-step.output}})
+ */
+public class OutputStepHandler implements IWorkflowStepHandler {
+
+	@Override
+	public StepResult execute(String stepId, Map<String, Object> config,
+			WorkflowContext context, Insight insight) {
+		long start = System.currentTimeMillis();
+		Object value = config.get("value");
+		return StepResult.success(stepId, value, System.currentTimeMillis() - start);
+	}
+}

--- a/src/prerna/reactor/workflow/engine/handlers/RunPixelStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/RunPixelStepHandler.java
@@ -1,0 +1,53 @@
+package prerna.reactor.workflow.engine.handlers;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.om.Insight;
+import prerna.reactor.workflow.engine.StepResult;
+import prerna.reactor.workflow.engine.WorkflowContext;
+import prerna.sablecc2.PixelRunner;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+/**
+ * Executes a Pixel recipe string and returns its result.
+ * 
+ * Config:
+ *   recipe — the Pixel expression to execute (e.g., "Query(engine=\"uuid\", query=\"SELECT ...\");")
+ */
+public class RunPixelStepHandler implements IWorkflowStepHandler {
+
+	private static final Logger classLogger = LogManager.getLogger(RunPixelStepHandler.class);
+
+	@Override
+	public StepResult execute(String stepId, Map<String, Object> config,
+			WorkflowContext context, Insight insight) {
+		long start = System.currentTimeMillis();
+
+		String recipe = (String) config.get("recipe");
+		if (recipe == null || recipe.trim().isEmpty()) {
+			return StepResult.error(stepId, "RunPixel step requires a 'recipe' in config",
+					System.currentTimeMillis() - start);
+		}
+
+		try {
+			PixelRunner runner = insight.runPixel(recipe);
+			List<NounMetadata> results = runner.getResults();
+
+			Object output = null;
+			if (results != null && !results.isEmpty()) {
+				NounMetadata lastResult = results.get(results.size() - 1);
+				output = lastResult.getValue();
+			}
+
+			return StepResult.success(stepId, output, System.currentTimeMillis() - start);
+		} catch (Exception e) {
+			classLogger.error("RunPixel step '{}' failed", stepId, e);
+			return StepResult.error(stepId, "Pixel execution failed: " + e.getMessage(),
+					System.currentTimeMillis() - start);
+		}
+	}
+}

--- a/src/prerna/reactor/workflow/engine/handlers/RunPixelStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/RunPixelStepHandler.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine.handlers;
 
 import java.util.List;
@@ -30,6 +57,14 @@ public class RunPixelStepHandler implements IWorkflowStepHandler {
 		String recipe = (String) config.get("recipe");
 		if (recipe == null || recipe.trim().isEmpty()) {
 			return StepResult.error(stepId, "RunPixel step requires a 'recipe' in config",
+					System.currentTimeMillis() - start);
+		}
+
+		// Block runtime template expressions in recipe to prevent Pixel injection via LLM output.
+		// recipe values must be static strings set at workflow design time.
+		if (recipe.contains("{{") && recipe.contains("}}")) {
+			return StepResult.error(stepId,
+					"RunPixel recipe must be a static Pixel expression. Dynamic template references are not permitted.",
 					System.currentTimeMillis() - start);
 		}
 

--- a/src/prerna/reactor/workflow/engine/handlers/RunToolStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/RunToolStepHandler.java
@@ -1,0 +1,64 @@
+package prerna.reactor.workflow.engine.handlers;
+
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.engine.api.IEngine;
+import prerna.engine.api.IMCP;
+import prerna.engine.impl.MCPFactory;
+import prerna.om.Insight;
+import prerna.reactor.workflow.engine.StepResult;
+import prerna.reactor.workflow.engine.WorkflowContext;
+import prerna.util.Utility;
+
+/**
+ * Executes an MCP tool on an engine and returns the result.
+ * 
+ * Config:
+ *   engineId  — the engine/project ID that hosts the tool
+ *   toolName  — the tool name to invoke
+ *   params    — Map of parameters to pass to the tool
+ */
+public class RunToolStepHandler implements IWorkflowStepHandler {
+
+	private static final Logger classLogger = LogManager.getLogger(RunToolStepHandler.class);
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public StepResult execute(String stepId, Map<String, Object> config,
+			WorkflowContext context, Insight insight) {
+		long start = System.currentTimeMillis();
+
+		String engineId = (String) config.get("engineId");
+		String toolName = (String) config.get("toolName");
+		Map<String, Object> params = (Map<String, Object>) config.get("params");
+
+		if (engineId == null || engineId.isEmpty()) {
+			return StepResult.error(stepId, "RunTool step requires 'engineId' in config",
+					System.currentTimeMillis() - start);
+		}
+		if (toolName == null || toolName.isEmpty()) {
+			return StepResult.error(stepId, "RunTool step requires 'toolName' in config",
+					System.currentTimeMillis() - start);
+		}
+
+		try {
+			IEngine engine = Utility.getEngine(engineId);
+			if (engine == null) {
+				return StepResult.error(stepId, "Engine not found: " + engineId,
+						System.currentTimeMillis() - start);
+			}
+
+			IMCP mcp = MCPFactory.build(engine);
+			Object output = mcp.callTool(toolName, params, insight);
+
+			return StepResult.success(stepId, output, System.currentTimeMillis() - start);
+		} catch (Exception e) {
+			classLogger.error("RunTool step '{}' failed", stepId, e);
+			return StepResult.error(stepId, "Tool execution failed: " + e.getMessage(),
+					System.currentTimeMillis() - start);
+		}
+	}
+}

--- a/src/prerna/reactor/workflow/engine/handlers/RunToolStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/RunToolStepHandler.java
@@ -1,3 +1,30 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine.handlers;
 
 import java.util.Map;
@@ -5,6 +32,7 @@ import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import prerna.auth.utils.SecurityEngineUtils;
 import prerna.engine.api.IEngine;
 import prerna.engine.api.IMCP;
 import prerna.engine.impl.MCPFactory;
@@ -45,6 +73,10 @@ public class RunToolStepHandler implements IWorkflowStepHandler {
 		}
 
 		try {
+			if (!SecurityEngineUtils.userCanViewEngine(insight.getUser(), engineId)) {
+				return StepResult.error(stepId, "User does not have access to engine: " + engineId,
+						System.currentTimeMillis() - start);
+			}
 			IEngine engine = Utility.getEngine(engineId);
 			if (engine == null) {
 				return StepResult.error(stepId, "Engine not found: " + engineId,

--- a/src/prerna/reactor/workflow/engine/handlers/StaticStepHandler.java
+++ b/src/prerna/reactor/workflow/engine/handlers/StaticStepHandler.java
@@ -1,0 +1,25 @@
+package prerna.reactor.workflow.engine.handlers;
+
+import java.util.Map;
+
+import prerna.om.Insight;
+import prerna.reactor.workflow.engine.StepResult;
+import prerna.reactor.workflow.engine.WorkflowContext;
+
+/**
+ * Simplest handler — returns a static value from config.
+ * Useful for injecting constants, default values, or test data into a workflow.
+ * 
+ * Config:
+ *   value — the value to output (any type)
+ */
+public class StaticStepHandler implements IWorkflowStepHandler {
+
+	@Override
+	public StepResult execute(String stepId, Map<String, Object> config,
+			WorkflowContext context, Insight insight) {
+		long start = System.currentTimeMillis();
+		Object value = config.get("value");
+		return StepResult.success(stepId, value, System.currentTimeMillis() - start);
+	}
+}

--- a/src/prerna/reactor/workflow/engine/handlers/WorkflowStepHandlerRegistry.java
+++ b/src/prerna/reactor/workflow/engine/handlers/WorkflowStepHandlerRegistry.java
@@ -1,0 +1,49 @@
+package prerna.reactor.workflow.engine.handlers;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import prerna.reactor.workflow.engine.WorkflowStep;
+
+/**
+ * Registry that maps step type strings to their handler implementations.
+ */
+public class WorkflowStepHandlerRegistry {
+
+	private static final Map<String, IWorkflowStepHandler> HANDLERS = new HashMap<>();
+
+	static {
+		HANDLERS.put(WorkflowStep.STEP_TYPE.STATIC.name(), new StaticStepHandler());
+		HANDLERS.put(WorkflowStep.STEP_TYPE.CONDITION.name(), new ConditionStepHandler());
+		HANDLERS.put(WorkflowStep.STEP_TYPE.OUTPUT.name(), new OutputStepHandler());
+		HANDLERS.put(WorkflowStep.STEP_TYPE.RUN_PIXEL.name(), new RunPixelStepHandler());
+		HANDLERS.put(WorkflowStep.STEP_TYPE.RUN_TOOL.name(), new RunToolStepHandler());
+		HANDLERS.put(WorkflowStep.STEP_TYPE.LLM_ASK.name(), new LLMAskStepHandler());
+		HANDLERS.put(WorkflowStep.STEP_TYPE.LLM_AGENT.name(), new LLMAgentStepHandler());
+	}
+
+	/**
+	 * Get the handler for a given step type.
+	 * 
+	 * @param type the step type string (e.g., "LLM_ASK", "RUN_TOOL")
+	 * @return the handler, or null if no handler is registered for this type
+	 */
+	public static IWorkflowStepHandler getHandler(String type) {
+		return HANDLERS.get(type);
+	}
+
+	/**
+	 * Register a custom handler for a step type.
+	 * Can be used to override built-in handlers or add new types.
+	 */
+	public static void register(String type, IWorkflowStepHandler handler) {
+		HANDLERS.put(type, handler);
+	}
+
+	/**
+	 * Check if a handler exists for the given type.
+	 */
+	public static boolean hasHandler(String type) {
+		return HANDLERS.containsKey(type);
+	}
+}

--- a/src/prerna/reactor/workflow/engine/handlers/WorkflowStepHandlerRegistry.java
+++ b/src/prerna/reactor/workflow/engine/handlers/WorkflowStepHandlerRegistry.java
@@ -1,16 +1,45 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
 package prerna.reactor.workflow.engine.handlers;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import prerna.reactor.workflow.engine.WorkflowStep;
 
 /**
  * Registry that maps step type strings to their handler implementations.
  */
-public class WorkflowStepHandlerRegistry {
+public final class WorkflowStepHandlerRegistry {
 
-	private static final Map<String, IWorkflowStepHandler> HANDLERS = new HashMap<>();
+	private static final Map<String, IWorkflowStepHandler> HANDLERS = new ConcurrentHashMap<>();
+
+	private WorkflowStepHandlerRegistry() {}
 
 	static {
 		HANDLERS.put(WorkflowStep.STEP_TYPE.STATIC.name(), new StaticStepHandler());


### PR DESCRIPTION
# feat(agent): Agent Observability, Workflow Engine, and Dashboard

## Description

Implements the first two phases of the SEMOSS agent infrastructure improvements documented in
`workspace/docs/ai-agents-pk/`. This PR follows the 6-phase roadmap (`05-implementation-roadmap.md`)
and builds exclusively using SEMOSS-native idioms — no foreign patterns, no standalone
infrastructure classes.

**Phase 1 (Decision Tracing):** Fully implemented — every `RoomAgentHarness` run now emits a
full decision trace to the `ModelInferenceLogsDatabase` (H2), regardless of success or failure.

**Workflow Engine (cherry-pick from `parth-workflow-idea` + review hardening):** 9-step-type
DAG executor with security checks, injection protection, diamond-CONDITION deadlock fix, and all
18 review findings applied.

**Agent Observability Dashboard:** Admin-facing Pixel backend (`AgentSummaryMetrics`) powering a
dark-mode portal with KPI cards, bar charts, trace table, and drilldown modal.

**Phase 2 (Eval Engine) + Phase 3 (Task Spec/Policy):** Interface-level scaffolding only.
Concrete implementations are tracked in the Phase 2 and Phase 3 backlog items.

---

## Changes Made

### `prerna/reactor/agent/AgentHarnessResult.java`
- Removed `final` from class declaration to allow future subclassing
- Added static `Builder` (consistent with `AgentRunContext` pattern)
- Added new nullable trace fields: `traceId`, `roomId`, `modelEngineId`, `startTime`,
  `endTime`, `steps`, `metrics`, `terminationReason`
- Added inner class `DecisionStep` — observable artifacts only (message IDs, tool call
  records, guardrails fired, token counts, timestamps). No provider-specific fields.
- **Zero breaking changes** — both existing constructors are preserved and still set all
  new fields to `null`/empty

### `prerna/reactor/agent/RoomAgentHarness.java`
- Wrapped `execute()` body in `try/catch/finally`; trace is always emitted — even on
  `AgentMaxIterationsException` or unexpected exceptions
- `terminationReason` is set to `"SUCCESS"`, `"MAX_ITERATIONS"`, or `"EXCEPTION:<msg>"`
- `keepInputOutput()` is resolved on the calling thread before async dispatch (not across
  thread boundaries)
- Per-iteration `DecisionStep` records accumulated via updated `driveToolLoop()` signature
- Async trace persistence via `CompletableFuture.runAsync()` with exception logging

### `prerna/engine/impl/model/inferencetracking/AgentTraceLogsUtils.java` *(new)*
- `initSchema()` — creates `AGENT_TRACE` and `AGENT_TRACE_STEP` tables if they don't exist,
  using the same `createTableIfNotExists` / `queryUtil` pattern as `ModelInferenceLogsUtils`
- `logTrace(result, userId, keepContent)` — inserts trace + step records; redacts tool call
  content when `keepContent=false` (only stores count, not results)
- `listTraces(roomId, limit)` — trace summaries for a room (no content — IDs + metadata only)
- `getTrace(traceId)` — full trace header + ordered steps

### `prerna/reactor/agent/trace/GetAgentTraceReactor.java` *(new)*
- Pixel: `GetAgentTrace(traceId=["abc123"])`
- Security: verifies requesting user owns the trace or is admin; strips `userId` from response

### `prerna/reactor/agent/trace/ListAgentTracesReactor.java` *(new)*
- Pixel: `ListAgentTraces(roomId=["room1"], limit=[50])`
- `roomId` is now **optional** — admin calling with no roomId returns all rooms via `listAllTraces()`
- Security: verifies user has access to the room via `RoomUtils.getRoom()` (non-admin path)
- Returns summaries only (no content) — safe for all users who can access the room

### `prerna/reactor/agent/trace/AgentSummaryMetricsReactor.java` *(new)*
- Pixel: `AgentSummaryMetrics()`
- Admin-only (`SecurityAdminUtils.userIsAdmin(user)`)
- Returns 8 KPI fields: `totalCalls`, `successCalls`, `errorCalls`, `errorRate`,
  `avgLatencyMs`, `totalDurationMs`, `callsLast24h`, `dailyCallsLast7Days` (for bar chart)

### `prerna/engine/impl/model/inferencetracking/AgentTraceLogsUtils.java`
- Added `listAllTraces(limit)` — admin all-rooms trace list, no room filter
- Added `getMetrics()` — 5 SQL queries (totals, 24h count, 7-day bucketed by day) + Java-side
  day-of-week bucketing for consistent chart data even with sparse days

### `prerna/engine/impl/model/inferencetracking/ModelInferenceLogsOwlCreator.java`
- Added `AGENT_TRACE` and `AGENT_TRACE_STEP` to `allSchemas` + `conceptsRequired`
- Schema owned entirely by OWL creator; `needsRemake()` auto-rebuilds on missing tables
- Types use DB-agnostic constants: `CLOB_DATATYPE_NAME`, `INTEGER_DATATYPE_NAME`, `TIMESTAMP_DATATYPE_NAME`
- Removed `AgentTraceLogsUtils.initSchema()` — schema bootstrap no longer needed

---

### Workflow Engine (`prerna/reactor/workflow/`)

#### Reactors
- **`RunWorkflowReactor`** — `RunWorkflow(project=[...], variables=[{...}])`; `Utility.getProject()` null-check; `SemossPixelException`; `PixelOperationType.OPERATION`
- **`SaveWorkflowReactor`** — `SaveWorkflow(project=[...], definition=[{...}])`; same hardening
- **`GetWorkflowStatusReactor`** — `GetWorkflowStatus(project=[...], workflowId=[...])`; same hardening

#### Engine
- **`WorkflowExecutor`** — DAG runner with `CompletableFuture`-based parallel step execution
  - Diamond-CONDITION deadlock fix: `getNotTakenSuccessors()` phantom-decrements in-degree of
    join nodes on the not-taken branch so they are never left blocked at 1
- **`WorkflowTemplateEngine`** — `final`, private constructor, `GsonBuilder`; handles `{{varName}}` substitution
- **`WorkflowDefinition`** — `InputStreamReader(UTF_8)` (was `FileReader`)
- **`WorkflowSettings`** — removed undocumented `"retry"` option from comment
- **`WorkflowStepHandlerRegistry`** — `final`, private constructor, `ConcurrentHashMap`
- **`StepResult`** — explicit imports (no wildcard)

#### Step Handlers
- **`LLMAskStepHandler`** — `SecurityEngineUtils.userCanViewEngine()` check before engine lookup
- **`LLMAgentStepHandler`** — same security check; `org.json.JSONArray` replaced with Gson `TypeToken`
- **`RunToolStepHandler`** — same security check
- **`RunPixelStepHandler`** — template injection blocked: rejects recipe containing `{{...}}` patterns
- `StaticStepHandler`, `ConditionStepHandler`, `OutputStepHandler` — unchanged (included in cherry-pick)

#### Reactor Registration
- `ReactorFactory` updated to register `RunWorkflow`, `SaveWorkflow`, `GetWorkflowStatus`, `AgentSummaryMetrics`

---

### Review Agents (`.github/agents/`)
- `reviewer.agent.md` — standard code reviewer agent
- `maher-review.agent.md` — Maher-style adversarial reviewer

---

### `prerna/engine/api/IEvalEngine.java` *(new — Phase 2 scaffold)*
- `IEvalEngine extends IEngine` with `evaluate(AgentEvalContext)`, `getEvalSpec()`,
  `evaluateBatch()` (default serial impl)
- Explicitly NOT `extends IFunctionEngine` — eval engines are meta-system components,
  not callable agent tools

### `prerna/reactor/agent/eval/AgentEvalContext.java` *(new — Phase 2 scaffold)*
- Immutable eval context: traceId, roomId, modelEngineId, userId, originalInput, result,
  taskSpec, steps. Builder pattern + convenience factory from result.

### `prerna/reactor/agent/eval/EvalResult.java` *(new — Phase 2 scaffold)*
- PASS/FAIL/ERROR status, ordered failure list (code + message), normalized 0.0–1.0 score

### `prerna/reactor/agent/eval/EvalSpec.java` *(new — Phase 2 scaffold)*
- Eval criteria loaded from .smss: requiredOutcomes, forbiddenActions, maxIterations, maxDuration

### `prerna/reactor/agent/policy/IAgentPolicy.java` *(new — Phase 3 scaffold)*
- `preRunCheck`, `iterationCheck`, `postRunCheck` lifecycle

### `prerna/reactor/agent/policy/PolicyDecision.java` *(new — Phase 3 scaffold)*
- ALLOW / BLOCK / ESCALATE_TO_HUMAN with reason string

---

## How to Test

### 1. Schema Bootstrap
```
# Start the SEMOSS server. On startup, call AgentTraceLogsUtils.initSchema() after
# ModelInferenceLogsUtils.initModelInferenceLogsDatabase() in the startup path.
# Verify AGENT_TRACE and AGENT_TRACE_STEP tables exist in the inference logs DB.
```

### 2. Trace Emission (basic)
```
# In a room with a model engine and MCP tools configured:
RunAgent(roomId=["your-room-id"], input=["What is 2+2?"])

# Then list traces:
ListAgentTraces(roomId=["your-room-id"])
# Expected: one trace entry with terminationReason="SUCCESS", iterations>=0

# Fetch full trace:
GetAgentTrace(traceId=["<id from list>"])
# Expected: header + steps (step count matches iterations)
```

### 3. Failure Trace
```
# Configure a room with maxIterations=1 and a multi-step task
RunAgent(roomId=["loop-room-id"], input=["complex multi-step task"])
# Expected: trace with terminationReason="MAX_ITERATIONS"

# Verify trace IS present even though execution threw AgentMaxIterationsException
ListAgentTraces(roomId=["loop-room-id"])
```

### 4. Workflow Engine
```
# Create a simple 2-step workflow JSON and upload to a project:
# { "steps": [{ "type":"LLM_ASK", "id":"s1", "engineId":"<llm-engine-id>", "prompt":"Say hi" },
#              { "type":"STATIC", "id":"s2", "value":"done" }], "edges": [{"from":"s1","to":"s2"}] }

# Save it:
SaveWorkflow(project=["<project-id>"], definition=[{...}])

# Run it:
RunWorkflow(project=["<project-id>"], workflowId=["<id>"], variables=[{}])
# Expected: result map with step outputs

# Check status:
GetWorkflowStatus(project=["<project-id>"], workflowId=["<id>"])

# Verify injection protection:
# Create a workflow with RunPixelStepHandler and recipe containing "{{evilVar}}"
# Expected: SemossPixelException "Template injection not allowed in recipe"
```

### 5. Agent Observability Dashboard
```
# As an admin user:
AgentSummaryMetrics()
# Expected: map with totalCalls, successCalls, errorCalls, errorRate, avgLatencyMs,
#           totalDurationMs, callsLast24h, dailyCallsLast7Days (list of 7 maps)

# List all traces (admin, no roomId):
ListAgentTraces(limit=[20])
# Expected: list of all trace summaries across all rooms

# Visit dashboard portal:
# http://localhost:9091/Monolith/public_home/8d069588-650e-4bba-a4be-0a326087d976/portals/index.html
# Expected: dark-mode dashboard with KPI cards loading from AgentSummaryMetrics() and
#           trace table from ListAgentTraces(); 60s auto-refresh; drilldown modal on row click
```

### 6. Content Retention Policy
```
# Configure a model engine with KEEP_INPUT_OUTPUT=false in its .smss
# Run an agent in a room using that engine
# In the DB directly: SELECT TOOL_CALLS_JSON FROM AGENT_TRACE_STEP WHERE TRACE_ID = '...'
# Expected: {"count":N} (not the full tool call content)
```

### 5. Security
```
# Attempt to fetch a trace owned by a different user (non-admin)
GetAgentTrace(traceId=["trace-belonging-to-other-user"])
# Expected: "Access denied to trace" error
```

### 6. Backward Compatibility
```
# Any code constructing AgentHarnessResult via old constructors:
new AgentHarnessResult(text, iter, records)
new AgentHarnessResult(text, iter, records, reflections)
# Both must still compile and produce results with null trace fields
# All callers of getFinalText(), getIterations(), getToolCallRecords(), getReflectionsUsed()
# must be unaffected
```

---

## Notes

- Schema bootstrap is fully automatic via `ModelInferenceLogsOwlCreator`. No manual `initSchema()`
  call is required. Tables are created/rebuilt by `needsRemake()` on startup.
- Workflow JSON files are stored in `<project>/app_root/workflows/`. The `SaveWorkflow` reactor
  handles creation. `RunWorkflow` loads and validates the file before starting the executor.
- The diamond-CONDITION fix in `WorkflowExecutor` is critical for any workflow with a condition
  that fans out and rejoins. Without it, the join node stalls permanently at `inDegree=1`.
- The async trace persistence uses `CompletableFuture.runAsync()` with the JVM common pool.
  For high-throughput environments, replace with a dedicated `ScheduledExecutorService` —
  same pattern as `ModelEngineInferenceLogsWorker`.
- Phase 2 (`CATALOG_TYPE.EVAL`, concrete eval engines) and Phase 3 (AgentPolicyResolver,
  PolicyAgentHarness, OrchestratorAgentHarness) are tracked as separate backlog items.
- `RunWorkflow` as an MCP tool for playground agents is on the backlog.
