### PR TITLE
Updating Python Docker file for transient mirror sync issue

### DIFF
--- a/docker/Dockerfile.python
+++ b/docker/Dockerfile.python
@@ -79,9 +79,10 @@ COPY --from=builder /usr/lib/python /usr/lib/python
 ENV VIRTUAL_ENV="/usr/lib/python/semossvenv"
 ENV PATH=$VIRTUAL_ENV/bin:$PATH
 
-# Install additional dependencies
-RUN apt-get update \
-    && apt-get install -y tesseract-ocr \
+# Install additional dependencies with retry for transient Ubuntu mirror issues
+RUN rm -rf /var/lib/apt/lists/* \
+    && for i in 1 2 3; do apt-get update && break || (sleep 10 && rm -rf /var/lib/apt/lists/*); done \
+    && apt-get install -y --no-install-recommends --fix-missing tesseract-ocr \
     && apt-get -y autoremove \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Occasionally getting a failure that looks transient and external to the repo code. The Docker Python build fails during `apt-get update` / `apt-get install tesseract-ocr` because the Ubuntu `jammy-security` package index was inconsistent while `security.ubuntu.com` was syncing (`File has unexpected size ... Mirror sync in progress?`). Meaning apt downloaded metadata that no longer matched the package list by the time it fetched it. 

 Adding retry logic around the apt step in `docker/Dockerfile.python`, or rerun if this was a one-off mirror issue.

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->