### PR TITLE
feat: add SPARQL query reactors and raw URI support for RDF databases

### DIFF
--- a/src/prerna/auth/utils/reactors/admin/AdminSqlQueryReactor.java
+++ b/src/prerna/auth/utils/reactors/admin/AdminSqlQueryReactor.java
@@ -192,7 +192,7 @@ public class AdminSqlQueryReactor extends AbstractReactor {
 			BasicIteratorTask task = new BasicIteratorTask(qs);
 			task.setNumCollect(limit);
 			task.setCollectLimit(limit);
-			this.insight.addQueriedDatabasesese(databaseId);
+			this.insight.addQueriedDatabases(databaseId);
 			return new NounMetadata(task, PixelDataType.FORMATTED_DATA_SET);
 		} catch (Exception e) {
 			classLogger.error("Unable to execute the admin SELECT query.", e);

--- a/src/prerna/engine/api/IHeadersDataRow.java
+++ b/src/prerna/engine/api/IHeadersDataRow.java
@@ -33,57 +33,75 @@ import com.google.gson.TypeAdapter;
 
 import prerna.util.gson.HeadersDataRowAdapter;
 
-public interface IHeadersDataRow{
+public interface IHeadersDataRow {
 
 	// Right now there is only one implementation of IHeadersDataRow
-	enum HEADERS_DATA_ROW_TYPE {HEADERS_DATA_ROW};
-	
+	enum HEADERS_DATA_ROW_TYPE {
+		HEADERS_DATA_ROW
+	};
+
 	/**
 	 * Get the type of the header
+	 * 
 	 * @return
 	 */
 	HEADERS_DATA_ROW_TYPE getHeaderType();
-	
+
 	/**
 	 * Get the headers corresponding to the values by index
+	 * 
 	 * @return
 	 */
 	String[] getHeaders();
 
 	/**
-	 * Get the raw headers
-	 * This is useful when we alias headers to be unique during loops
+	 * Get the raw headers This is useful when we alias headers to be unique during
+	 * loops
+	 * 
 	 * @return
 	 */
 	String[] getRawHeaders();
 
 	/**
 	 * Get the values of the row
+	 * 
 	 * @return
 	 */
 	Object[] getValues();
-	
+
 	/**
-	 * Get the raw values
-	 * This is useful if you want to see full URIs from a RDF engine
+	 * Get the raw values This is useful if you want to see full URIs from a RDF
+	 * engine
+	 * 
 	 * @return
 	 */
 	Object[] getRawValues();
 
 	/**
+	 * Set whether getValues() should return raw (full URI / typed literal) or clean
+	 * (processed instance name) values.
+	 * 
+	 * @param raw
+	 */
+	void setRaw(boolean raw);
+
+	/**
 	 * Get the number of records in the row
+	 * 
 	 * @return
 	 */
 	int getRecordLength();
 
 	/**
 	 * This is really only for testing purposes
+	 * 
 	 * @return
 	 */
 	String toRawString();
 
 	/**
 	 * Add new values into an existing headers data row
+	 * 
 	 * @param addHeaders
 	 * @param addValues
 	 */
@@ -91,59 +109,60 @@ public interface IHeadersDataRow{
 
 	/**
 	 * Add a single new column and value
+	 * 
 	 * @param addHeader
 	 * @param addValues
 	 */
 	void addFields(String addHeader, Object addValues);
 
-	
 	/**
 	 * Copy the headers row
+	 * 
 	 * @return
 	 */
 	IHeadersDataRow copy();
-	
-	
+
 	// <<<<<<< Methods to be used for other purposes
-	
-	String toJson();	
-	
+
+	String toJson();
+
 	// gets a particular value
 	void open();
-		
+
 	// add a tuple
 	void addField(String fieldName, Object value);
-	
+
 	// gets a particular field
 	Object getField(String fieldName);
 
 	String getQuery();
-	
+
 	void setQuery(String query);
-	
+
 	Map<String, Object> flushRowToMap();
-	
+
 	/*
 	 * 
 	 * Methods around serialization
 	 * 
 	 */
-	
+
 	// Right now only one ;)
 	static TypeAdapter getAdapterForHeader(HEADERS_DATA_ROW_TYPE type) {
-		if(type == HEADERS_DATA_ROW_TYPE.HEADERS_DATA_ROW) {
+		if (type == HEADERS_DATA_ROW_TYPE.HEADERS_DATA_ROW) {
 			return new HeadersDataRowAdapter();
-		}		
+		}
 		return null;
 	}
-	
+
 	/**
 	 * Convert string to SELECTOR_TYPE
+	 * 
 	 * @param s
 	 * @return
 	 */
 	static HEADERS_DATA_ROW_TYPE convertStringToHeaderType(String s) {
-		if(s.equals(HEADERS_DATA_ROW_TYPE.HEADERS_DATA_ROW.toString())) {
+		if (s.equals(HEADERS_DATA_ROW_TYPE.HEADERS_DATA_ROW.toString())) {
 			return HEADERS_DATA_ROW_TYPE.HEADERS_DATA_ROW;
 		}
 		return null;

--- a/src/prerna/om/HeadersDataRow.java
+++ b/src/prerna/om/HeadersDataRow.java
@@ -27,10 +27,11 @@
  *******************************************************************************/
 package prerna.om;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Vector;
 
 import com.google.gson.Gson;
 
@@ -38,7 +39,7 @@ import prerna.engine.api.IHeadersDataRow;
 import prerna.util.gson.GsonUtility;
 import prerna.util.sql.AbstractSqlQueryUtil;
 
-public class HeadersDataRow implements IHeadersDataRow{
+public class HeadersDataRow implements IHeadersDataRow {
 
 	/**
 	 * Base components corresponding to a header row
@@ -48,15 +49,17 @@ public class HeadersDataRow implements IHeadersDataRow{
 	private Object[] values;
 	private Object[] rawValues;
 	private int recordLength;
-	
-	private Vector <Object> vecValues = null;
-	private Vector <String> vecHeaders = null;
+
+	private boolean raw = false;
+
+	private List<Object> vecValues = null;
+	private List<String> vecHeaders = null;
 	private String query;
-	
+
 	public HeadersDataRow(String[] headers, Object[] values) {
 		this(headers, headers, values, values);
 	}
-	
+
 	public HeadersDataRow(String[] headers, String[] rawHeaders, Object[] values) {
 		this(headers, rawHeaders, values, values);
 	}
@@ -66,18 +69,18 @@ public class HeadersDataRow implements IHeadersDataRow{
 	}
 
 	public HeadersDataRow(String[] headers, String[] rawHeaders, Object[] values, Object[] rawValues) {
-		if(headers.length != values.length && values.length != rawValues.length) {
+		if (headers.length != values.length && values.length != rawValues.length) {
 			throw new IllegalArgumentException("Length of parameters not equal");
 		}
-		
+
 		this.headers = headers;
 		this.rawHeaders = rawHeaders;
-		if(this.rawHeaders == null) {
+		if (this.rawHeaders == null) {
 			this.rawHeaders = this.headers;
 		}
 		this.values = values;
 		this.rawValues = rawValues;
-		
+
 		this.recordLength = headers.length;
 	}
 
@@ -92,26 +95,38 @@ public class HeadersDataRow implements IHeadersDataRow{
 	}
 
 	@Override
+	public void setRaw(boolean raw) {
+		this.raw = raw;
+	}
+
+	@Override
 	public Object[] getValues() {
-		return values;
+		if (this.raw) {
+			Object[] stringified = new Object[this.rawValues.length];
+			for (int i = 0; i < this.rawValues.length; i++) {
+				stringified[i] = this.rawValues[i] != null ? this.rawValues[i].toString() : null;
+			}
+			return stringified;
+		}
+		return this.values;
 	}
 
 	@Override
 	public Object[] getRawValues() {
 		return rawValues;
 	}
-	
+
 	@Override
 	public String toString() {
 		StringBuilder ret = new StringBuilder();
 		int size = headers.length;
 		int index = 0;
 		ret.append("START ROW\n");
-		for(; index < size; index++) {
+		for (; index < size; index++) {
 			ret.append("\tHEADER=").append(headers[index]).append("\tVALUE=").append(values[index]).append("\n");
 		}
 		ret.append("END ROW\n");
-		
+
 		return ret.toString();
 	}
 
@@ -121,37 +136,37 @@ public class HeadersDataRow implements IHeadersDataRow{
 		int size = headers.length;
 		int index = 0;
 		ret.append("START ROW\n");
-		for(; index < size; index++) {
+		for (; index < size; index++) {
 			ret.append("\tHEADER=").append(headers[index]).append("\tVALUE=").append(rawValues[index]).append("\n");
 		}
 		ret.append("END ROW\n");
-		
+
 		return ret.toString();
 	}
-	
+
 	@Override
 	public void addFields(String[] addHeaders, Object[] addValues) {
 		int newValuesLength = addHeaders.length;
-		if(newValuesLength != addValues.length) {
+		if (newValuesLength != addValues.length) {
 			throw new IllegalArgumentException("Length of parameters not equal");
 		}
-		
+
 		// we will make new arrays and copy over the values
 		int totalLength = this.recordLength + newValuesLength;
 		String[] newHeaders = new String[totalLength];
 		Object[] newValues = new Object[totalLength];
-		
+
 		System.arraycopy(this.headers, 0, newHeaders, 0, this.recordLength);
 		System.arraycopy(this.values, 0, newValues, 0, this.recordLength);
-		
+
 		// add the new values into the new headers / values
 		int counter = 0;
-		for(int i = 0; i < newValuesLength; i++) {
+		for (int i = 0; i < newValuesLength; i++) {
 			newHeaders[this.recordLength + i] = addHeaders[counter];
 			newValues[this.recordLength + i] = addValues[counter];
 			counter++;
 		}
-		
+
 		// adjust references
 		this.headers = newHeaders;
 		this.values = newValues;
@@ -159,21 +174,21 @@ public class HeadersDataRow implements IHeadersDataRow{
 		this.rawHeaders = this.headers;
 		this.rawValues = this.values;
 	}
-	
+
 	@Override
 	public void addFields(String addHeader, Object addValues) {
 		// we will make new arrays and copy over the values
 		int totalLength = this.recordLength + 1;
 		String[] newHeaders = new String[totalLength];
 		Object[] newValues = new Object[totalLength];
-		
+
 		System.arraycopy(this.headers, 0, newHeaders, 0, this.recordLength);
 		System.arraycopy(this.values, 0, newValues, 0, this.recordLength);
-		
+
 		// add the new values into the new headers / values
 		newHeaders[this.recordLength] = addHeader;
 		newValues[this.recordLength] = addValues;
-		
+
 		// adjust references
 		this.headers = newHeaders;
 		this.values = newValues;
@@ -181,7 +196,7 @@ public class HeadersDataRow implements IHeadersDataRow{
 		this.rawHeaders = this.headers;
 		this.rawValues = this.values;
 	}
-	
+
 	@Override
 	public IHeadersDataRow copy() {
 		// convert the main portions and return new
@@ -190,15 +205,15 @@ public class HeadersDataRow implements IHeadersDataRow{
 		String[] cRawHeaders = gson.fromJson(gson.toJson(this.rawHeaders), String[].class);
 		Object[] cValues = gson.fromJson(gson.toJson(this.values), Object[].class);
 		Object[] cRawValues = gson.fromJson(gson.toJson(this.rawValues), Object[].class);
-		
+
 		return new HeadersDataRow(cHeaders, cRawHeaders, cValues, cRawValues);
 	}
-	
+
 	@Override
 	public Map<String, Object> flushRowToMap() {
 		Map<String, Object> map = new HashMap<String, Object>();
-		for(int i = 0; i < headers.length; i++) {
-			if(values[i] instanceof java.sql.Clob) {
+		for (int i = 0; i < headers.length; i++) {
+			if (values[i] instanceof java.sql.Clob) {
 				String value = AbstractSqlQueryUtil.flushClobToString((java.sql.Clob) values[i]);
 				map.put(headers[i], value);
 			} else {
@@ -207,9 +222,8 @@ public class HeadersDataRow implements IHeadersDataRow{
 		}
 		return map;
 	}
-	
-	/////////////////////////////////////////////
 
+	/////////////////////////////////////////////
 
 	@Override
 	public String toJson() {
@@ -218,8 +232,8 @@ public class HeadersDataRow implements IHeadersDataRow{
 
 	@Override
 	public void open() {
-		vecHeaders = new Vector<String>();
-		vecValues = new Vector<Object>();
+		vecHeaders = new ArrayList<String>();
+		vecValues = new ArrayList<Object>();
 		vecHeaders.addAll(Arrays.asList(headers));
 		vecValues.addAll(Arrays.asList(values));
 	}
@@ -229,7 +243,7 @@ public class HeadersDataRow implements IHeadersDataRow{
 		vecHeaders.add(fieldName);
 		vecValues.add(value);
 	}
-	
+
 	public boolean isValue(String fieldName) {
 		return vecHeaders.indexOf(fieldName) >= 0;
 	}
@@ -237,8 +251,8 @@ public class HeadersDataRow implements IHeadersDataRow{
 	@Override
 	public Object getField(String fieldName) {
 		int fieldIndex = vecHeaders.indexOf(fieldName);
-		if(fieldIndex >= 0) {
-			return vecValues.elementAt(fieldIndex);
+		if (fieldIndex >= 0) {
+			return vecValues.get(fieldIndex);
 		}
 		return null;
 	}

--- a/src/prerna/om/Insight.java
+++ b/src/prerna/om/Insight.java
@@ -1187,7 +1187,7 @@ public class Insight implements Serializable {
 	 *
 	 * @param databaseId the database engine ID that was queried
 	 */
-	public void addQueriedDatabasesese(String databaseId) {
+	public void addQueriedDatabases(String databaseId) {
 		// this is a set
 		this.queriedDatabaseIds.add(databaseId);
 	}

--- a/src/prerna/query/interpreters/SparqlInterpreter.java
+++ b/src/prerna/query/interpreters/SparqlInterpreter.java
@@ -74,7 +74,7 @@ import prerna.util.Constants;
 import prerna.util.Utility;
 
 public class SparqlInterpreter extends AbstractQueryInterpreter {
-	
+
 	private static final Logger classLogger = LogManager.getLogger(SparqlInterpreter.class);
 
 	// string containing the return variable section of the query
@@ -101,36 +101,36 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 
 	// some things around optimizing the filters
 	private boolean bindingsAdded = false;
-	
+
 	// map to store the selector name to the alisa
 	private Map<String, String> selectorAlias;
-	
+
 	// filtered columns
 	private Set<String> qsFilteredColumns;
 	private Set<String> qsFilteredColumnsToNull;
 	// store the engine
 	private IDatabaseEngine engine;
-	
+
 	public SparqlInterpreter() {
-		
+
 	}
-	
+
 	public SparqlInterpreter(IDatabaseEngine engine) {
 		this.engine = engine;
 	}
-	
+
 	@Override
 	public String composeQuery() {
-		if(this.qs instanceof HardSelectQueryStruct) {
+		if (this.qs instanceof HardSelectQueryStruct) {
 			return ((HardSelectQueryStruct) this.qs).getQuery();
 		}
-		
+
 		String baseUri = "http://semoss.org/ontologies";
-		if(this.engine != null) {
+		if (this.engine != null) {
 			baseUri = this.engine.getNodeBaseUri();
 		}
-		
-		// get the return statement 
+
+		// get the return statement
 		this.selectorAlias = new HashMap<String, String>();
 		this.selectorWhereClause = new StringBuilder();
 		this.addedSelectors = new HashMap<String, String>();
@@ -139,25 +139,25 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 		qsFilteredColumnsToNull = getFilteredColumnsToNull(combinedFilters.getFilters());
 		// add the join where clause
 		addJoins(this.qs.getRelations());
-				
+
 		addSelectors(this.qs.getSelectors());
-		
+
 		// add the filters
 		addFilters(combinedFilters, baseUri);
-		
+
 		// add the havings
 		addHavings(this.qs.getHavingFilters(), baseUri);
-		
+
 		// add the group bys
 		addGroupClause(((SelectQueryStruct) this.qs).getGroupBy());
-		
+
 		// add sort bys
 		addOrderByClause(((SelectQueryStruct) this.qs).getCombinedOrderBy());
-		
+
 		// combine the pieces and return
 		StringBuilder query = new StringBuilder();
 		String distinct = "";
-		if(((SelectQueryStruct) this.qs).isDistinct()) {
+		if (((SelectQueryStruct) this.qs).isDistinct()) {
 			distinct = "DISTINCT ";
 		}
 		query.append("SELECT ").append(distinct).append(this.selectors.toString());
@@ -170,68 +170,70 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 		query.append(this.groupByClause.toString());
 		query.append(" ");
 		String havingsClauseString = this.havingsClause.toString().trim();
-		if(!havingsClauseString.isEmpty()) {
+		if (!havingsClauseString.isEmpty()) {
 			query.append("HAVING(").append(havingsClauseString).append(") ");
 		}
 		query.append(this.sortByClause);
-		
+
 		long limit = ((SelectQueryStruct) this.qs).getLimit();
 		long offset = ((SelectQueryStruct) this.qs).getOffset();
-		if(limit > 0) {
-			query.append(" LIMIT ").append(limit); 
+		if (limit > 0) {
+			query.append(" LIMIT ").append(limit);
 		}
-		if(offset > 0) {
-			query.append(" OFFSET ").append(offset); 
+		if (offset > 0) {
+			query.append(" OFFSET ").append(offset);
 		}
 		query.append(" ");
 		query.append(this.bindingsWhereClause.toString());
-		
-		if(logger.isDebugEnabled()) {
-			if(query.length() > 500) {
-				logger.debug("SPARQL QUERY....  " + query.substring(0,  500) + "...");
+
+		if (logger.isDebugEnabled()) {
+			if (query.length() > 500) {
+				logger.debug("SPARQL QUERY....  " + query.substring(0, 500) + "...");
 			} else {
 				logger.debug("SPARQL QUERY....  " + query);
 			}
 		}
 		return query.toString();
 	}
-	
+
 	/**
 	 * Add the selector variables
+	 * 
 	 * @param selectors2
 	 */
 	private void addSelectors(List<IQuerySelector> selectors) {
 		this.selectors = new StringBuilder();
 		int numSelectors = selectors.size();
-		for(int i = 0; i < numSelectors; i++) {
+		for (int i = 0; i < numSelectors; i++) {
 			IQuerySelector selector = selectors.get(i);
 			String alias = selector.getAlias();
-			
+
 			String var = processSelector(selector);
-			if(var.equals("?" + alias)) {
+			if (var.equals("?" + alias)) {
 				this.selectors.append(var).append(" ");
 			} else {
 				this.selectors.append("(").append(var).append(" AS ?").append(alias).append(") ");
 			}
 		}
 	}
-	
+
 	/**
 	 * Method is used to generate the appropriate syntax for each type of selector
-	 * Note, this returns everything without the alias since this is called again from
-	 * the base methods it calls to allow for complex math expressions
+	 * Note, this returns everything without the alias since this is called again
+	 * from the base methods it calls to allow for complex math expressions
+	 * 
 	 * @param selector
 	 * @return
 	 */
 	private String processSelector(IQuerySelector selector) {
 		IQuerySelector.SELECTOR_TYPE selectorType = selector.getSelectorType();
-		if(selectorType == IQuerySelector.SELECTOR_TYPE.CONSTANT) {
+		if (selectorType == IQuerySelector.SELECTOR_TYPE.CONSTANT) {
 			return processConstantSelector((QueryConstantSelector) selector);
-		} else if(selectorType == IQuerySelector.SELECTOR_TYPE.COLUMN) {
+		} else if (selectorType == IQuerySelector.SELECTOR_TYPE.COLUMN) {
 			return processColumnSelector((QueryColumnSelector) selector);
-		} else if(selectorType == IQuerySelector.SELECTOR_TYPE.FUNCTION) {
+		} else if (selectorType == IQuerySelector.SELECTOR_TYPE.FUNCTION) {
 			return processFunctionSelector((QueryFunctionSelector) selector);
-		} else if(selectorType == IQuerySelector.SELECTOR_TYPE.ARITHMETIC) {
+		} else if (selectorType == IQuerySelector.SELECTOR_TYPE.ARITHMETIC) {
 			return processArithmeticSelector((QueryArithmeticSelector) selector);
 		}
 		return null;
@@ -239,23 +241,23 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 
 	private String processConstantSelector(QueryConstantSelector selector) {
 		Object constant = selector.getConstant();
-		if(constant instanceof SubQueryExpression) {
+		if (constant instanceof SubQueryExpression) {
 			ITask innerTask = null;
 			try {
 				innerTask = ((SubQueryExpression) constant).generateQsTask();
 				innerTask.setLogger(logger);
-				if(innerTask.hasNext()) {
+				if (innerTask.hasNext()) {
 					Object value = innerTask.next().getValues()[0];
-					if(value instanceof Number) {
+					if (value instanceof Number) {
 						return value.toString();
 					} else {
 						return "\"" + constant + "\"";
 					}
 				}
-			} catch(Exception e) {
+			} catch (Exception e) {
 				classLogger.error(Constants.STACKTRACE, e);
 			} finally {
-				if(innerTask != null) {
+				if (innerTask != null) {
 					try {
 						innerTask.close();
 					} catch (IOException e) {
@@ -263,10 +265,10 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 					}
 				}
 			}
-			
+
 			// if this doesn't return anything...
 			return "\"NULL\"";
-		} else if(constant instanceof Number) {
+		} else if (constant instanceof Number) {
 			return constant.toString();
 		} else {
 			return "\"" + constant + "\"";
@@ -277,10 +279,9 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 		String concept = selector.getTable();
 		String property = selector.getColumn();
 		String alias = selector.getAlias();
-		
+
 		/*
-		 * START
-		 * THIS SECTION IS SO WE PROCESS THE COLUMNS THAT ARE NEEDED AND MAKE SURE
+		 * START THIS SECTION IS SO WE PROCESS THE COLUMNS THAT ARE NEEDED AND MAKE SURE
 		 * THEY ARE DEFINED WITHIN THE WHERE CLAUSE
 		 */
 		String conceptCleanVarName = Utility.cleanVariableString(concept);
@@ -288,7 +289,7 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 		// add the node to the where statement
 		addNodeSelectorTriple(conceptCleanVarName, concept);
 		// and the property if it is a prop
-		if(!property.equals(SelectQueryStruct.PRIM_KEY_PLACEHOLDER)) {
+		if (!property.equals(SelectQueryStruct.PRIM_KEY_PLACEHOLDER)) {
 			// make unique based on property
 			cleanVarName += "__" + Utility.cleanVariableString(property);
 			addNodePropertySelectorTriple(cleanVarName, property, concept, conceptCleanVarName);
@@ -296,23 +297,23 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 		this.selectorAlias.put(cleanVarName, alias);
 		return "?" + cleanVarName;
 	}
-	
+
 	private String processFunctionSelector(QueryFunctionSelector selector) {
 		List<IQuerySelector> innerSelectors = selector.getInnerSelector();
 		String function = selector.getFunction();
 		String colCast = selector.getColCast();
-		
+
 		StringBuilder expression = new StringBuilder();
 		expression.append(QueryFunctionHelper.convertFunctionToSparqlSyntax(function)).append("(");
-		if(selector.isDistinct()) {
+		if (selector.isDistinct()) {
 			expression.append("DISTINCT ");
 		}
 		int size = innerSelectors.size();
-		for(int i = 0; i< size; i++) {
-			if(i > 0) {
+		for (int i = 0; i < size; i++) {
+			if (i > 0) {
 				expression.append(",");
 			}
-			if(!colCast.isEmpty()) {
+			if (!colCast.isEmpty()) {
 				expression.append(colCast).append("(").append(processSelector(innerSelectors.get(i))).append(")");
 			} else {
 				expression.append(processSelector(innerSelectors.get(i)));
@@ -331,52 +332,58 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 
 	/**
 	 * Adds the node triple
+	 * 
 	 * @param nodeVarName
 	 * @param concept
 	 */
 	private String addNodeSelectorTriple(String nodeVarName, String concept) {
-		if(!this.addedSelectors.containsKey(nodeVarName)) {
+		if (!this.addedSelectors.containsKey(nodeVarName)) {
 			String nodeUri = engine.getPhysicalUriFromPixelSelector(concept);
 			// add the pattern around the concept
-			this.selectorWhereClause.append("{?").append(nodeVarName).append(" <").append(RDF.TYPE).append("> <").append(nodeUri).append(">}");
+			this.selectorWhereClause.append("{?").append(nodeVarName).append(" <").append(RDF.TYPE).append("> <")
+					.append(nodeUri).append(">}");
 			this.addedSelectors.put(nodeVarName, nodeUri);
 		}
 		return this.addedSelectors.get(nodeVarName);
 	}
-	
+
 	/**
 	 * Add a node property triple
+	 * 
 	 * @param propVarName
 	 * @param property
 	 * @param nodeVarName
 	 */
-	private String addNodePropertySelectorTriple(String propVarName, String property, String concept, String conceptVarName) {
-		if(!this.addedSelectors.containsKey(propVarName)) {
+	private String addNodePropertySelectorTriple(String propVarName, String property, String concept,
+			String conceptVarName) {
+		if (!this.addedSelectors.containsKey(propVarName)) {
 			String propUri = engine.getPhysicalUriFromPixelSelector(concept + "__" + property);
 			// add the pattern around the property
 			// if filtered and not to a null
 			// no need for optional
-			if(this.qsFilteredColumns.contains(propVarName) && !this.qsFilteredColumnsToNull.contains(propVarName)) {
-				this.selectorWhereClause.append("{?").append(conceptVarName).append(" <").append(propUri).append("> ?").append(propVarName).append("}");
+			if (this.qsFilteredColumns.contains(propVarName) && !this.qsFilteredColumnsToNull.contains(propVarName)) {
+				this.selectorWhereClause.append("{?").append(conceptVarName).append(" <").append(propUri).append("> ?")
+						.append(propVarName).append("}");
 			} else {
-				this.selectorWhereClause.append("OPTIONAL{?").append(conceptVarName).append(" <").append(propUri).append("> ?").append(propVarName).append("}");
+				this.selectorWhereClause.append("OPTIONAL{?").append(conceptVarName).append(" <").append(propUri)
+						.append("> ?").append(propVarName).append("}");
 			}
 			this.addedSelectors.put(propVarName, propUri);
 		}
 		return this.addedSelectors.get(propVarName);
 	}
-	
+
 	private void addJoins(Set<IRelation> relations) {
 		this.relationshipWhereClause = new StringBuilder();
 		for (IRelation relationship : relations) {
-			if(relationship.getRelationType() == IRelation.RELATION_TYPE.BASIC) {
+			if (relationship.getRelationType() == IRelation.RELATION_TYPE.BASIC) {
 				BasicRelationship rel = (BasicRelationship) relationship;
 				String fromNode = rel.getFromConcept();
 				String joinType = rel.getJoinType();
 				String toNode = rel.getToConcept();
 				addJoin(fromNode, joinType, toNode);
 			} else {
-				logger.info("Cannot process relationship of type: " + relationship.getRelationType());
+				logger.info("Cannot process relationship of type: {}", relationship.getRelationType());
 			}
 		}
 	}
@@ -386,100 +393,108 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 		String fromURI = this.engine.getPhysicalUriFromPixelSelector(fromNode);
 		String toNodeVarName = Utility.cleanVariableString(toNode);
 		String toURI = this.engine.getPhysicalUriFromPixelSelector(toNode);
-		
+
 		// need to figure out what the predicate is from the owl
-		// also need to determine the direction of the relationship -- if it is forward or backward
-		String query = "SELECT ?relationship WHERE { {<" + fromURI + "> ?relationship <" + toURI + "> } filter(?relationship != <http://semoss.org/ontologies/Relation>) } ORDER BY DESC(?relationship)";
+		// also need to determine the direction of the relationship -- if it is forward
+		// or backward
+		String query = "SELECT ?relationship WHERE { {<" + fromURI + "> ?relationship <" + toURI
+				+ "> } filter(?relationship != <http://semoss.org/ontologies/Relation>) } ORDER BY DESC(?relationship)";
 		TupleQueryResult res = (TupleQueryResult) this.engine.execOntoSelectQuery(query);
-		String predURI = " unable to get pred from owl for " + fromURI + " and " + toURI;
+		String predURI = null;
 		try {
-			if(res.hasNext()){
+			if (res.hasNext()) {
 				predURI = res.next().getBinding(res.getBindingNames().get(0)).getValue().toString();
 			}
 		} catch (QueryEvaluationException e) {
-			logger.error("ERROR in query for metadata ::: predURI = " + predURI);
+			logger.error("ERROR in query for metadata between {} and {}", fromURI, toURI);
 		}
-		if(predURI == null) {
-			throw new IllegalArgumentException("Unable to add join because we are unable to find the predicate on the owl");
+		if (predURI == null) {
+			throw new IllegalArgumentException(
+					"Unable to add join because we are unable to find the predicate on the owl");
 		}
-		
-		//TODO: how do i do these types of joins? i need to use this information to update the selectors to have coalesce with them
-		//TODO: how do i do these types of joins? i need to use this information to update the selectors to have coalesce with them
-		//TODO: how do i do these types of joins? i need to use this information to update the selectors to have coalesce with them
-		//ignoring for now... old logic doesn't account for it so i will get to this later
-		
+
+		// TODO: how do i do these types of joins? i need to use this information to
+		// update the selectors to have coalesce with them
+		// TODO: how do i do these types of joins? i need to use this information to
+		// update the selectors to have coalesce with them
+		// TODO: how do i do these types of joins? i need to use this information to
+		// update the selectors to have coalesce with them
+		// ignoring for now... old logic doesn't account for it so i will get to this
+		// later
+
 		// create a random variable name that is unique
 //		String randomRelVarName = Utility.getRandomString(6);
-		if(joinType.equals("inner.join")) {
+		if (joinType.equals("inner.join")) {
 			addNodeSelectorTriple(fromNodeVarName, fromNode);
 			addNodeSelectorTriple(toNodeVarName, toNode);
 //			this.relationshipWhereClause.append("{?").append(randomRelVarName).append(" <").append(RDFS.SUBPROPERTYOF).append("> <").append(predURI).append(">}");
-			this.relationshipWhereClause.append("{?").append(fromNodeVarName).append(" <").append(predURI).append("> ?").append(toNodeVarName).append("}");
-		
-		} else if(joinType.equals("left.outer.join")) {
+			this.relationshipWhereClause.append("{?").append(fromNodeVarName).append(" <").append(predURI).append("> ?")
+					.append(toNodeVarName).append("}");
+
+		} else if (joinType.equals("left.outer.join")) {
 			addNodeSelectorTriple(fromNodeVarName, fromNode);
 			this.relationshipWhereClause.append("OPTIONAL {")
 //				.append("{?").append(randomRelVarName).append(" <").append(RDFS.SUBPROPERTYOF).append("> <").append(predURI).append(">}")
-				.append("{?").append(toNodeVarName).append(" <").append(RDF.TYPE).append("> <").append(toURI).append(">} ")
-				.append("{?").append(fromNodeVarName).append(" <").append(predURI).append("> ?").append(toNodeVarName).append("}")
-				.append("}");
-			
+					.append("{?").append(toNodeVarName).append(" <").append(RDF.TYPE).append("> <").append(toURI)
+					.append(">} ").append("{?").append(fromNodeVarName).append(" <").append(predURI).append("> ?")
+					.append(toNodeVarName).append("}").append("}");
+
 			this.addedSelectors.put(toNodeVarName, toURI);
 
-		} else if(joinType.equals("right.outer.join")) {
+		} else if (joinType.equals("right.outer.join")) {
 			addNodeSelectorTriple(toNodeVarName, toNode);
 			this.relationshipWhereClause.append("OPTIONAL {")
 //			.append("{?").append(randomRelVarName).append(" <").append(RDFS.SUBPROPERTYOF).append("> <").append(predURI).append(">}")
-				.append("{?").append(fromNodeVarName).append(" <").append(RDF.TYPE).append("> <").append(fromURI).append(">} ")
-				.append("{?").append(fromNodeVarName).append(" <").append(predURI).append("> ?").append(toNodeVarName).append("}")
-				.append("}");
-			
+					.append("{?").append(fromNodeVarName).append(" <").append(RDF.TYPE).append("> <").append(fromURI)
+					.append(">} ").append("{?").append(fromNodeVarName).append(" <").append(predURI).append("> ?")
+					.append(toNodeVarName).append("}").append("}");
+
 			this.addedSelectors.put(fromNodeVarName, fromURI);
-			
-		} else if(joinType.equals("outer.join")) {
+
+		} else if (joinType.equals("outer.join")) {
 			addNodeSelectorTriple(fromNodeVarName, fromNode);
 			addNodeSelectorTriple(toNodeVarName, toNode);
 			this.relationshipWhereClause.append("OPTIONAL {")
 //				.append("{?").append(randomRelVarName).append(" <").append(RDFS.SUBPROPERTYOF).append("> <").append(predURI).append(">}")
-				.append("{?").append(fromNodeVarName).append(" <").append(predURI).append("> ?").append(toNodeVarName).append("}")
-				.append("}");
+					.append("{?").append(fromNodeVarName).append(" <").append(predURI).append("> ?")
+					.append(toNodeVarName).append("}").append("}");
 		}
 	}
-	
+
 	/////////////////////////////////////////////////////////////////////
 	/////////////////////////////////////////////////////////////////////
 	//////////////////////// FILTERING //////////////////////////////////
 	/////////////////////////////////////////////////////////////////////
 	/////////////////////////////////////////////////////////////////////
 
-	
 	private void addFilters(GenRowFilters grf, String baseUri) {
 		this.filtersWhereClause = new StringBuilder();
 		this.bindWhereClause = new StringBuilder();
 		this.bindingsWhereClause = new StringBuilder();
-		
+
 		List<IQueryFilter> filters = grf.getFilters();
-		for(IQueryFilter filter : filters) {
+		for (IQueryFilter filter : filters) {
 			boolean startSimple = filter.getQueryFilterType() == IQueryFilter.QUERY_FILTER_TYPE.SIMPLE;
 			StringBuilder filterSyntax = processFilter(filter, baseUri, startSimple);
-			if(filterSyntax != null) {
+			if (filterSyntax != null) {
 				// NOTE! we add the filter here and not within the individual methods
 				// so we can correctly do AND/OR filtering
 				this.filtersWhereClause.append(" FILTER( ").append(filterSyntax.toString()).append(")");
 			}
 		}
 	}
-	
+
 	private void addHavings(GenRowFilters grf, String baseUri) {
 		this.havingsClause = new StringBuilder();
-		
+
 		List<IQueryFilter> filters = grf.getFilters();
 		boolean first = true;
-		for(IQueryFilter filter : filters) {
-			// do not want this to go through the simple process which would try to add bind() and bindings()
+		for (IQueryFilter filter : filters) {
+			// do not want this to go through the simple process which would try to add
+			// bind() and bindings()
 			StringBuilder filterSyntax = processFilter(filter, baseUri, false);
-			if(filterSyntax != null) {
-				if(first) {
+			if (filterSyntax != null) {
+				if (first) {
 					this.havingsClause.append(" ( ").append(filterSyntax.toString()).append(") ");
 					first = false;
 				} else {
@@ -488,14 +503,14 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 			}
 		}
 	}
-	
+
 	private StringBuilder processFilter(IQueryFilter filter, String baseUri, boolean startSimple) {
 		IQueryFilter.QUERY_FILTER_TYPE filterType = filter.getQueryFilterType();
-		if(filterType == IQueryFilter.QUERY_FILTER_TYPE.SIMPLE) {
+		if (filterType == IQueryFilter.QUERY_FILTER_TYPE.SIMPLE) {
 			return processSimpleQueryFilter((SimpleQueryFilter) filter, baseUri, startSimple);
-		} else if(filterType == IQueryFilter.QUERY_FILTER_TYPE.AND) {
+		} else if (filterType == IQueryFilter.QUERY_FILTER_TYPE.AND) {
 			return processAndQueryFilter((AndQueryFilter) filter, baseUri);
-		} else if(filterType == IQueryFilter.QUERY_FILTER_TYPE.OR) {
+		} else if (filterType == IQueryFilter.QUERY_FILTER_TYPE.OR) {
 			return processOrQueryFilter((OrQueryFilter) filter, baseUri);
 		}
 		return null;
@@ -505,8 +520,8 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 		StringBuilder filterBuilder = new StringBuilder("(");
 		List<IQueryFilter> filterList = filter.getFilterList();
 		int numAnds = filterList.size();
-		for(int i = 0; i < numAnds; i++) {
-			if(i != 0) {
+		for (int i = 0; i < numAnds; i++) {
+			if (i != 0) {
 				filterBuilder.append(" || ");
 			}
 			filterBuilder.append(processFilter(filterList.get(i), baseUri, false));
@@ -519,8 +534,8 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 		StringBuilder filterBuilder = new StringBuilder("(");
 		List<IQueryFilter> filterList = filter.getFilterList();
 		int numAnds = filterList.size();
-		for(int i = 0; i < numAnds; i++) {
-			if(i != 0) {
+		for (int i = 0; i < numAnds; i++) {
+			if (i != 0) {
 				filterBuilder.append(" && ");
 			}
 			filterBuilder.append(processFilter(filterList.get(i), baseUri, false));
@@ -535,25 +550,29 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 		String thisComparator = filter.getComparator();
 
 		FILTER_TYPE fType = filter.getSimpleFilterType();
-		if(fType == FILTER_TYPE.COL_TO_COL) {
+		if (fType == FILTER_TYPE.COL_TO_COL) {
 			return addSelectorToSelectorFilter(leftComp, rightComp, thisComparator);
-		} else if(fType == FILTER_TYPE.COL_TO_VALUES) {
+		} else if (fType == FILTER_TYPE.COL_TO_VALUES) {
 			return addSelectorToValuesFilter(leftComp, rightComp, thisComparator, baseUri, startSimple);
-		} else if(fType == FILTER_TYPE.VALUES_TO_COL) {
-			// same logic as above, just switch the order and reverse the comparator if it is numeric
-			return addSelectorToValuesFilter(rightComp, leftComp, IQueryFilter.getReverseNumericalComparator(thisComparator), baseUri, startSimple);
-		} else if(fType == FILTER_TYPE.COL_TO_LAMBDA) {
+		} else if (fType == FILTER_TYPE.VALUES_TO_COL) {
+			// same logic as above, just switch the order and reverse the comparator if it
+			// is numeric
+			return addSelectorToValuesFilter(rightComp, leftComp,
+					IQueryFilter.getReverseNumericalComparator(thisComparator), baseUri, startSimple);
+		} else if (fType == FILTER_TYPE.COL_TO_LAMBDA) {
 			return addSelectorToLambda(leftComp, rightComp, thisComparator, baseUri, startSimple);
-		} else if(fType == FILTER_TYPE.LAMBDA_TO_COL) {
-			// same logic as above, just switch the order and reverse the comparator if it is numeric
-			return addSelectorToLambda(rightComp, leftComp, IQueryFilter.getReverseNumericalComparator(thisComparator), baseUri, startSimple);
-		} else if(fType == FILTER_TYPE.VALUE_TO_VALUE) {
+		} else if (fType == FILTER_TYPE.LAMBDA_TO_COL) {
+			// same logic as above, just switch the order and reverse the comparator if it
+			// is numeric
+			return addSelectorToLambda(rightComp, leftComp, IQueryFilter.getReverseNumericalComparator(thisComparator),
+					baseUri, startSimple);
+		} else if (fType == FILTER_TYPE.VALUE_TO_VALUE) {
 			// WHY WOULD YOU DO THIS!!!
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * 
 	 * @param leftComp
@@ -561,20 +580,22 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 	 * @param thisComparator
 	 * @return
 	 */
-	private StringBuilder addSelectorToLambda(NounMetadata leftComp, NounMetadata rightComp, String thisComparator, String baseUri, boolean startSimple) {
+	private StringBuilder addSelectorToLambda(NounMetadata leftComp, NounMetadata rightComp, String thisComparator,
+			String baseUri, boolean startSimple) {
 		// need to evaluate the lambda on the right
 		IReactor reactor = (IReactor) rightComp.getValue();
 		NounMetadata nounEvaluated = reactor.execute();
 
 		Map<String, Object> mergeMetadata = reactor.mergeIntoQsMetadata();
-		if(mergeMetadata.get(IReactor.MERGE_INTO_QS_FORMAT).equals(IReactor.MERGE_INTO_QS_FORMAT_SCALAR)) {
+		if (mergeMetadata.get(IReactor.MERGE_INTO_QS_FORMAT).equals(IReactor.MERGE_INTO_QS_FORMAT_SCALAR)) {
 			return addSelectorToValuesFilter(leftComp, nounEvaluated, thisComparator, baseUri, startSimple);
 		}
-		
+
 		throw new IllegalArgumentException("Unknown qs format to merge");
 	}
 
-	private StringBuilder addSelectorToSelectorFilter(NounMetadata leftComp, NounMetadata rightComp, String thisComparator) {
+	private StringBuilder addSelectorToSelectorFilter(NounMetadata leftComp, NounMetadata rightComp,
+			String thisComparator) {
 		// get the left side
 		IQuerySelector leftSelector = (IQuerySelector) leftComp.getValue();
 		IQuerySelector rightSelector = (IQuerySelector) rightComp.getValue();
@@ -582,138 +603,150 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 		/*
 		 * Add the filter syntax here once we have the correct physical names
 		 */
-		
-		StringBuilder filterBuilder = new StringBuilder(processSelector(leftSelector))
-			.append(" ").append(thisComparator).append(" ").append(processSelector(rightSelector));
-		
+
+		StringBuilder filterBuilder = new StringBuilder(processSelector(leftSelector)).append(" ")
+				.append(thisComparator).append(" ").append(processSelector(rightSelector));
+
 		return filterBuilder;
 	}
-	
+
 	/**
 	 * Add a filter of one column to a set of values
+	 * 
 	 * @param leftComp
 	 * @param rightComp
 	 * @param thisComparator
 	 */
-	private StringBuilder addSelectorToValuesFilter(NounMetadata leftComp, NounMetadata rightComp, String thisComparator, String baseUri, boolean isSimple) {
+	private StringBuilder addSelectorToValuesFilter(NounMetadata leftComp, NounMetadata rightComp,
+			String thisComparator, String baseUri, boolean isSimple) {
 		IQuerySelector leftSelector = (IQuerySelector) leftComp.getValue();
 		String columnExpression = processSelector(leftSelector);
-		
+
 		List<Object> rightObjects = new Vector<Object>();
 		// ugh... this is gross
-		if(rightComp.getValue() instanceof Collection) {
-			rightObjects.addAll( (Collection) rightComp.getValue());
+		if (rightComp.getValue() instanceof Collection) {
+			rightObjects.addAll((Collection) rightComp.getValue());
 		} else {
 			rightObjects.add(rightComp.getValue());
 		}
-		
-		// if we have a simple column, we can try to do optimizations with bind, bindings, etc.
+
+		// if we have a simple column, we can try to do optimizations with bind,
+		// bindings, etc.
 		// if it is complex, we must do Filter
-		if(leftSelector instanceof QueryColumnSelector) {
+		if (leftSelector instanceof QueryColumnSelector) {
 			// column expression already starts with ?
 			// want to remove it for now
 			columnExpression = columnExpression.substring(1);
 			boolean isProp = false;
-			if(columnExpression.contains("__")) {
+			if (columnExpression.contains("__")) {
 				isProp = true;
 			}
-			return addColToValuesFilter(columnExpression, thisComparator, rightObjects, rightComp.getNounType(), isProp, baseUri, isSimple);
+			return addColToValuesFilter(columnExpression, thisComparator, rightObjects, rightComp.getNounType(), isProp,
+					baseUri, isSimple);
 		} else {
-			return addComplexExpressionToValuesFilter(columnExpression, thisComparator, rightObjects, rightComp.getNounType());
+			return addComplexExpressionToValuesFilter(columnExpression, thisComparator, rightObjects,
+					rightComp.getNounType());
 		}
 	}
-	
-	private StringBuilder addComplexExpressionToValuesFilter(String leftExpression, String thisComparator, List<Object> rightObjects, PixelDataType nounType) {
+
+	private StringBuilder addComplexExpressionToValuesFilter(String leftExpression, String thisComparator,
+			List<Object> rightObjects, PixelDataType nounType) {
 		int numObjects = rightObjects.size();
 		StringBuilder filterBuilder = new StringBuilder();
 		// modify the == comparator to work on sparql
-		if(thisComparator.equals("==")) {
+		if (thisComparator.equals("==")) {
 			thisComparator = "=";
 		}
-		if(nounType == PixelDataType.CONST_DECIMAL || nounType == PixelDataType.CONST_INT) {
-			for(int i = 0; i < numObjects; i++) {
-				if(i != 0) {
+		if (nounType == PixelDataType.CONST_DECIMAL || nounType == PixelDataType.CONST_INT) {
+			for (int i = 0; i < numObjects; i++) {
+				if (i != 0) {
 					this.filtersWhereClause.append(" || ");
 				}
 				filterBuilder.append("(").append(leftExpression).append(") ").append(thisComparator).append(" ")
-					.append("\"").append(rightObjects.get(i)).append("\"^^<").append(XSD.xdouble).append(">");
+						.append("\"").append(rightObjects.get(i)).append("\"^^<").append(XSD.xdouble).append(">");
 			}
 		} else {
-			for(int i = 0; i < numObjects; i++) {
-				if(i != 0) {
+			for (int i = 0; i < numObjects; i++) {
+				if (i != 0) {
 					filterBuilder.append(" || ");
 				}
 				filterBuilder.append("(").append(leftExpression).append(") ").append(thisComparator).append(" ")
-					.append("\"").append(rightObjects.get(i)).append("\"");
+						.append("\"").append(rightObjects.get(i)).append("\"");
 			}
 		}
 		return filterBuilder;
 	}
 
 	/**
-	 * Add a filter of variable name to set of values
-	 * Will figure out the most optimal way to add the filter
+	 * Add a filter of variable name to set of values Will figure out the most
+	 * optimal way to add the filter
+	 * 
 	 * @param leftCleanVarName
 	 * @param thisComparator
 	 * @param rightObjects
 	 * @param nounType
 	 * @param isProp
 	 */
-	private StringBuilder addColToValuesFilter(String leftCleanVarName, String thisComparator, List<Object> rightObjects, 
-			PixelDataType nounType, boolean isProp, String baseUri, boolean isSimple) {
-		
+	private StringBuilder addColToValuesFilter(String leftCleanVarName, String thisComparator,
+			List<Object> rightObjects, PixelDataType nounType, boolean isProp, String baseUri, boolean isSimple) {
+
 		// need to account for null inputs
 		// need to account for null inputs
 		boolean addNullCheck = rightObjects.remove(null);
 		boolean nullCheckWithEquals = true;
-		if(!addNullCheck) {
+		if (!addNullCheck) {
 			// are we searching for null?
-			addNullCheck = IQueryInterpreter.getAllSearchComparators().contains(thisComparator) && 
-					(rightObjects.contains("n") || rightObjects.contains("nu") || rightObjects.contains("nul") || rightObjects.contains("null"));
+			addNullCheck = IQueryInterpreter.getAllSearchComparators().contains(thisComparator)
+					&& (rightObjects.contains("n") || rightObjects.contains("nu") || rightObjects.contains("nul")
+							|| rightObjects.contains("null"));
 		}
 		boolean hasMoreValuesThanNull = !rightObjects.isEmpty();
-		if(addNullCheck) {
+		if (addNullCheck) {
 			// can only work if comparator is == or !=
-			if(thisComparator.equals("!=") || thisComparator.equals("<>")) {
+			if (thisComparator.equals("!=") || thisComparator.equals("<>")) {
 				nullCheckWithEquals = false;
 			}
 		}
-		
+
 		int numObjects = rightObjects.size();
-		if(!addNullCheck && numObjects == 1 && isSimple && thisComparator.equals("==")) {
+		if (!addNullCheck && numObjects == 1 && isSimple && thisComparator.equals("==")) {
 			// can add a bind
-			if(isProp) {
-				if(nounType == PixelDataType.CONST_DECIMAL || nounType == PixelDataType.CONST_INT) {
-					this.bindWhereClause.append("BIND(\"").append(rightObjects.get(0)).append("\"^^<").append(XSD.xdouble).append("> AS ?").append(leftCleanVarName).append(")");
+			if (isProp) {
+				if (nounType == PixelDataType.CONST_DECIMAL || nounType == PixelDataType.CONST_INT) {
+					this.bindWhereClause.append("BIND(\"").append(rightObjects.get(0)).append("\"^^<")
+							.append(XSD.xdouble).append("> AS ?").append(leftCleanVarName).append(")");
 				} else {
-					this.bindWhereClause.append("BIND(\"").append(rightObjects.get(0)).append("\" AS ?").append(leftCleanVarName).append(")");
+					this.bindWhereClause.append("BIND(\"").append(rightObjects.get(0)).append("\" AS ?")
+							.append(leftCleanVarName).append(")");
 				}
 			} else {
 				String concpetType = Utility.getInstanceName(this.addedSelectors.get(leftCleanVarName));
 				this.bindWhereClause.append("BIND(<").append(baseUri).append(concpetType).append("/")
-							.append(rightObjects.get(0)).append("> AS ?").append(leftCleanVarName).append(")");
+						.append(rightObjects.get(0)).append("> AS ?").append(leftCleanVarName).append(")");
 			}
 			// do not return anything
 			// since it is simple and we will append this at the start
 			return null;
-		} else if(!addNullCheck && !bindingsAdded && isSimple && numObjects > 1 && thisComparator.equals("==")){
+		} else if (!addNullCheck && !bindingsAdded && isSimple && numObjects > 1 && thisComparator.equals("==")) {
 			// add bindings at end
 			this.bindingsWhereClause = new StringBuilder();
 			this.bindingsWhereClause.append("BINDINGS ?").append(leftCleanVarName).append("{");
-			if(isProp) {
-				if(nounType == PixelDataType.CONST_DECIMAL || nounType == PixelDataType.CONST_INT) {
-					for(int i = 0; i < numObjects; i++) {
-						this.bindingsWhereClause.append("(\"").append(rightObjects.get(i)).append("\"^^<").append(XSD.xdouble).append(">)");
+			if (isProp) {
+				if (nounType == PixelDataType.CONST_DECIMAL || nounType == PixelDataType.CONST_INT) {
+					for (int i = 0; i < numObjects; i++) {
+						this.bindingsWhereClause.append("(\"").append(rightObjects.get(i)).append("\"^^<")
+								.append(XSD.xdouble).append(">)");
 					}
 				} else {
-					for(int i = 0; i < numObjects; i++) {
+					for (int i = 0; i < numObjects; i++) {
 						this.bindingsWhereClause.append("(\"").append(rightObjects.get(i)).append("\")");
 					}
 				}
 			} else {
 				String concpetType = Utility.getInstanceName(this.addedSelectors.get(leftCleanVarName));
-				for(int i = 0; i < numObjects; i++) {
-					this.bindingsWhereClause.append("(<").append(baseUri).append(concpetType).append("/").append(rightObjects.get(i)).append(">)");
+				for (int i = 0; i < numObjects; i++) {
+					this.bindingsWhereClause.append("(<").append(baseUri).append(concpetType).append("/")
+							.append(rightObjects.get(i)).append(">)");
 				}
 			}
 			this.bindingsWhereClause.append("}");
@@ -726,128 +759,138 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 			// start the syntax
 			StringBuilder filterBuilder = new StringBuilder();
 			// modify the == comparator to work on sparql
-			if(thisComparator.equals("==")) {
+			if (thisComparator.equals("==")) {
 				thisComparator = "=";
 			}
-			
-			if(addNullCheck) {
+
+			if (addNullCheck) {
 				// can only work if comparator is == or !=
-				if(thisComparator.equals("==") || IQueryInterpreter.getPosSearchComparators().contains(thisComparator)) {
+				if (thisComparator.equals("==")
+						|| IQueryInterpreter.getPosSearchComparators().contains(thisComparator)) {
 					filterBuilder.append("!BOUND(?").append(leftCleanVarName).append(")");
-				} else if(thisComparator.equals("!=") || thisComparator.equals("<>") || IQueryInterpreter.getNegSearchComparators().contains(thisComparator)) {
+				} else if (thisComparator.equals("!=") || thisComparator.equals("<>")
+						|| IQueryInterpreter.getNegSearchComparators().contains(thisComparator)) {
 					filterBuilder.append("BOUND(?").append(leftCleanVarName).append(")");
 				}
 			}
-			
-			if(hasMoreValuesThanNull) {
-				
+
+			if (hasMoreValuesThanNull) {
+
 				// if we added a null check
 				// we need to add and or to the rest of everything
-				if(addNullCheck) {
-					if(nullCheckWithEquals) {
+				if (addNullCheck) {
+					if (nullCheckWithEquals) {
 						filterBuilder.append(" || (");
 					} else {
 						filterBuilder.append(" && (");
 					}
 				}
-				
+
 				// based on the input, set the filter information
 				// if it is a like, we will use a regex filter
 				// otherwise, normal filter
-				if(thisComparator.equals(SEARCH_COMPARATOR) || thisComparator.equals(NOT_SEARCH_COMPARATOR)) {
+				if (thisComparator.equals(SEARCH_COMPARATOR) || thisComparator.equals(NOT_SEARCH_COMPARATOR)) {
 					String notFilter = thisComparator.equals(NOT_SEARCH_COMPARATOR) ? "!" : "";
-					if(isProp) {
-						for(int i = 0; i < numObjects; i++) {
-							if(i != 0) {
+					if (isProp) {
+						for (int i = 0; i < numObjects; i++) {
+							if (i != 0) {
 								filterBuilder.append(" || ");
 							}
-							filterBuilder.append(notFilter).append("REGEX(STR(?").append(leftCleanVarName).append("), \"").append(rightObjects.get(i)).append("\", 'i')");
+							filterBuilder.append(notFilter).append("REGEX(STR(?").append(leftCleanVarName)
+									.append("), \"").append(rightObjects.get(i)).append("\", 'i')");
 						}
 					} else {
 						String concpetType = Utility.getInstanceName(this.addedSelectors.get(leftCleanVarName));
-						for(int i = 0; i < numObjects; i++) {
-							if(i != 0) {
+						for (int i = 0; i < numObjects; i++) {
+							if (i != 0) {
 								filterBuilder.append(" || ");
 							}
-							filterBuilder.append(notFilter).append("REGEX(STR(?").append(leftCleanVarName).append("), \"")
-									.append(baseUri).append(concpetType).append("/.*").append(rightObjects.get(i).toString().replace("%", "\\\\%")).append("\", 'i')");
+							filterBuilder.append(notFilter).append("REGEX(STR(?").append(leftCleanVarName)
+									.append("), \"").append(baseUri).append(concpetType).append("/.*")
+									.append(rightObjects.get(i).toString().replace("%", "\\\\%")).append("\", 'i')");
 						}
 					}
-				} else if(thisComparator.equals(BEGINS_COMPARATOR) || thisComparator.equals(NOT_BEGINS_COMPARATOR)) {
+				} else if (thisComparator.equals(BEGINS_COMPARATOR) || thisComparator.equals(NOT_BEGINS_COMPARATOR)) {
 					String notFilter = thisComparator.equals(NOT_BEGINS_COMPARATOR) ? "!" : "";
-					if(isProp) {
-						for(int i = 0; i < numObjects; i++) {
-							if(i != 0) {
+					if (isProp) {
+						for (int i = 0; i < numObjects; i++) {
+							if (i != 0) {
 								filterBuilder.append(" || ");
 							}
-							filterBuilder.append(notFilter).append("REGEX(STR(?").append(leftCleanVarName).append("), \"^").append(rightObjects.get(i)).append("\", 'i')");
+							filterBuilder.append(notFilter).append("REGEX(STR(?").append(leftCleanVarName)
+									.append("), \"^").append(rightObjects.get(i)).append("\", 'i')");
 						}
 					} else {
 						String concpetType = Utility.getInstanceName(this.addedSelectors.get(leftCleanVarName));
-						for(int i = 0; i < numObjects; i++) {
-							if(i != 0) {
+						for (int i = 0; i < numObjects; i++) {
+							if (i != 0) {
 								filterBuilder.append(" || ");
 							}
-							filterBuilder.append(notFilter).append("REGEX(STR(?").append(leftCleanVarName).append("), \"")
-									.append(baseUri).append(concpetType).append("/").append(rightObjects.get(i).toString().replace("%", "\\\\%")).append("\", 'i')");
+							filterBuilder.append(notFilter).append("REGEX(STR(?").append(leftCleanVarName)
+									.append("), \"").append(baseUri).append(concpetType).append("/")
+									.append(rightObjects.get(i).toString().replace("%", "\\\\%")).append("\", 'i')");
 						}
 					}
-				} else if(thisComparator.equals(ENDS_COMPARATOR) || thisComparator.equals(NOT_ENDS_COMPARATOR)) {
+				} else if (thisComparator.equals(ENDS_COMPARATOR) || thisComparator.equals(NOT_ENDS_COMPARATOR)) {
 					String notFilter = thisComparator.equals(NOT_ENDS_COMPARATOR) ? "!" : "";
-					if(isProp) {
-						for(int i = 0; i < numObjects; i++) {
-							if(i != 0) {
+					if (isProp) {
+						for (int i = 0; i < numObjects; i++) {
+							if (i != 0) {
 								filterBuilder.append(" || ");
 							}
-							filterBuilder.append(notFilter).append("REGEX(STR(?").append(leftCleanVarName).append("), \"").append(rightObjects.get(i)).append("$\", 'i')");
+							filterBuilder.append(notFilter).append("REGEX(STR(?").append(leftCleanVarName)
+									.append("), \"").append(rightObjects.get(i)).append("$\", 'i')");
 						}
 					} else {
 						String concpetType = Utility.getInstanceName(this.addedSelectors.get(leftCleanVarName));
-						for(int i = 0; i < numObjects; i++) {
-							if(i != 0) {
+						for (int i = 0; i < numObjects; i++) {
+							if (i != 0) {
 								filterBuilder.append(" || ");
 							}
-							filterBuilder.append(notFilter).append("REGEX(STR(?").append(leftCleanVarName).append("), \"")
-									.append(baseUri).append(concpetType).append("/.*").append(rightObjects.get(i).toString().replace("%", "\\\\%")).append("$\", 'i')");
+							filterBuilder.append(notFilter).append("REGEX(STR(?").append(leftCleanVarName)
+									.append("), \"").append(baseUri).append(concpetType).append("/.*")
+									.append(rightObjects.get(i).toString().replace("%", "\\\\%")).append("$\", 'i')");
 						}
 					}
 				} else {
-					if(isProp) {
-						if(nounType == PixelDataType.CONST_DECIMAL || nounType == PixelDataType.CONST_INT) {
-							for(int i = 0; i < numObjects; i++) {
-								if(i != 0) {
-									this.filtersWhereClause.append(" || ");
-								}
-								filterBuilder.append("?").append(leftCleanVarName).append(" ").append(thisComparator).append(" ")
-									.append("\"").append(rightObjects.get(i)).append("\"^^<").append(XSD.xdouble).append(">");
-							}
-						} else {
-							for(int i = 0; i < numObjects; i++) {
-								if(i != 0) {
+					if (isProp) {
+						if (nounType == PixelDataType.CONST_DECIMAL || nounType == PixelDataType.CONST_INT) {
+							for (int i = 0; i < numObjects; i++) {
+								if (i != 0) {
 									filterBuilder.append(" || ");
 								}
-								filterBuilder.append("?").append(leftCleanVarName).append(" ").append(thisComparator).append(" ")
-									.append("\"").append(rightObjects.get(i)).append("\"");
+								filterBuilder.append("?").append(leftCleanVarName).append(" ").append(thisComparator)
+										.append(" ").append("\"").append(rightObjects.get(i)).append("\"^^<")
+										.append(XSD.xdouble).append(">");
+							}
+						} else {
+							for (int i = 0; i < numObjects; i++) {
+								if (i != 0) {
+									filterBuilder.append(" || ");
+								}
+								filterBuilder.append("?").append(leftCleanVarName).append(" ").append(thisComparator)
+										.append(" ").append("\"").append(rightObjects.get(i)).append("\"");
 							}
 						}
 					} else {
 						String concpetType = Utility.getInstanceName(this.addedSelectors.get(leftCleanVarName));
-						for(int i = 0; i < numObjects; i++) {
-							if(i != 0) {
+						for (int i = 0; i < numObjects; i++) {
+							if (i != 0) {
 								filterBuilder.append(" || ");
 							}
-							filterBuilder.append("?").append(leftCleanVarName).append(" ").append(thisComparator).append(" ")
-								.append("<").append(baseUri).append(concpetType).append("/").append(rightObjects.get(i)).append(">");
+							filterBuilder.append("?").append(leftCleanVarName).append(" ").append(thisComparator)
+									.append(" ").append("<").append(baseUri).append(concpetType).append("/")
+									.append(rightObjects.get(i)).append(">");
 						}
 					}
 				}
-				
+
 				// close if added null check
-				if(addNullCheck) {
+				if (addNullCheck) {
 					filterBuilder.append(")");
 				}
 			}
-			
+
 			return filterBuilder;
 		}
 	}
@@ -857,29 +900,30 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 	//////////////////////// OTHER PARAMS ///////////////////////////////
 	/////////////////////////////////////////////////////////////////////
 	/////////////////////////////////////////////////////////////////////
-	
+
 	/**
 	 * Generate the group by clause
+	 * 
 	 * @param groupBy
 	 */
 	private void addGroupClause(List<IQuerySelector> groupBy) {
 		this.groupByClause = new StringBuilder();
 		int numGroups = groupBy.size();
-		if(numGroups == 0) {
+		if (numGroups == 0) {
 			return;
 		}
-		
+
 		this.groupByClause.append(" GROUP BY");
-		for(int i = 0; i < numGroups; i++) {
+		for (int i = 0; i < numGroups; i++) {
 			IQuerySelector groupBySelector = groupBy.get(i);
-			
-			if(groupBySelector.getSelectorType() == IQuerySelector.SELECTOR_TYPE.COLUMN) {
+
+			if (groupBySelector.getSelectorType() == IQuerySelector.SELECTOR_TYPE.COLUMN) {
 				QueryColumnSelector gSelect = (QueryColumnSelector) groupBySelector;
 				String tableName = gSelect.getTable();
 				String columnName = gSelect.getColumn();
 
 				String varName = Utility.cleanVariableString(tableName);
-				if(!columnName.equals(SelectQueryStruct.PRIM_KEY_PLACEHOLDER)) {
+				if (!columnName.equals(SelectQueryStruct.PRIM_KEY_PLACEHOLDER)) {
 					varName += "__" + Utility.cleanVariableString(columnName);
 				}
 				this.groupByClause.append(" ?").append(varName);
@@ -890,39 +934,40 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 			}
 		}
 	}
-	
+
 	/**
 	 * Generate the order by clause
+	 * 
 	 * @param orderBy
 	 */
 	private void addOrderByClause(List<IQuerySort> orderByList) {
 		this.sortByClause = new StringBuilder();
 		int numOrders = orderByList.size();
-		if(numOrders == 0) {
+		if (numOrders == 0) {
 			return;
 		}
 
 		this.sortByClause.append(" ORDER BY");
-		for(int i = 0; i < numOrders; i++) {
+		for (int i = 0; i < numOrders; i++) {
 			IQuerySort orderBy = orderByList.get(i);
-			if(orderBy.getQuerySortType() == IQuerySort.QUERY_SORT_TYPE.COLUMN) {
+			if (orderBy.getQuerySortType() == IQuerySort.QUERY_SORT_TYPE.COLUMN) {
 				QueryColumnOrderBySelector gSelect = (QueryColumnOrderBySelector) orderBy;
 				String tableName = gSelect.getTable();
 				String columnName = gSelect.getColumn();
 				ORDER_BY_DIRECTION sortDirection = gSelect.getSortDir();
-				
+
 				String varName = Utility.cleanVariableString(tableName);
-				if(!columnName.equals(SelectQueryStruct.PRIM_KEY_PLACEHOLDER)) {
+				if (!columnName.equals(SelectQueryStruct.PRIM_KEY_PLACEHOLDER)) {
 					varName += "__" + Utility.cleanVariableString(columnName);
 				}
-	
-				if(sortDirection == ORDER_BY_DIRECTION.ASC) {
+
+				if (sortDirection == ORDER_BY_DIRECTION.ASC) {
 					this.sortByClause.append(" ASC(");
 				} else {
 					this.sortByClause.append(" DESC(");
 				}
-				
-				if(this.selectorAlias.containsKey(varName)) {
+
+				if (this.selectorAlias.containsKey(varName)) {
 					this.sortByClause.append("?").append(this.selectorAlias.get(varName));
 				} else {
 					this.sortByClause.append("?").append(varName);
@@ -932,47 +977,49 @@ public class SparqlInterpreter extends AbstractQueryInterpreter {
 			}
 		}
 	}
-	
+
 	/**
-	 * Need to determine if a filter is set to equal null 
-	 * Need to make sure this property definition is an optional
+	 * Need to determine if a filter is set to equal null Need to make sure this
+	 * property definition is an optional
+	 * 
 	 * @param combinedFilters
 	 * @return
 	 */
 	private Set<String> getFilteredColumnsToNull(List<IQueryFilter> filters) {
 		Set<String> qsColumnsEqualNull = new HashSet<String>();
-		for(IQueryFilter f : filters) {
-			if(f.getQueryFilterType() == QUERY_FILTER_TYPE.SIMPLE) {
+		for (IQueryFilter f : filters) {
+			if (f.getQueryFilterType() == QUERY_FILTER_TYPE.SIMPLE) {
 				SimpleQueryFilter simpleF = (SimpleQueryFilter) f;
-				
+
 				IQuerySelector selector = null;
 				Object val = null;
-				if(simpleF.getSimpleFilterType() == SimpleQueryFilter.FILTER_TYPE.COL_TO_VALUES) {
+				if (simpleF.getSimpleFilterType() == SimpleQueryFilter.FILTER_TYPE.COL_TO_VALUES) {
 					selector = (IQuerySelector) simpleF.getLComparison().getValue();
 					val = simpleF.getRComparison().getValue();
-				} else if(simpleF.getSimpleFilterType() == SimpleQueryFilter.FILTER_TYPE.VALUES_TO_COL) {
+				} else if (simpleF.getSimpleFilterType() == SimpleQueryFilter.FILTER_TYPE.VALUES_TO_COL) {
 					val = simpleF.getLComparison().getValue();
 					selector = (IQuerySelector) simpleF.getRComparison().getValue();
 				} else {
 					// ignore other types
 					continue;
 				}
-				
-				if(val == null) {
-					qsColumnsEqualNull.add(selector.getQueryStructName()); 
+
+				if (val == null) {
+					qsColumnsEqualNull.add(selector.getQueryStructName());
 				} else {
-					if(val instanceof List) {
-						if(((List) val).contains(null)) {
-							qsColumnsEqualNull.add(selector.getQueryStructName()); 
+					if (val instanceof List) {
+						if (((List) val).contains(null)) {
+							qsColumnsEqualNull.add(selector.getQueryStructName());
 						}
 					}
 				}
-			} else if(f.getQueryFilterType() == QUERY_FILTER_TYPE.OR || f.getQueryFilterType() == QUERY_FILTER_TYPE.AND) {
+			} else if (f.getQueryFilterType() == QUERY_FILTER_TYPE.OR
+					|| f.getQueryFilterType() == QUERY_FILTER_TYPE.AND) {
 				AbstractListFilter listF = (AbstractListFilter) f;
 				qsColumnsEqualNull.addAll(getFilteredColumnsToNull(listF.getFilterList()));
 			}
 		}
-		
+
 		return qsColumnsEqualNull;
 	}
 }

--- a/src/prerna/rdf/engine/wrappers/SelectStatement.java
+++ b/src/prerna/rdf/engine/wrappers/SelectStatement.java
@@ -33,83 +33,93 @@ import java.util.Map;
 import prerna.engine.api.IHeadersDataRow;
 import prerna.engine.api.ISelectStatement;
 
-public class SelectStatement  implements ISelectStatement {
-	
+public class SelectStatement implements ISelectStatement {
+
 	transient public Map propHash = new LinkedHashMap();
 	transient public Map rawPropHash = new LinkedHashMap();
 	String serialRep = null;
 
+	@Override
 	public Object getVar(Object var) {
 		Object retVal = propHash.get(var);
 		return retVal;
 	}
 
+	@Override
 	public Object getRawVar(Object var) {
 		// TODO Auto-generated method stub
 		return rawPropHash.get(var);
 	}
 
+	@Override
 	public void setPropHash(Map propHash) {
 		this.propHash = propHash;
 	}
 
+	@Override
 	public void setRPropHash(Map rawPropHash) {
 		// TODO Auto-generated method stub
 		this.rawPropHash = rawPropHash;
 	}
 
+	@Override
 	public Map getPropHash() {
 		// TODO Auto-generated method stub
 		return propHash;
 	}
 
+	@Override
 	public Map getRPropHash() {
 		// TODO Auto-generated method stub
 		return rawPropHash;
 	}
 
-	
 	@Override
 	public void setVar(Object key, Object value) {
 		propHash.put(key, value);
-		
+
 	}
 
 	@Override
 	public void setRawVar(Object key, Object value) {
-		rawPropHash.put(key, value);		
+		rawPropHash.put(key, value);
 	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
-		result = prime * result
-				+ ((propHash == null) ? 0 : propHash.hashCode());
-		result = prime * result
-				+ ((rawPropHash == null) ? 0 : rawPropHash.hashCode());
+		result = prime * result + ((propHash == null) ? 0 : propHash.hashCode());
+		result = prime * result + ((rawPropHash == null) ? 0 : rawPropHash.hashCode());
 		return result;
 	}
 
 	@Override
 	public boolean equals(Object obj) {
-		if (this == obj)
+		if (this == obj) {
 			return true;
-		if (obj == null)
+		}
+		if (obj == null) {
 			return false;
-		if (getClass() != obj.getClass())
+		}
+		if (getClass() != obj.getClass()) {
 			return false;
+		}
 		SelectStatement other = (SelectStatement) obj;
 		if (propHash == null) {
-			if (other.propHash != null)
+			if (other.propHash != null) {
 				return false;
-		} else if (!propHash.equals(other.propHash))
+			}
+		} else if (!propHash.equals(other.propHash)) {
 			return false;
+		}
 		if (rawPropHash == null) {
-			if (other.rawPropHash != null)
+			if (other.rawPropHash != null) {
 				return false;
-		} else if (!rawPropHash.equals(other.rawPropHash))
+			}
+		} else if (!rawPropHash.equals(other.rawPropHash)) {
 			return false;
+		}
 		return true;
 	}
 
@@ -122,7 +132,7 @@ public class SelectStatement  implements ISelectStatement {
 	@Override
 	public String[] getHeaders() {
 		// TODO Auto-generated method stub
-		return (String[]) propHash.keySet().toArray(new String[]{});
+		return (String[]) propHash.keySet().toArray(new String[] {});
 	}
 
 	@Override
@@ -130,7 +140,7 @@ public class SelectStatement  implements ISelectStatement {
 		// TODO Auto-generated method stub
 		return propHash.values().toArray();
 	}
-	
+
 	@Override
 	public Object[] getRawValues() {
 		// TODO Auto-generated method stub
@@ -152,13 +162,13 @@ public class SelectStatement  implements ISelectStatement {
 	@Override
 	public void open() {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
 	public void addField(String fieldName, Object value) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
@@ -176,7 +186,7 @@ public class SelectStatement  implements ISelectStatement {
 	@Override
 	public void addFields(String[] addHeaders, Object[] addValues) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
@@ -188,7 +198,7 @@ public class SelectStatement  implements ISelectStatement {
 	@Override
 	public void addFields(String addHeader, Object addValues) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
@@ -198,20 +208,26 @@ public class SelectStatement  implements ISelectStatement {
 	}
 
 	@Override
-	public String getQuery(){
+	public String getQuery() {
 		return "";
 	}
 
 	@Override
 	public void setQuery(String query) {
 		// TODO Auto-generated method stub
-		
+
 	}
 
 	@Override
 	public Map<String, Object> flushRowToMap() {
 		// TODO Auto-generated method stub
 		return null;
+	}
+
+	@Override
+	public void setRaw(boolean raw) {
+		// TODO Auto-generated method stub
+
 	}
 
 //	@Override

--- a/src/prerna/reactor/qs/AbstractSparqlQueryReactor.java
+++ b/src/prerna/reactor/qs/AbstractSparqlQueryReactor.java
@@ -1,0 +1,190 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.qs;
+
+import java.util.Locale;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.User;
+import prerna.auth.utils.SecurityEngineUtils;
+import prerna.engine.api.IDatabaseEngine;
+import prerna.engine.api.IEngine;
+import prerna.engine.api.IRDFDatabase;
+import prerna.query.querystruct.AbstractQueryStruct.QUERY_STRUCT_TYPE;
+import prerna.query.querystruct.HardSelectQueryStruct;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.execptions.SemossPixelException;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.sablecc2.om.task.BasicIteratorTask;
+import prerna.util.Utility;
+
+public abstract class AbstractSparqlQueryReactor extends AbstractReactor {
+
+	private static final Logger classLogger = LogManager.getLogger(AbstractSparqlQueryReactor.class);
+
+	private static final int DEFAULT_LIMIT = 50;
+	private static final int MAX_LIMIT = 5_000;
+
+	public AbstractSparqlQueryReactor() {
+		this.keysToGet = new String[] { ReactorKeysEnum.QUERY_KEY.getKey(), ReactorKeysEnum.DATABASE.getKey(),
+				ReactorKeysEnum.LIMIT.getKey(), "raw" };
+		this.keyRequired = new int[] { 1, 1, 0, 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		User user = this.insight.getUser();
+		if (user == null) {
+			NounMetadata noun = new NounMetadata("User must be signed into an account in order to run this operation",
+					PixelDataType.CONST_STRING, PixelOperationType.ERROR, PixelOperationType.LOGGIN_REQUIRED_ERROR);
+			SemossPixelException err = new SemossPixelException(noun);
+			err.setContinueThreadOfExecution(false);
+			throw err;
+		}
+
+		organizeKeys();
+		String sparqlQuery = getDecodedQuery();
+		String databaseId = this.keyValue.get(this.keysToGet[1]);
+		String limitStr = this.keyValue.get(this.keysToGet[2]);
+		String rawStr = this.keyValue.get(this.keysToGet[3]);
+
+		if (sparqlQuery == null || sparqlQuery.trim().isEmpty()) {
+			throw new SemossPixelException("SPARQL query cannot be empty");
+		}
+
+		if (databaseId == null || databaseId.trim().isEmpty()) {
+			throw new SemossPixelException("Database id is required");
+		}
+
+		if (!isSparqlSelect(sparqlQuery)) {
+			throw new SemossPixelException("Only SPARQL SELECT queries are supported");
+		}
+
+		IEngine engine = Utility.getEngine(databaseId);
+		if (!(engine instanceof IRDFDatabase)) {
+			throw new IllegalArgumentException("The database is not an RDF engine that accepts SPARQL");
+		}
+
+		if (!SecurityEngineUtils.userCanViewEngine(user, databaseId)) {
+			throw new SemossPixelException("User does not have permission to query this database");
+		}
+
+		boolean raw = rawStr != null && Boolean.parseBoolean(rawStr.trim());
+
+		try {
+			HardSelectQueryStruct qs = buildQs(sparqlQuery, (IDatabaseEngine) engine, databaseId);
+			int limit = parseLimit(limitStr);
+			BasicIteratorTask task = new BasicIteratorTask(qs);
+			task.setNumCollect(limit);
+			task.setCollectLimit(limit);
+			task.setReturnRaw(raw);
+			this.insight.addQueriedDatabases(databaseId);
+			return new NounMetadata(task, PixelDataType.FORMATTED_DATA_SET);
+		} catch (SemossPixelException e) {
+			throw e;
+		} catch (Exception e) {
+			classLogger.error("Error executing SPARQL query for database {}", databaseId, e);
+			throw new SemossPixelException("Error executing SPARQL query: " + e.getMessage());
+		}
+	}
+
+	/**
+	 * @return Decoded SPARQL query string ready for execution
+	 */
+	protected abstract String getDecodedQuery();
+
+	/**
+	 * Skips PREFIX/BASE declarations and comment lines, then checks if the first
+	 * real query keyword is SELECT.
+	 */
+	private static boolean isSparqlSelect(String sparql) {
+		for (String line : sparql.split("\\n")) {
+			String t = line.trim();
+			if (t.isEmpty() || t.startsWith("#")) {
+				continue;
+			}
+			String upper = t.toUpperCase(Locale.ROOT);
+			if (upper.startsWith("PREFIX ") || upper.startsWith("BASE ")) {
+				continue;
+			}
+			return upper.startsWith("SELECT");
+		}
+		return false;
+	}
+
+	private HardSelectQueryStruct buildQs(String sparqlQuery, IDatabaseEngine engine, String databaseId) {
+		HardSelectQueryStruct qs = new HardSelectQueryStruct();
+		qs.setEngineId(databaseId);
+		qs.setEngine(engine);
+		qs.setQuery(sparqlQuery);
+		qs.setQsType(QUERY_STRUCT_TYPE.RAW_ENGINE_QUERY);
+		return qs;
+	}
+
+	private int parseLimit(String limitStr) {
+		int limit = DEFAULT_LIMIT;
+		if (limitStr != null && !limitStr.trim().isEmpty()) {
+			try {
+				limit = Integer.parseInt(limitStr.trim());
+				if (limit <= 0) {
+					classLogger.warn("Non-positive limit value: {}, using default {}", limit, DEFAULT_LIMIT);
+					limit = DEFAULT_LIMIT;
+				} else if (limit > MAX_LIMIT) {
+					classLogger.warn("Limit value {} exceeds maximum {}, using maximum", limit, MAX_LIMIT);
+					limit = MAX_LIMIT;
+				}
+			} catch (NumberFormatException e) {
+				classLogger.warn("Invalid limit value: {}, using default {}", limitStr, DEFAULT_LIMIT);
+			}
+		}
+		return limit;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Execute a SPARQL SELECT query against an RDF database";
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (key.equals(ReactorKeysEnum.DATABASE.getKey())) {
+			return "The database id";
+		} else if (key.equals(ReactorKeysEnum.LIMIT.getKey())) {
+			return "Limits the number of rows retrieved";
+		} else if (key.equals("raw")) {
+			return "When true, returns the full URI or literal representation for each binding instead of the processed instance name";
+		}
+		return super.getDescriptionForKey(key);
+	}
+
+}

--- a/src/prerna/reactor/qs/AbstractSqlQueryReactor.java
+++ b/src/prerna/reactor/qs/AbstractSqlQueryReactor.java
@@ -232,7 +232,7 @@ public abstract class AbstractSqlQueryReactor extends AbstractReactor {
 			BasicIteratorTask task = new BasicIteratorTask(qs);
 			task.setNumCollect(limit);
 			task.setCollectLimit(limit);
-			this.insight.addQueriedDatabasesese(databaseId);
+			this.insight.addQueriedDatabases(databaseId);
 			return new NounMetadata(task, PixelDataType.FORMATTED_DATA_SET);
 		} catch (Exception e) {
 			classLogger.error("Error executing SELECT SQL query for database {}", databaseId, e);

--- a/src/prerna/reactor/qs/SparqlQueryBase64Reactor.java
+++ b/src/prerna/reactor/qs/SparqlQueryBase64Reactor.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.qs;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import prerna.sablecc2.om.ReactorKeysEnum;
+
+/**
+ * Executes a Base64-encoded SPARQL SELECT query against an RDF database.
+ */
+public class SparqlQueryBase64Reactor extends AbstractSparqlQueryReactor {
+
+	@Override
+	protected String getDecodedQuery() {
+		try {
+			return new String(Base64.getDecoder().decode(this.keyValue.get(ReactorKeysEnum.QUERY_KEY.getKey())),
+					StandardCharsets.UTF_8);
+		} catch (Exception e) {
+			throw new IllegalArgumentException("Failed to decode query: input is not a base64-encoded utf-8 string", e);
+		}
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (key.equals(ReactorKeysEnum.QUERY_KEY.getKey())) {
+			return "The SPARQL SELECT query to execute. The query should be passed as a base64-encoded utf-8 string";
+		}
+		return super.getDescriptionForKey(key);
+	}
+
+}

--- a/src/prerna/reactor/qs/SparqlQueryReactor.java
+++ b/src/prerna/reactor/qs/SparqlQueryReactor.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.qs;
+
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.util.Utility;
+
+/**
+ * Executes a URI-encoded SPARQL SELECT query against an RDF database. The query
+ * should be wrapped in encode/decode blocks for proper encoding.
+ */
+public class SparqlQueryReactor extends AbstractSparqlQueryReactor {
+
+	@Override
+	protected String getDecodedQuery() {
+		return Utility.decodeURIComponent(this.keyValue.get(ReactorKeysEnum.QUERY_KEY.getKey()));
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (key.equals(ReactorKeysEnum.QUERY_KEY.getKey())) {
+			return "The SPARQL SELECT query to execute. The query should be passed within <encode> </encode> blocks for proper encoding";
+		}
+		return super.getDescriptionForKey(key);
+	}
+
+}

--- a/src/prerna/reactor/qs/source/DatabaseReactor.java
+++ b/src/prerna/reactor/qs/source/DatabaseReactor.java
@@ -62,7 +62,7 @@ public class DatabaseReactor extends AbstractQueryStructReactor {
 
 		this.qs.setEngineId(databaseId);
 		// add the engine to the insight
-		this.insight.addQueriedDatabasesese(databaseId);
+		this.insight.addQueriedDatabases(databaseId);
 
 		// checking if it is a big data engine
 		Object bigDataProp = Utility.getEngine(databaseId).getSmssProp().get(Constants.BIG_DATA_ENGINE);

--- a/src/prerna/sablecc2/om/task/BasicIteratorTask.java
+++ b/src/prerna/sablecc2/om/task/BasicIteratorTask.java
@@ -78,6 +78,7 @@ public class BasicIteratorTask extends AbstractTask {
 
 	private long collectLimit = -1;
 	private long collectCounter = 0;
+	private boolean returnRaw = false;
 
 	public BasicIteratorTask(SelectQueryStruct qs) {
 		this.qs = qs;
@@ -153,6 +154,10 @@ public class BasicIteratorTask extends AbstractTask {
 		return iterator.hasNext();
 	}
 
+	public void setReturnRaw(boolean returnRaw) {
+		this.returnRaw = returnRaw;
+	}
+
 	@Override
 	public IHeadersDataRow next() {
 		if (this.iterator == null) {
@@ -162,7 +167,11 @@ public class BasicIteratorTask extends AbstractTask {
 		if (this.collectLimit > -1) {
 			collectCounter++;
 		}
-		return iterator.next();
+		IHeadersDataRow row = iterator.next();
+		if (row != null) {
+			row.setRaw(this.returnRaw);
+		}
+		return row;
 	}
 
 	@Override

--- a/src/prerna/util/sql/AbstractSqlQueryUtil.java
+++ b/src/prerna/util/sql/AbstractSqlQueryUtil.java
@@ -300,9 +300,9 @@ public abstract class AbstractSqlQueryUtil {
 	 * Replace a conneciton url to a file based db (H2, SQLite) with
 	 * "@BaseFolder@/db/@ENGINE@"
 	 * <p>
-	 * In {@link RDBMSNativeEngine#open(Properties) method we call {@link
-	 * #fillFileParameterizedConnectionUrl(String, String, String)} to turn back
-	 * into a useable conneciton url
+	 * In {@link RDBMSNativeEngine#open(Properties) method we call
+	 * {@link #fillFileParameterizedConnectionUrl(String, String, String)} to turn
+	 * back into a useable conneciton url
 	 * </p>
 	 * 
 	 * @param connectionUrl


### PR DESCRIPTION
- Add SparqlQueryReactor and SparqlQueryBase64Reactor (SELECT-only, mirrors SQL equivalents)
- Add raw=true parameter: IHeadersDataRow.setRaw() makes getValues() return full URIs/typed literals instead of stripped instance names; BasicIteratorTask threads the flag through next()
- Fix SparqlInterpreter: predURI null guard, numeric multi-value filter || written to wrong builder
- Rename addQueriedDatabasesese -> addQueriedDatabases across all callers