### PR TITLE
Fixing user room permission error when looking for agent harness history in room that does not exist.

### DIFF
--- a/src/prerna/reactor/agent/GetClaudeCodeTranscriptHistoryReactor.java
+++ b/src/prerna/reactor/agent/GetClaudeCodeTranscriptHistoryReactor.java
@@ -72,15 +72,14 @@ public class GetClaudeCodeTranscriptHistoryReactor extends AbstractReactor {
 		}
 		String finalRoomId = roomId.trim();
 		
+		List<Object> events = new ArrayList<>();
+		
 		Room room;
 		try {
 		    room = RoomUtils.getOrLoadRoom(roomId, this.insight);
 		} catch(Exception e) {
-			classLogger.error("User does not have access to this room {}", finalRoomId, e);
-			throw new IllegalStateException("User does not have access to this room");
+			return new NounMetadata(events, PixelDataType.CUSTOM_DATA_STRUCTURE, PixelOperationType.OPERATION);
 		}
-
-		List<Object> events = new ArrayList<>();
 
 		Path jsonl = ClaudeCodeTranscriptLocator.findJsonlFile(roomId);
 		if (jsonl == null) {

--- a/src/prerna/reactor/agent/GetGitHubCopilotTranscriptHistoryReactor.java
+++ b/src/prerna/reactor/agent/GetGitHubCopilotTranscriptHistoryReactor.java
@@ -71,16 +71,17 @@ public class GetGitHubCopilotTranscriptHistoryReactor extends AbstractReactor {
 		if (roomId == null || roomId.trim().isEmpty()) {
 			throw new IllegalArgumentException("Room id is required");
 		}
+		
+		List<Object> events = new ArrayList<>();
 
 		String finalRoomId = roomId.trim();
 		try {
 			RoomUtils.getOrLoadRoom(finalRoomId, this.insight);
 		} catch (Exception e) {
-			classLogger.error("User does not have access to GitHub Copilot room {}", finalRoomId, e);
-			throw new IllegalStateException("User does not have access to this room");
+			return new NounMetadata(events, PixelDataType.CUSTOM_DATA_STRUCTURE, PixelOperationType.OPERATION);
 		}
 
-		List<Object> events = new ArrayList<>();
+		
 		Set<String> suppressedToolCallIds = new HashSet<>();
 		Path jsonl = GitHubCopilotTranscriptLocator.findJsonlFile(finalRoomId);
 		if (jsonl == null) {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Previously on chat load (Agent47) we were looking for agent harness history in JSONL files and if the room did not exist we were throwing an error that said user did not have permission to access room. Now we simply return an empty events array if the room does not exist. 

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->