### PR TITLE
Fixing naming logic with full prompt

### DIFF
--- a/src/prerna/engine/impl/model/AbstractModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractModelEngine.java
@@ -244,11 +244,13 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 		// update current usage based on this new request
 		ModelUsageRestrictionUtility.updateRestrictionMapCurrentUsage(userRestrictionMap, askModelResponse, inputTime,
 				outputTime);
+		
+		String currentRoomName = room.getRoomName();
 
-		// save the output if its full prompt since it short circuits the room object.
-		if (fullPrompt != null) {
+
+		// Grabbing room name from first input message if room name is empty and its full prompt..
+		if (fullPrompt != null && currentRoomName.isEmpty()) {
 			String roomName = null;
-			// Check if first message is input and has a prompt, use it as room name
 			if (!room.getMessages().isEmpty()) {
 				AbstractMessage first = room.getMessages().get(0);
 				if (first instanceof InputMessage) {


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

The current logic will always rename a room if full prompt is sent. This fixes to check if a room already has a name and skips the renaming process if it does. 

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->