### PR TITLE
fix: itask returns data

### DIFF
--- a/src/prerna/reactor/agent/mcp/MCPUtility.java
+++ b/src/prerna/reactor/agent/mcp/MCPUtility.java
@@ -72,6 +72,7 @@ import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.PixelOperationType;
 import prerna.sablecc2.om.execptions.SemossMCPException;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.sablecc2.om.task.ITask;
 import prerna.util.Constants;
 import prerna.util.EngineUtility;
 import prerna.util.Utility;
@@ -418,6 +419,14 @@ public final class MCPUtility {
 			} catch (WebApplicationException | IOException e) {
 				classLogger.error("The pixel ran but an error occurred streaming the pixel results", e.getMessage());
 				return "An error occurred streaming the pixel execution output: " + e.getMessage();
+			}
+		} else if (value instanceof ITask) {
+			try (ITask task = (ITask) value) {
+				Map<String, Object> collectedData = task.collect(true);
+				return GSON.toJson(collectedData);
+			} catch (Exception e) {
+				classLogger.error("Error collecting task data for MCP result", e);
+				return "An error occurred collecting the query results: " + e.getMessage();
 			}
 		}
 


### PR DESCRIPTION
## Description
When MCP tools execute Pixel that returns an `ITask` (e.g., database queries), the result was not being serialized properly. This fix adds handling for `ITask` return types so query results are collected and returned as JSON to the MCP client.

## Changes Made
- Added `ITask` handling in `MCPUtility.java`'s result serialization logic
- Calls `task.collect(true)` to gather all result data
- Serializes collected data to JSON via GSON
- Properly closes the task resource using try-with-resources
- Includes error handling with logging on failure

## How to Test
1. Connect an MCP client to a SEMOSS MCP server
2. Invoke a tool that runs a database query (e.g., a Pixel that returns a frame/task)
3. Verify the query results are returned as JSON to the MCP client instead of a raw object reference

## Notes
- Previously, `ITask` values would fall through to the generic `GSON.toJson(value)` call, which does not properly serialize task iterators
- The fix mirrors the existing pattern for handling `PixelStream` results above it
