### PR TITLE
Agent Harness Hooks

### DIFF
--- a/src/prerna/reactor/agent/AgentRunner.java
+++ b/src/prerna/reactor/agent/AgentRunner.java
@@ -120,7 +120,7 @@ public final class AgentRunner {
 
         String filePath = "";
         if (paramMap.containsKey("project")) {
-        	String projectId = paramMap.remove("project").toString();
+        	String projectId = paramMap.get("project").toString();
         	filePath = AssetUtility.getProjectAssetsFolder(projectId);
         	logger.info("Using project ID {} to set agent working directory..", projectId);
         } else if(paramMap.containsKey("filePath")){

--- a/src/prerna/reactor/agent/AppBuildingHarness.java
+++ b/src/prerna/reactor/agent/AppBuildingHarness.java
@@ -34,6 +34,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -49,6 +50,7 @@ import prerna.om.Insight;
 import prerna.project.api.IProject;
 import prerna.util.EngineUtility;
 import prerna.util.Utility;
+import prerna.reactor.agent.hooks.GitCommitAgentHook;
 
 /**
  * Abstract base class for harnesses that build inside a project's {@code client/}
@@ -93,11 +95,40 @@ public abstract class AppBuildingHarness implements IAgentHarness {
             ensureClaudeStructure(clientPath);
             AppBuilderHarnessConfiguration.ensureAgentConfig(clientPath);
         }
-        return doExecute(ctx);
+        List<IMessageHook> hooks = getMessageHooks();
+        for (IMessageHook h : hooks) {
+            h.beforeMessage(ctx);
+        }
+        AgentHarnessResult result = doExecute(ctx);
+        for (IMessageHook h : hooks) {
+            h.afterMessage(ctx, result);
+        }
+        return result;
     }
 
     /** Subclass entry point. Wrapped by {@link #execute(AgentRunContext)}. */
     protected abstract AgentHarnessResult doExecute(AgentRunContext ctx) throws Exception;
+
+    /**
+     * Hooks shared by every {@link AppBuildingHarness} subclass. Populate this
+     * list with hooks that should run for all harnesses by default. The base
+     * {@link #getMessageHooks()} returns this list as-is; subclasses that
+     * override {@code getMessageHooks()} are responsible for calling
+     * {@code super.getMessageHooks()} to include them (or deliberately omitting
+     * the call to opt out).
+     */
+    private static final List<IMessageHook> COMMON_HOOKS =
+            Collections.singletonList(new GitCommitAgentHook());
+
+    /**
+     * Hooks fired around each {@link #execute(AgentRunContext)} call, in list
+     * order. Default: returns {@link #COMMON_HOOKS}. Subclasses may override
+     * to compose, reorder, or replace the common hooks — typically by calling
+     * {@code super.getMessageHooks()} and appending their own.
+     */
+    protected List<IMessageHook> getMessageHooks() {
+        return COMMON_HOOKS;
+    }
 
     // ============================================================
     // Shared resolution helpers (used inside doExecute)

--- a/src/prerna/reactor/agent/ClaudeCodeAgentHarness.java
+++ b/src/prerna/reactor/agent/ClaudeCodeAgentHarness.java
@@ -65,9 +65,40 @@ public class ClaudeCodeAgentHarness extends AppBuildingHarness {
     /** Registry name used by {@link AgentHarnessRegistry}. */
     public static final String NAME = "claude_code";
 
+    private static final IMessageHook LOGGING_HOOK = new IMessageHook() {
+        @Override
+        public void beforeMessage(AgentRunContext ctx) {
+            String input = ctx.getInput();
+            logger.debug("[claude_code] pre-message: room={}, inputLen={}",
+                    ctx.getRoom().getId(),
+                    input == null ? 0 : input.length());
+        }
+
+        @Override
+        public void afterMessage(AgentRunContext ctx, AgentHarnessResult result) {
+            String finalText = result.getFinalText();
+            logger.debug("[claude_code] post-message: room={}, iterations={}, finalTextLen={}",
+                    ctx.getRoom().getId(),
+                    result.getIterations(),
+                    finalText == null ? 0 : finalText.length());
+        }
+    };
+
     @Override
     public String getName() {
         return NAME;
+    }
+
+    /**
+     * Common hooks first, then this harness's own hooks. Drop the
+     * {@code super} call to opt out of the common hooks; reorder the
+     * {@code addAll} / {@code add} calls to control execution order.
+     */
+    @Override
+    protected List<IMessageHook> getMessageHooks() {
+        List<IMessageHook> all = new ArrayList<>(super.getMessageHooks());
+        all.add(LOGGING_HOOK);
+        return all;
     }
 
     @Override

--- a/src/prerna/reactor/agent/IMessageHook.java
+++ b/src/prerna/reactor/agent/IMessageHook.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.agent;
+
+/**
+ * Observer-style hook fired around a single agent message — i.e. one
+ * {@link IAgentHarness#execute(AgentRunContext)} call.
+ *
+ * <p>Hooks are returned by {@link AppBuildingHarness#getMessageHooks()} and
+ * invoked in list order. {@link #beforeMessage} fires before
+ * {@code doExecute}; {@link #afterMessage} fires only after a successful
+ * {@code doExecute} return. If any hook throws, subsequent hooks in the
+ * chain are skipped and the exception propagates to the caller.
+ */
+public interface IMessageHook {
+
+    /** Fires before {@code doExecute}. Throw to abort the message. Default: no-op. */
+    default void beforeMessage(AgentRunContext ctx) throws Exception {}
+
+    /** Fires after a successful {@code doExecute}, with the produced result. Default: no-op. */
+    default void afterMessage(AgentRunContext ctx, AgentHarnessResult result) throws Exception {}
+}

--- a/src/prerna/reactor/agent/hooks/GitCommitAgentHook.java
+++ b/src/prerna/reactor/agent/hooks/GitCommitAgentHook.java
@@ -1,0 +1,50 @@
+package prerna.reactor.agent.hooks;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.AccessToken;
+import prerna.auth.User;
+import prerna.engine.api.IEngine.CATALOG_TYPE;
+import prerna.engine.api.IEngine;
+import prerna.reactor.agent.AgentHarnessResult;
+import prerna.reactor.agent.AgentRunContext;
+import prerna.reactor.agent.IMessageHook;
+import prerna.util.EngineUtility;
+import prerna.util.Utility;
+import prerna.util.git.GitRepoUtils;
+
+
+public final class GitCommitAgentHook implements IMessageHook {
+	
+	private static final Logger classLogger = LogManager.getLogger(GitCommitAgentHook.class);
+	
+    @Override
+    public void afterMessage(AgentRunContext ctx, AgentHarnessResult result) throws Exception {
+    	Map<String, Object> paramMap = ctx.getParamMap();
+    	String projectId = Objects.toString(paramMap.get("project"), null);
+    	if (projectId == null) {
+    		classLogger.error("POST MESSAGE GIT COMMIT HOOK IS MISSING PROJECT ID");
+    		return;
+    	}
+    	
+    	IEngine projectEngine = Utility.getProject(projectId);
+    	
+    	String projectName = projectEngine.getEngineName();
+    	
+    	String gitFolder = EngineUtility.getSpecificEngineVersionFolder(CATALOG_TYPE.PROJECT, projectId, projectName);
+    	
+    	GitRepoUtils.addAllFiles(gitFolder, true);
+    	
+    	User user = ctx.getInsight().getUser();
+    	
+    	AccessToken accessToken = user.getAccessToken(user.getPrimaryLogin());
+		String author = accessToken.getUsername();
+		String email = accessToken.getEmail();
+		GitRepoUtils.commitAddedFiles(gitFolder, "CODING AGENT EDIT", author, email);
+    	
+    }    	
+}


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Adds an extension point for running custom logic around each agent message — one user message = one IAgentHarness.execute(ctx) call. The first concrete hook auto-commits agent edits to the project's git repo after every message; downstream hooks (audit, telemetry, etc.) plug in the same way.

Changes
New: IMessageHook
Observer-style interface with two default-no-op methods:

beforeMessage(AgentRunContext ctx) — fires before doExecute
afterMessage(AgentRunContext ctx, AgentHarnessResult result) — fires only on successful doExecute return
If any hook throws, subsequent hooks are skipped and the exception propagates.

Modified: AppBuildingHarness

New private static final List<IMessageHook> COMMON_HOOKS — hooks that run for every subclass
New protected List<IMessageHook> getMessageHooks() — returns COMMON_HOOKS by default; non-final so subclasses can compose, reorder, or opt out
The final execute() template method now iterates the hook list before/after doExecute
New: GitCommitAgentHook
First concrete hook. On afterMessage, resolves the project from ctx.getParamMap().get("project"), runs git add -A + git commit on the project's version folder using the calling user's name/email. Bails gracefully (logs and returns) when no project ID is present. Wired into COMMON_HOOKS, so every harness inherits it.

Modified: ClaudeCodeAgentHarness
Demonstrates the composition pattern: a tiny inline LOGGING_HOOK plus an override that calls super.getMessageHooks() and appends.

How to add another hook
Hook that should run for every harness — add to COMMON_HOOKS in AppBuildingHarness:
```
private static final List<IMessageHook> COMMON_HOOKS = List.of(
    new GitCommitAgentHook(),
    new YourNewCommonHook()
);
```

Hook that should run for one specific harness — override getMessageHooks() in that subclass and append:
```
@Override
protected List<IMessageHook> getMessageHooks() {
    List<IMessageHook> all = new ArrayList<>(super.getMessageHooks());
    all.add(new YourHarnessSpecificHook());
    return all;
}
```

Opt out of common hooks for a specific harness — override and skip the super call:

```
@Override
protected List<IMessageHook> getMessageHooks() {
    return List.of(new OnlyMyHook());  // common hooks deliberately not included
}
```

How to write a hook
Implement IMessageHook and override only the side you care about (both methods have default no-op implementations):
```
public final class MyHook implements IMessageHook {
    @Override
    public void afterMessage(AgentRunContext ctx, AgentHarnessResult result) {
        // your logic — has access to room, user, input, params, result
    }
}
```

Place stateless hooks (most cases) in prerna.reactor.agent.hooks and reuse a single instance via new MyHook() in the list. Hooks needing config take constructor params.

Behavior notes
Hooks fire in list order; declaration order = execution order for both before and after.
afterMessage only fires when doExecute returns successfully. If doExecute throws, no afterMessage runs (the git commit will not fire on a failed message — by design).
beforeMessage failures abort the message; doExecute does not run.
The compiler can't catch a forgotten super.getMessageHooks() call. If you add a critical hook to COMMON_HOOKS later, audit the subclass overrides to make sure no harness is silently dropping it.
Files touched
Semoss/src/prerna/reactor/agent/IMessageHook.java (new)
Semoss/src/prerna/reactor/agent/hooks/GitCommitAgentHook.java (new)
Semoss/src/prerna/reactor/agent/AppBuildingHarness.java
Semoss/src/prerna/reactor/agent/ClaudeCodeAgentHarness.java

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->