### PR TITLE
fix(faiss): replace pickle index files with parquet/npy and improve cold start

### DIFF
--- a/py/testing/vector_database/vector_db_test.py
+++ b/py/testing/vector_database/vector_db_test.py
@@ -8,9 +8,10 @@ Ensure the below items before run it,
     - Make sure you have the below model engines,
         - Dev_Testing_FAISS__1222b449-1bc6-4358-9398-1ed828e4f26a
         - TextEmbeddings BAAI-Large-En-V1.5__e4449559-bcff-4941-ae72-0e3f18e06660_engine
-    - Make sure you have added the `dataset.pkl`, `vectors.pkl` and `dummy.pdf` in the test_files folder
+    - Make sure you have added the `dataset.parquet`, `vectors.npy` and `dummy.pdf` in the test_files folder
         - test_files path - Semoss/py/testing/vector_database/test_files
-        - Create the test_files folder if you don't have and add the pkl files into it from Dev_Testing_FAISS engine (Dev_Testing_FAISS_\Dev_Testing_FAISS_\schema\default)
+        - Create the test_files folder if you don't have and add the index files into it from Dev_Testing_FAISS engine (Dev_Testing_FAISS_\Dev_Testing_FAISS_\schema\default).
+          Legacy `.pkl` index files are auto-migrated on first FAISSSearcher init.
     - Make sure you have a valid `.env.example` file with the below required keys:
         - SERVER_CLIENT_BASE
         - SERVER_ACCESS_KEY
@@ -52,8 +53,8 @@ def test_nearestNeighbor_with_local_model(embed_tokenizer):
     Test the nearestNeighbor function using local model engine using related functions and assertions.
         - Checking the `create_searcher` function by creating `default` searcher.
         - Checking the `searcher_exists` function by checking the existing `default` searcher.
-        - Checking the `load_dataset` by loading the `dataset.pkl` file.
-        - Checking the `load_encoded_vectors` by loading the `vectors.pkl` file.
+        - Checking the `load_dataset` by loading the `dataset.parquet` file.
+        - Checking the `load_encoded_vectors` by loading the `vectors.npy` file.
         - Checking the `nearestNeighbor` function by finding the nearest neightbor against the question.
         - Test the results of `nearestNeighbor` function
             - Checking the type of results
@@ -83,9 +84,11 @@ def test_nearestNeighbor_with_local_model(embed_tokenizer):
     faiss_db.create_searcher(searcher_name="default", base_path=path_to_index_class)
     is_exist = faiss_db.searcher_exists(searcher_name="default")
     if is_exist:  # if 'default' searcher exists
-        faiss_db.searchers["default"].load_dataset(path_to_index_class + "/dataset.pkl")
+        faiss_db.searchers["default"].load_dataset(
+            path_to_index_class + "/dataset.parquet"
+        )
         faiss_db.searchers["default"].load_encoded_vectors(
-            path_to_index_class + "/vectors.pkl"
+            path_to_index_class + "/vectors.npy"
         )
         search_results = faiss_db.searchers["default"].nearestNeighbor(
             question="how is the president chosen?"
@@ -104,8 +107,8 @@ def test_nearestNeighbor_with_tomcat_via_ai_server(embed_tokenizer):
     """
     Test the nearestNeighbor function using Tomcat model engine using related functions and assertions.
         - Checking the `create_searcher` function by creating `default` searcher.
-        - Checking the `load_dataset` by loading the `dataset.pkl` file.
-        - Checking the `load_encoded_vectors` by loading the `vectors.pkl` file.
+        - Checking the `load_dataset` by loading the `dataset.parquet` file.
+        - Checking the `load_encoded_vectors` by loading the `vectors.npy` file.
         - Checking the `nearestNeighbor` function by finding the nearest neightbor against the question.
         - Test the results of `nearestNeighbor` function
             - Checking the type of results
@@ -132,9 +135,9 @@ def test_nearestNeighbor_with_tomcat_via_ai_server(embed_tokenizer):
     )
 
     faiss_db.create_searcher(searcher_name="default", base_path=path_to_index_class)
-    faiss_db.searchers["default"].load_dataset(path_to_index_class + "/dataset.pkl")
+    faiss_db.searchers["default"].load_dataset(path_to_index_class + "/dataset.parquet")
     faiss_db.searchers["default"].load_encoded_vectors(
-        path_to_index_class + "/vectors.pkl"
+        path_to_index_class + "/vectors.npy"
     )
     search_results = faiss_db.searchers["default"].nearestNeighbor(
         question="how is the president chosen?"

--- a/py/vector_database/faiss/_legacy_pickle_migration.py
+++ b/py/vector_database/faiss/_legacy_pickle_migration.py
@@ -1,0 +1,123 @@
+"""
+One-time migration of legacy pickle (.pkl) index files to safe formats.
+
+Background:
+    Older FAISS indexes wrote `dataset.pkl` (HuggingFace Dataset / pandas DataFrame)
+    and `vectors.pkl` (numpy ndarray) using `pickle.dump`. `pickle.load` is unsafe
+    because it can execute arbitrary code, so the loader path was migrated to use
+    Parquet (datasets) and `.npy` (vectors), which are pure-data formats.
+
+    This module is the *only* remaining place in the codebase that calls
+    `pickle.load`. It runs once per `base_path`, converts each `.pkl` in place,
+    and deletes the original after a successful conversion. After the migration
+    completes there is no further pickle exposure at runtime.
+"""
+
+import glob
+import logging
+import os
+import pickle  # noqa: S403 - isolated to legacy migration; see module docstring
+from typing import Tuple
+
+import numpy as np
+import pandas as pd
+from datasets import Dataset
+
+_logger = logging.getLogger(__name__)
+
+_VECTOR_PKL_SUFFIXES = ("vectors.pkl",)
+_DATASET_PKL_SUFFIXES = ("dataset.pkl",)
+
+
+def migrate_pickle_to_safe(base_path: str) -> Tuple[int, int]:
+    """
+    Convert any legacy `.pkl` files under ``base_path`` to safe formats.
+
+    The directory layout produced by FAISSSearcher is::
+
+        base_path/
+            dataset.pkl              -> dataset.parquet
+            vectors.pkl              -> vectors.npy
+            indexed_files/
+                <name>_dataset.pkl   -> <name>_dataset.parquet
+                <name>_vectors.pkl   -> <name>_vectors.npy
+
+    Returns:
+        Tuple ``(converted, failed)`` counting files processed.
+    """
+    if not base_path or not os.path.isdir(base_path):
+        return (0, 0)
+
+    candidates = []
+    for name in ("dataset.pkl", "vectors.pkl"):
+        path = os.path.join(base_path, name)
+        if os.path.exists(path):
+            candidates.append(path)
+
+    indexed_files_dir = os.path.join(base_path, "indexed_files")
+    if os.path.isdir(indexed_files_dir):
+        candidates.extend(glob.glob(os.path.join(indexed_files_dir, "*_dataset.pkl")))
+        candidates.extend(glob.glob(os.path.join(indexed_files_dir, "*_vectors.pkl")))
+
+    if not candidates:
+        return (0, 0)
+
+    _logger.warning(
+        "Legacy pickle index files detected under %s — migrating %d file(s) to safe formats (.parquet/.npy). "
+        "This runs once; pickle files will be deleted after successful conversion.",
+        base_path,
+        len(candidates),
+    )
+
+    converted = 0
+    failed = 0
+    for pkl_path in candidates:
+        try:
+            if pkl_path.endswith(_VECTOR_PKL_SUFFIXES):
+                _convert_vector_pkl(pkl_path)
+            elif pkl_path.endswith(_DATASET_PKL_SUFFIXES):
+                _convert_dataset_pkl(pkl_path)
+            else:
+                continue
+            os.remove(pkl_path)
+            converted += 1
+        except Exception:
+            failed += 1
+            _logger.exception("Failed to migrate legacy pickle file: %s", pkl_path)
+
+    _logger.warning(
+        "Pickle migration complete for %s: converted=%d, failed=%d",
+        base_path,
+        converted,
+        failed,
+    )
+    return (converted, failed)
+
+
+def _convert_vector_pkl(pkl_path: str) -> None:
+    npy_path = pkl_path[: -len(".pkl")] + ".npy"
+    if os.path.exists(npy_path):
+        return
+    with open(pkl_path, "rb") as f:
+        vectors = pickle.load(f)  # noqa: S301 - legacy migration only
+    if not isinstance(vectors, np.ndarray):
+        raise TypeError(
+            f"Expected numpy.ndarray in {pkl_path}, got {type(vectors).__name__}"
+        )
+    np.save(npy_path, vectors, allow_pickle=False)
+
+
+def _convert_dataset_pkl(pkl_path: str) -> None:
+    parquet_path = pkl_path[: -len(".pkl")] + ".parquet"
+    if os.path.exists(parquet_path):
+        return
+    with open(pkl_path, "rb") as f:
+        obj = pickle.load(f)  # noqa: S301 - legacy migration only
+    if isinstance(obj, Dataset):
+        obj.to_parquet(parquet_path)
+    elif isinstance(obj, pd.DataFrame):
+        obj.to_parquet(parquet_path, index=False)
+    else:
+        raise TypeError(
+            f"Expected Dataset or pandas.DataFrame in {pkl_path}, got {type(obj).__name__}"
+        )

--- a/py/vector_database/faiss/faiss_client.py
+++ b/py/vector_database/faiss/faiss_client.py
@@ -1,11 +1,12 @@
-from typing import List, Dict, Union, Optional, Any, Tuple
-from datasets import Dataset, concatenate_datasets, disable_caching, Value
+from typing import List, Dict, Union, Optional, Tuple
+import atexit
 import logging
+import threading
+from concurrent.futures import Future, ThreadPoolExecutor
 
 import pandas as pd
 import faiss
 import numpy as np
-import pickle
 import os
 import glob
 import re
@@ -14,6 +15,35 @@ import re
 from gaas_gpt_model import ModelEngine
 from ..constants import ENCODING_OPTIONS
 from ..utils.bm25_client import BM25Searcher
+from ._legacy_pickle_migration import migrate_pickle_to_safe
+
+# ---------------------------------------------------------------------------
+# Shared warmup pool
+# ---------------------------------------------------------------------------
+# Lazily-created process-wide thread pool used to load cold-start state
+# (today: BM25 index + JSON corpus) in the background while __init__ returns.
+# The on-disk loads are I/O bound, so two workers is enough to overlap the
+# common case of one or two engines opening at once without saturating disk.
+# Callers retrieve the value through a Future (`bm25_searcher` property), so
+# the second-through-Nth caller naturally awaits the in-flight load rather
+# than starting a duplicate.
+_WARMUP_EXECUTOR: Optional[ThreadPoolExecutor] = None
+_WARMUP_EXECUTOR_LOCK = threading.Lock()
+
+
+def _warmup_executor() -> ThreadPoolExecutor:
+    global _WARMUP_EXECUTOR
+    if _WARMUP_EXECUTOR is None:
+        with _WARMUP_EXECUTOR_LOCK:
+            if _WARMUP_EXECUTOR is None:
+                _WARMUP_EXECUTOR = ThreadPoolExecutor(
+                    max_workers=2, thread_name_prefix="faiss-warmup"
+                )
+                atexit.register(
+                    _WARMUP_EXECUTOR.shutdown, wait=False, cancel_futures=True
+                )
+    return _WARMUP_EXECUTOR
+
 
 class FAISSSearcher:
     """
@@ -32,7 +62,7 @@ class FAISSSearcher:
         enable_hybrid_search: bool = True,
     ):
         self.class_logger = logging.getLogger(__name__)
-        
+
         self._device_loaded = False
         self._device = None
 
@@ -46,11 +76,12 @@ class FAISSSearcher:
         self.default_sort_direction = default_sort_direction
         self.base_path = base_path
 
-        disable_caching()
+        # One-shot conversion of any legacy .pkl files to safe formats (.parquet/.npy).
+        migrate_pickle_to_safe(base_path)
 
         # Load existing files
-        master_dataset_path = os.path.join(base_path, "dataset.pkl")
-        master_vector_path = os.path.join(base_path, "vectors.pkl")
+        master_dataset_path = os.path.join(base_path, "dataset.parquet")
+        master_vector_path = os.path.join(base_path, "vectors.npy")
 
         if not os.path.exists(master_dataset_path) or not os.path.exists(
             master_vector_path
@@ -60,12 +91,19 @@ class FAISSSearcher:
             self.load_dataset(master_dataset_path)
             self.load_encoded_vectors(master_vector_path)
 
-        # BM25 components
-        self.bm25_searcher = None
+        # BM25 components are kicked off in a background warmup thread when hybrid
+        # search is enabled: the JSON corpus + bm25s file load is I/O-heavy and
+        # would otherwise dominate cold-start. Callers retrieve the searcher via
+        # the `bm25_searcher` property, which awaits the same Future — so a
+        # request that lands before the warmup finishes just blocks on it
+        # instead of starting a duplicate load. If hybrid is disabled or the
+        # background load fails we fall back to building inline on first access.
         self.enable_hybrid_search = enable_hybrid_search
+        self._bm25_searcher = None
+        self._bm25_lock = threading.Lock()
+        self._bm25_future: Optional[Future] = None
         if self.enable_hybrid_search:
-            self.bm25_searcher = BM25Searcher(base_path=base_path)
-            self.bm25_searcher.generate_and_load_bm25_index(self.ds)
+            self._bm25_future = _warmup_executor().submit(self._build_bm25_searcher)
 
         self.rerank = False
         self.reranker_model = None
@@ -79,8 +117,8 @@ class FAISSSearcher:
 
     @ds.setter
     def ds(self, value):
-        if value is not None and not isinstance(value, (pd.DataFrame, Dataset)):
-            raise TypeError("ds must be a pd.DataFrame or Dataset")
+        if value is not None and not isinstance(value, pd.DataFrame):
+            raise TypeError("ds must be a pandas.DataFrame")
         self._ds = value
 
     @property
@@ -113,7 +151,50 @@ class FAISSSearcher:
             raise TypeError("base_path must be a string")
         self._base_path = value
 
-	# ensure that device is lazy loaded to avoid heavy torch import as long as possible
+    @property
+    def bm25_searcher(self):
+        """Return the BM25 searcher, awaiting the background warmup if needed.
+
+        Returns None when hybrid search is disabled. Otherwise:
+          - If `__init__` submitted a warmup Future and it's still running,
+            this blocks until the Future completes; concurrent callers all
+            await the same Future (no duplicate loads).
+          - If the warmup Future failed, falls back to an inline build under a
+            lock so subsequent reads don't keep re-raising the original error.
+          - If `__init__` never submitted a warmup (e.g. the field was reset),
+            builds inline under the lock.
+        After the first successful load the cached searcher is returned with
+        no synchronization overhead.
+        """
+        if not self.enable_hybrid_search:
+            return None
+        if self._bm25_searcher is not None:
+            return self._bm25_searcher
+        with self._bm25_lock:
+            if self._bm25_searcher is not None:
+                return self._bm25_searcher
+            future = self._bm25_future
+            if future is not None:
+                try:
+                    self._bm25_searcher = future.result()
+                except Exception:
+                    self.class_logger.exception(
+                        "Background BM25 warmup failed; building inline"
+                    )
+                finally:
+                    self._bm25_future = None
+            if self._bm25_searcher is None:
+                self._bm25_searcher = self._build_bm25_searcher()
+            return self._bm25_searcher
+
+    def _build_bm25_searcher(self) -> BM25Searcher:
+        """Construct and load the BM25 searcher. Called either by the background
+        warmup or inline from the `bm25_searcher` property as a fallback."""
+        searcher = BM25Searcher(base_path=self.base_path)
+        searcher.generate_and_load_bm25_index(self.ds)
+        return searcher
+
+    # ensure that device is lazy loaded to avoid heavy torch import as long as possible
     def __getattr__(self, name):
         """
         Called only if 'name' is not found in the normal attribute dictionary.
@@ -124,7 +205,9 @@ class FAISSSearcher:
                 self._init_device()
             return self._device
         # If it's not the special attribute, raise AttributeError
-        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+        raise AttributeError(
+            f"'{type(self).__name__}' object has no attribute '{name}'"
+        )
 
     def _init_device(self):
         """
@@ -132,37 +215,12 @@ class FAISSSearcher:
         """
         self.class_logger.info(f"Loading torch in faiss client")
         import torch
+
         self._device = (
             torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
         )
         self._device_loaded = True
         self.class_logger.info(f"Done loading torch in faiss client")
-
-    def _concatenate_columns(
-        self,
-        row: Dict[str, Any],
-        target_column: str,
-        columns_to_index: List[str] = None,
-        separator: str = "\n",
-    ) -> Dict[str, str]:
-        """
-        Given a set of Index Classes, find the closest match(es) using FAISSearcher.nearestNeighbor across all index classes.
-
-        Args:
-            row (`Dict[str, Any]`): A row dictionary in a dataset
-            results (`Optional[Union[int, None]]`): The column name or key for the concatenated column values
-            columns_to_index (`List[str]`): A list containing the column names to be concatenated
-            separator (`str`): The value to separate the concatenated values by
-
-        Return:
-            `Dict[str, str]` A dictionary containing the new column name as the key and the concatenated columns as a the value.
-        """
-        text = ""
-        for col in columns_to_index:
-            text += str(row[col])
-            text += separator
-
-        return {target_column: text}
 
     def nearestNeighbor(
         self,
@@ -224,9 +282,9 @@ class FAISSSearcher:
     ):
         """Perform hybrid BM25 + vector search"""
         if columns_to_return is None:
-            columns_to_return = list(self.ds.features)
+            columns_to_return = list(self.ds.columns)
 
-        fusion_limit = max(total_limit * 2, limit * 2,  20)
+        fusion_limit = max(total_limit * 2, limit * 2, 20)
 
         # 1. Do vector search
         vector_results = self._vector_only_search(
@@ -253,8 +311,7 @@ class FAISSSearcher:
             filter_ids = self._filter_dataset(filter)
             filter_ids_set = set(filter_ids)
             bm25_results = [
-                result for result in bm25_results
-                if result["idx"] in filter_ids_set
+                result for result in bm25_results if result["idx"] in filter_ids_set
             ]
 
         # 3. Combine using reciprocal rank fusion
@@ -292,7 +349,7 @@ class FAISSSearcher:
     ) -> List[Dict]:
         """Original vector-only search logic"""
         if columns_to_return is None:
-            columns_to_return = list(self.ds.features)
+            columns_to_return = list(self.ds.columns)
 
         search_vector = self.embeddings_engine.embeddings(
             strings_to_embed=[question], insight_id=insight_id
@@ -353,7 +410,7 @@ class FAISSSearcher:
         final_output = []
         for _, row in samples_df.iterrows():
             output = {"Score": row["distances"], "idx": int(row["ann"])}
-            data_row = self.ds[int(row["ann"])]
+            data_row = self.ds.iloc[int(row["ann"])]
             output.update({col: data_row[col] for col in columns_to_return})
             final_output.append(output)
 
@@ -548,7 +605,7 @@ class FAISSSearcher:
         Get the unique list of documents
         """
         if self.ds is not None:
-            return self.ds.unique("Source")
+            return self.ds["Source"].unique().tolist()
 
         return []
 
@@ -557,14 +614,14 @@ class FAISSSearcher:
         Get the list of all the records
         """
         if self.ds is not None:
-            return self.ds.sort(column_names=["Source", "Divider", "Part"]).to_list()
+            return self.ds.sort_values(by=["Source", "Divider", "Part"]).to_dict(
+                "records"
+            )
 
         return []
 
     def _filter_dataset(self, filter: str) -> List[int]:
-        filterDf = self.ds.to_pandas()
-
-        return filterDf.query(filter).index.to_list()
+        return self.ds.query(filter).index.to_list()
 
     def load_dataset(self, dataset_location: str) -> None:
         """
@@ -572,116 +629,88 @@ class FAISSSearcher:
 
         Args:
         dataset_location(`str`):
-            The file path to the stored dataset. Currently only csv and pkl file types are supported
+            The file path to the stored dataset. Supported file types are csv and parquet.
+            Legacy `.pkl` paths are transparently rewritten to `.parquet` for callers that
+            still reference the old extension.
 
         Returns:
         `None`
         """
+        if dataset_location.endswith(".pkl"):
+            self.class_logger.warning(
+                "load_dataset called with legacy .pkl path; reading the migrated .parquet file instead: %s",
+                dataset_location,
+            )
+            dataset_location = dataset_location[: -len(".pkl")] + ".parquet"
         self.ds = self._load_dataset(dataset_location=dataset_location)
 
-    def _load_dataset(self, dataset_location: str) -> Union[Dataset, pd.DataFrame]:
+    def _load_dataset(self, dataset_location: str) -> pd.DataFrame:
         """
         Internal method to load the dataset based on its file type.
 
         Args:
         dataset_location(`str`):
-            The file path to the stored dataset. Currently only csv and pkl file types are supported
+            The file path to the stored dataset. Supported file types are csv and parquet.
 
         Returns:
-        `None`
+        `pd.DataFrame`
         """
+        loaded_dataset = None
         if dataset_location.endswith(".csv"):
-            try:
-                loaded_dataset = Dataset.from_csv(
-                    path_or_paths=dataset_location,
-                    encoding="utf-8",
-                    keep_in_memory=True,
+            for encoding in tuple(ENCODING_OPTIONS):
+                try:
+                    loaded_dataset = pd.read_csv(dataset_location, encoding=encoding)
+                    break
+                except Exception:
+                    continue
+            if loaded_dataset is None:
+                raise Exception(
+                    "Unable to read the file with any of the specified encodings"
                 )
-            except:
-                for encoding in ENCODING_OPTIONS:
-                    try:
-                        temp_df = pd.read_csv(dataset_location, encoding=encoding)
-                        loaded_dataset = Dataset.from_pandas(temp_df)
-                        break
-                    except:
-                        continue
-                else:
-                    # The else clause is executed if the loop completes without encountering a break
-                    raise Exception(
-                        "Unable to read the file with any of the specified encodings"
-                    )
-
-        elif dataset_location.endswith(".pkl"):
-            with open(dataset_location, "rb") as file:
-                loaded_dataset = pickle.load(file)
+        elif dataset_location.endswith(".parquet"):
+            loaded_dataset = pd.read_parquet(dataset_location)
         else:
             raise ValueError(
                 "Dataset creation for provided file type has not been defined"
             )
 
-        assert isinstance(loaded_dataset, Dataset)
-
-        dataset_columns = list(loaded_dataset.features)
-
-        extracted_with_cfg = all(
-            col in dataset_columns
-            for col in ["Source", "Divider", "Part", "Tokens", "Content"]
-        )
-        if isinstance(loaded_dataset, Dataset) and extracted_with_cfg:
-
-            if "Modality" not in dataset_columns:
-                loaded_dataset = loaded_dataset.add_column(
-                    "Modality", ["text" for i in range(loaded_dataset.num_rows)]
-                )
-
-            # to be safe, force all columns
-            new_features = loaded_dataset.features.copy()
-            new_features["Source"] = Value(dtype="string", id=None)
-            new_features["Divider"] = Value(dtype="string", id=None)
-            new_features["Part"] = Value(dtype="string", id=None)
-            new_features["Tokens"] = Value(dtype="int64", id=None)
-            new_features["Content"] = Value(dtype="string", id=None)
-
-            try:
-                loaded_dataset = loaded_dataset.cast(new_features, keep_in_memory=True)
-            except AttributeError:
-                # This catch is required due to a version change in the datasets package
-                # Previously, there was no attribute called _batches which is required with the new `cast` method. This is missing from the pickle file
-                # The solution is to reconstruct the dataset from a pandas frame
-                try:
-                    loaded_dataset = Dataset.from_pandas(loaded_dataset.to_pandas())
-                except AttributeError:
-                    loaded_dataset = Dataset.from_pandas(
-                        loaded_dataset.data.to_pandas()
-                    )
-                loaded_dataset = loaded_dataset.cast(new_features, keep_in_memory=True)
-
-        elif isinstance(loaded_dataset, pd.DataFrame) and extracted_with_cfg:
-            if "Modality" not in dataset_columns:
-                loaded_dataset["Modality"] = "text"
-
-            # to be safe, force all columns
-            loaded_dataset["Source"] = loaded_dataset["Source"].astype(str)
-            loaded_dataset["Divider"] = loaded_dataset["Divider"].astype(str)
-            loaded_dataset["Part"] = loaded_dataset["Part"].astype(str)
-            loaded_dataset["Tokens"] = loaded_dataset["Tokens"].astype(int)
-            loaded_dataset["Content"] = loaded_dataset["Content"].astype(str)
-
         return loaded_dataset
 
     def save_dataset(self, dataset_location: str) -> None:
         """
-        Utility method to save datasets from object onto the disk.
+        Utility method to save datasets from object onto the disk as Parquet.
 
         Args:
         dataset_location(`str`):
-            The file path to the write the dataset.
+            The file path to the write the dataset. Must end in `.parquet`.
 
         Returns:
         `None`
         """
-        with open(dataset_location, "wb") as file:
-            pickle.dump(self.ds, file)
+        if not isinstance(self.ds, pd.DataFrame):
+            raise TypeError(
+                f"save_dataset requires pandas.DataFrame, got {type(self.ds).__name__}"
+            )
+        # Normalize columns to canonical dtypes before writing. Per-source
+        # parquet files can disagree on Divider/Part dtype (legacy HF-Dataset
+        # writes used string; pandas inference from CSV can yield int), and the
+        # concatenation produces an object column with mixed Python types that
+        # pyarrow refuses to serialize.
+        self._enforce_canonical_schema(self.ds)
+        self.ds.to_parquet(dataset_location, index=False)
+
+    @staticmethod
+    def _enforce_canonical_schema(df: pd.DataFrame) -> None:
+        """Cast the standard CFG columns to their canonical dtypes in place.
+
+        Cheap when columns already have the expected dtype, so it can be called
+        at every write site without paying a noticeable cost in the common case.
+        """
+        for col in ("Source", "Divider", "Part", "Content"):
+            if col in df.columns:
+                df[col] = df[col].astype(str)
+        if "Tokens" in df.columns:
+            df["Tokens"] = df["Tokens"].astype("int64")
 
     def load_encoded_vectors(self, encoded_vectors_location: str) -> None:
         """
@@ -689,11 +718,19 @@ class FAISSSearcher:
 
         Args:
         encoded_vectors_location(`str`):
-            The file path to the stored embeddings file. Currently only npy and pkl file types are supported
+            The file path to the stored embeddings file. Supported file type is `.npy`.
+            Legacy `.pkl` paths are transparently rewritten to `.npy` for callers that
+            still reference the old extension.
 
         Returns:
         `None`
         """
+        if encoded_vectors_location.endswith(".pkl"):
+            self.class_logger.warning(
+                "load_encoded_vectors called with legacy .pkl path; reading the migrated .npy file instead: %s",
+                encoded_vectors_location,
+            )
+            encoded_vectors_location = encoded_vectors_location[: -len(".pkl")] + ".npy"
         self.encoded_vectors = self._load_encoded_vectors(
             encoded_vectors_location=encoded_vectors_location
         )
@@ -714,16 +751,19 @@ class FAISSSearcher:
 
         Args:
         encoded_vectors_location(`str`):
-            The file path to the stored embeddings file. Currently only npy and pkl file types are supported
+            The file path to the stored embeddings file. Only `.npy` files are supported.
 
         Returns:
         `None`
         """
-        if encoded_vectors_location.endswith(".npy"):
-            encoded_vectors = np.load(encoded_vectors_location)
-        else:
-            with open(encoded_vectors_location, "rb") as file:
-                encoded_vectors = pickle.load(file)
+        if not encoded_vectors_location.endswith(".npy"):
+            raise ValueError(
+                f"Encoded vectors must be loaded from a .npy file, got: {encoded_vectors_location}"
+            )
+        # allow_pickle=False ensures np.load cannot deserialize arbitrary Python objects.
+        encoded_vectors = np.load(
+            encoded_vectors_location, allow_pickle=False, mmap_mode="r"
+        )
 
         assert isinstance(encoded_vectors, np.ndarray)
 
@@ -731,33 +771,32 @@ class FAISSSearcher:
 
     def save_encoded_vectors(self, encoded_vectors_location: str) -> None:
         """
-        Utility method to save embeddings from object onto the disk.
+        Utility method to save embeddings from object onto the disk as a `.npy` file.
 
         Args:
         encoded_vectors_location(`str`):
-            The file path to the write the dataset.
+            The file path to the write the dataset. Must end in `.npy`.
 
         Returns:
         `None`
         """
-        with open(encoded_vectors_location, "wb") as file:
-            pickle.dump(self.encoded_vectors, file)
+        np.save(encoded_vectors_location, self.encoded_vectors, allow_pickle=False)
 
     def _concatenate_datasets(
         self,
-        datasets: Union[List[Dataset], List[pd.DataFrame]],
-    ) -> Union[Dataset, pd.DataFrame]:
+        datasets: List[pd.DataFrame],
+    ) -> pd.DataFrame:
         """
-        Interal utility method to concatenate datasets depending on the class type. Either pandas.DataFrame or datasets.Dataset
+        Internal utility method to concatenate a list of pandas DataFrames.
 
         Args:
-        datasets(`Union[List[Dataset], List[pd.DataFrame]]`):
-            A list of datasets where all the datasets of only of one type. Either pandas.DataFrame or datasets.Dataset
+        datasets(`List[pd.DataFrame]`):
+            A list of DataFrames to concatenate.
 
         Returns:
-        `Union[Dataset, pd.DataFrame]`
+        `pd.DataFrame`
         """
-        return concatenate_datasets(datasets)
+        return pd.concat(datasets, ignore_index=True)
 
     def addDocument(
         self,
@@ -786,20 +825,18 @@ class FAISSSearcher:
         if self.enable_hybrid_search and self.ds is not None:
             try:
                 # Extract all text content for BM25 indexing
-                if "Content" in self.ds.features:
-                    all_texts = self.ds["Content"]
+                if "Content" in self.ds.columns:
+                    all_texts = list(self.ds["Content"])
                 else:
                     # Fallback: concatenate all text fields
                     all_texts = []
                     for i in range(len(self.ds)):
-                        row = self.ds[i]
-                        text_parts = []
-                        for key, value in row.items():
-                            if isinstance(value, str):
-                                text_parts.append(value)
+                        row = self.ds.iloc[i]
+                        text_parts = [
+                            value for value in row.values if isinstance(value, str)
+                        ]
                         all_texts.append(" ".join(text_parts))
 
-                # TODO - would be good to grab ds of new records only to build
                 if self.bm25_searcher is not None:
                     self.bm25_searcher.build_bm25_index(all_texts)
 
@@ -856,39 +893,40 @@ class FAISSSearcher:
 
         # loop through and embed new docs
         for document in documentFileLocation:
-            # Create the Dataset for every file
+            # Create the DataFrame for every file
             dataset = self._load_dataset(dataset_location=document)
 
             # Change the unit of work
             # From being the document
             # To the individual source inside the document
-            sources = dataset.unique("Source")
+            sources = dataset["Source"].unique().tolist()
             for source_name in sources:
-                source_dataset = dataset.filter(
-                    lambda dataset: dataset["Source"] == source_name
+                source_dataset = dataset[dataset["Source"] == source_name].reset_index(
+                    drop=True
                 )
 
                 # Get the directory path and the base filename without extension
                 directory, base_filename = os.path.split(document)
-                new_file_extension = ".pkl"
+                dataset_extension = ".parquet"
+                vector_extension = ".npy"
 
                 if columns_to_index == None or len(columns_to_index) == 0:
-                    columns_to_index = list(source_dataset.features)
+                    columns_to_index = list(source_dataset.columns)
 
                 # save the dataset, this is for efficiency after removing docs
                 new_file_path = os.path.join(
-                    directory, source_name + "_dataset" + new_file_extension
+                    directory, source_name + "_dataset" + dataset_extension
                 )
 
                 # if applicable, create the concatenated columns
-                if source_dataset.num_rows > 0:
-                    source_dataset = source_dataset.map(
-                        self._concatenate_columns,
-                        fn_kwargs={
-                            "columns_to_index": columns_to_index,
-                            "target_column": target_column,
-                            "separator": separator,
-                        },
+                if len(source_dataset) > 0:
+                    # vectorized equivalent of mapping `_concatenate_columns`: build a
+                    # target_column whose value for each row is
+                    # `<v0><sep><v1><sep>...<vn-1><sep>` (note trailing separator,
+                    # preserved for parity with the previous Dataset.map behavior).
+                    parts = source_dataset[columns_to_index].astype(str)
+                    source_dataset[target_column] = parts.apply(
+                        lambda row: separator.join(row) + separator, axis=1
                     )
 
                     # transform chunks into keywords
@@ -898,23 +936,16 @@ class FAISSSearcher:
                     ):
                         keywords_for_target_col = (
                             self.keyword_engine.keyword_extraction(
-                                input=source_dataset[target_column],
+                                input=list(source_dataset[target_column]),
                                 insight_id=insight_id,
                                 param_dict=keyword_search_params,
                             )
                         )
-                        # source_dataset = source_dataset.add_column(target_column, keywords_for_target_col)
-                        source_dataset = source_dataset.remove_columns(
-                            column_names=target_column
-                        )
-                        source_dataset = source_dataset.add_column(
-                            target_column, keywords_for_target_col
-                        )
+                        source_dataset[target_column] = keywords_for_target_col
 
                     # get the embeddings for the document
-                    # vectors = self.embeddings_engine.get_embeddings(dataset[target_column])
                     vectors = self.embeddings_engine.embeddings(
-                        strings_to_embed=source_dataset[target_column],
+                        strings_to_embed=list(source_dataset[target_column]),
                         insight_id=insight_id,
                     )
                     vectors = np.array(vectors[0]["response"], dtype=np.float32)
@@ -922,16 +953,15 @@ class FAISSSearcher:
 
                     columns_to_remove.append(target_column)
                     columns_to_drop = list(
-                        set(columns_to_remove).intersection(
-                            set(source_dataset.features)
-                        )
+                        set(columns_to_remove).intersection(set(source_dataset.columns))
                     )
-                    source_dataset = source_dataset.remove_columns(
-                        column_names=columns_to_drop
-                    )
+                    source_dataset = source_dataset.drop(columns=columns_to_drop)
 
-                    with open(new_file_path, "wb") as file:
-                        pickle.dump(source_dataset, file)
+                    # Keep per-source files dtype-consistent so subsequent
+                    # `_validateEmbeddingFiles` concatenations don't produce
+                    # mixed-type columns that fail pyarrow serialization.
+                    self._enforce_canonical_schema(source_dataset)
+                    source_dataset.to_parquet(new_file_path, index=False)
 
                     # add the created source_dataset file path
                     createDocumentsResponse["createdDocuments"].append(new_file_path)
@@ -940,14 +970,12 @@ class FAISSSearcher:
                     if type(self.tokenizer).__name__ == "HuggingfaceTokenizer":
                         faiss.normalize_L2(vectors)
 
-                    # write out the vectors with the same file name
-                    # Change the file extension to ".pkl"
+                    # write out the vectors as a .npy file (no pickle)
                     new_file_path = os.path.join(
                         directory,
-                        source_name + "_vectors" + new_file_extension,
+                        source_name + "_vectors" + vector_extension,
                     )
-                    with open(new_file_path, "wb") as file:
-                        pickle.dump(vectors, file)
+                    np.save(new_file_path, vectors, allow_pickle=False)
 
                     # add the created embeddings file path
                     createDocumentsResponse["createdDocuments"].append(new_file_path)
@@ -1014,8 +1042,12 @@ class FAISSSearcher:
         """
         indexed_files_path = os.path.join(path_to_files, "indexed_files")
 
-        # List all pdfs files in the directory
-        all_vector_files = glob.glob(os.path.join(indexed_files_path, "*_vectors.pkl"))
+        # If any legacy .pkl files remain in this subtree, convert them now so the
+        # globs below find their migrated counterparts.
+        migrate_pickle_to_safe(path_to_files)
+
+        # List all vector files in the directory
+        all_vector_files = glob.glob(os.path.join(indexed_files_path, "*_vectors.npy"))
 
         valid_datasets_and_vectors = []
         corrupted_file_sets: List[Tuple] = []
@@ -1025,8 +1057,8 @@ class FAISSSearcher:
             # get the basename of the file
             # all csvs, datasets and vectors should contain this base name
             vector_filename = os.path.basename(full_vector_path)
-            base_filename = vector_filename.split("_vectors.pkl")[0]
-            dataset_filename = base_filename + "_dataset.pkl"
+            base_filename = vector_filename.split("_vectors.npy")[0]
+            dataset_filename = base_filename + "_dataset.parquet"
 
             full_dataset_path = os.path.join(indexed_files_path, dataset_filename)
             full_vector_path = os.path.join(indexed_files_path, vector_filename)
@@ -1066,31 +1098,30 @@ class FAISSSearcher:
 
         # bind the valid datasets and vectors
         if len(valid_datasets_and_vectors) > 0:
-            self.ds = valid_datasets_and_vectors[0][0]
-            self.encoded_vectors = valid_datasets_and_vectors[0][1]
+            dfs = [d for d, _ in valid_datasets_and_vectors]
+            vecs = [v for _, v in valid_datasets_and_vectors]
+
+            self.ds = pd.concat(dfs, ignore_index=True) if len(dfs) > 1 else dfs[0]
+            self.encoded_vectors = (
+                np.concatenate(vecs, axis=0) if len(vecs) > 1 else vecs[0]
+            )
             self.vector_dimensions = self.encoded_vectors.shape
 
-            # loop through and concatenate the others if any
-            for dataset, vectors in valid_datasets_and_vectors[1:]:
-                self.ds = self._concatenate_datasets([self.ds, dataset])
-                self.encoded_vectors = np.concatenate(
-                    (self.encoded_vectors, vectors), axis=0
-                )
-
-            encoded_vectors_location = os.path.join(path_to_files, "vectors.pkl")
-            dataset_location = os.path.join(path_to_files, "dataset.pkl")
+            encoded_vectors_location = os.path.join(path_to_files, "vectors.npy")
+            dataset_location = os.path.join(path_to_files, "dataset.parquet")
             self.save_encoded_vectors(encoded_vectors_location=encoded_vectors_location)
             self.save_dataset(dataset_location=dataset_location)
             created_documents.append(encoded_vectors_location)
             created_documents.append(dataset_location)
 
-            if (self.metric_type_is_cosine_similarity) and (
-                self.vector_dimensions != None
+            if (
+                self.metric_type_is_cosine_similarity
+                and self.vector_dimensions is not None
             ):
                 self.index = faiss.index_factory(
                     self.vector_dimensions[1], "Flat", faiss.METRIC_INNER_PRODUCT
                 )
-            elif self.vector_dimensions != None:
+            elif self.vector_dimensions is not None:
                 self.index = faiss.IndexFlatL2(self.vector_dimensions[1])
 
             if self.encoded_vectors is not None:
@@ -1128,12 +1159,7 @@ class FAISSSearcher:
 
         Returns `bool`
         """
-        if (
-            (self.ds == None)
-            or (list(self.ds.features) == [])
-            or (len(list(self.ds.features)) == 0)
-            or (self.ds.num_rows == 0)
-        ):
+        if self.ds is None or len(self.ds.columns) == 0 or len(self.ds) == 0:
             return False
         else:
             return True
@@ -1157,15 +1183,15 @@ class FAISSSearcher:
         for _, row in samples_df.iterrows():
             output = {}
             output.update({"Score": row["distances"]})
-            data_row = self.ds[int(row["ann"])]
+            data_row = self.ds.iloc[int(row["ann"])]
             output.update({col: data_row[col] for col in columns_to_return})
 
             # this is not pythonic but let us try this for now
             try:
-                if "Content" in data_row.keys():
+                if "Content" in data_row.index:
                     content = data_row["Content"]
                 else:
-                    content = " ".join([str(val) for val in data_row.values()])
+                    content = " ".join([str(val) for val in data_row.values])
 
                 score = self.cross_encode([[question, content]])
                 output.update({"Rerank_Score": score})

--- a/py/vector_database/faiss/faiss_database.py
+++ b/py/vector_database/faiss/faiss_database.py
@@ -134,8 +134,10 @@ class FAISSDatabase:
             if indexClass in self.searchers:
                 searcher = self.searchers[indexClass]
                 try:
-                    if searcher.ds is not None and "Content" in searcher.ds.features:
-                        searcher.bm25_searcher.build_bm25_index(searcher.ds["Content"])
+                    if searcher.ds is not None and "Content" in searcher.ds.columns:
+                        searcher.bm25_searcher.build_bm25_index(
+                            list(searcher.ds["Content"])
+                        )
                         results[indexClass] = True
                     else:
                         results[indexClass] = False

--- a/py/vector_database/tests/test_faiss_vector_db.py
+++ b/py/vector_database/tests/test_faiss_vector_db.py
@@ -71,9 +71,11 @@ class FaissVectorDatabaseTests(unittest.TestCase):
         )
 
         aGnETVb.create_searcher(searcher_name="default", base_path=path_to_index_class)
-        aGnETVb.searchers["default"].load_dataset(path_to_index_class + "/dataset.pkl")
+        aGnETVb.searchers["default"].load_dataset(
+            path_to_index_class + "/dataset.parquet"
+        )
         aGnETVb.searchers["default"].load_encoded_vectors(
-            path_to_index_class + "/vectors.pkl"
+            path_to_index_class + "/vectors.npy"
         )
         search_results = aGnETVb.searchers["default"].nearestNeighbor(
             question="how is the president chosen?"
@@ -115,9 +117,11 @@ class FaissVectorDatabaseTests(unittest.TestCase):
         )
 
         aGnETVb.create_searcher(searcher_name="default", base_path=path_to_index_class)
-        aGnETVb.searchers["default"].load_dataset(path_to_index_class + "/dataset.pkl")
+        aGnETVb.searchers["default"].load_dataset(
+            path_to_index_class + "/dataset.parquet"
+        )
         aGnETVb.searchers["default"].load_encoded_vectors(
-            path_to_index_class + "/vectors.pkl"
+            path_to_index_class + "/vectors.npy"
         )
         search_results = aGnETVb.searchers["default"].nearestNeighbor(
             question="how is the president chosen?"

--- a/py/vector_database/utils/bm25_client.py
+++ b/py/vector_database/utils/bm25_client.py
@@ -1,6 +1,6 @@
 import bm25s
 import os
-from datasets import Dataset
+import pandas as pd
 import logging
 from typing import List, Tuple, Optional, Dict
 import json
@@ -63,14 +63,14 @@ class BM25Searcher:
         except Exception as e:
             self.class_logger.error(f"Failed to save BM25 index: {e}")
 
-    def generate_and_load_bm25_index(self, ds: Dataset):
+    def generate_and_load_bm25_index(self, ds: Optional[pd.DataFrame]):
         """Load existing BM25 index and corpus if they exist"""
         try:
             if (
                 not os.path.exists(self.bm25_index_path)
                 or not os.path.exists(self.bm25_corpus_path)
             ) and ds is not None:
-                self.build_bm25_index(ds["Content"])
+                self.build_bm25_index(list(ds["Content"]))
             elif os.path.exists(self.bm25_index_path) and os.path.exists(
                 self.bm25_corpus_path
             ):
@@ -84,6 +84,9 @@ class BM25Searcher:
     def build_bm25_index(self, texts: List[str]):
         """Build BM25 index from text corpus"""
         try:
+            # Coerce to a plain list so downstream JSON serialization works whether the
+            # caller passed a list, a pandas Series, or any other iterable of strings.
+            texts = list(texts)
             corpus_tokens = bm25s.tokenize(texts, stopwords="en", stemmer=self.stemmer)
 
             self.bm25_index = bm25s.BM25(method="lucene")
@@ -142,7 +145,7 @@ class BM25Searcher:
         self,
         query: str,
         top_k: int = 10,
-        ds: Dataset = None,
+        ds: Optional[pd.DataFrame] = None,
         columns_to_return: Optional[List[str]] = None,
     ) -> List[Dict]:
         """Perform BM25 search and return document indices with scores"""
@@ -150,7 +153,7 @@ class BM25Searcher:
             return []
 
         if columns_to_return is None:
-            columns_to_return = list(ds.features)
+            columns_to_return = list(ds.columns)
 
         try:
             query_tokens = bm25s.tokenize([query], stopwords="en", stemmer=self.stemmer)
@@ -167,7 +170,7 @@ class BM25Searcher:
 
                     if doc_idx != -1:
                         output = {"BM25_Score": similarity_score, "idx": doc_idx}
-                        data_row = ds[doc_idx]
+                        data_row = ds.iloc[doc_idx]
                         output.update({col: data_row[col] for col in columns_to_return})
                         results.append(output)
 

--- a/src/prerna/engine/impl/vector/AbstractVectorDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/AbstractVectorDatabaseEngine.java
@@ -445,9 +445,8 @@ public abstract class AbstractVectorDatabaseEngine extends AbstractEngine implem
 
 			if (ClusterUtil.IS_CLUSTER) {
 				// push the actual documents over to the cloud
-				Thread copyFilesToCloudThread = new Thread(new CopyFilesToEngineRunner(this.engineId,
-						this.getCatalogType(), filesToCopyToCloud.stream().toArray(String[]::new)));
-				copyFilesToCloudThread.start();
+				Thread.ofVirtual().start(new CopyFilesToEngineRunner(this.engineId, this.getCatalogType(),
+						filesToCopyToCloud.stream().toArray(String[]::new)));
 			}
 		} catch (Exception e) {
 			classLogger.error("Failed to add documents to vector database for index class: '{}'", indexClass, e);

--- a/src/prerna/engine/impl/vector/FaissDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/FaissDatabaseEngine.java
@@ -303,9 +303,8 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 			filesToCopyToCloud.addAll(vectorCsvFiles);
 			// and the return files (dataset/vector)
 			filesToCopyToCloud.addAll((List<String>) pythonResponseAfterCreatingFiles.get("createdDocuments"));
-			Thread copyFilesToCloudThread = new Thread(new CopyFilesToEngineRunner(engineId, this.getCatalogType(),
+			Thread.ofVirtual().start(new CopyFilesToEngineRunner(engineId, this.getCatalogType(),
 					filesToCopyToCloud.stream().toArray(String[]::new)));
-			copyFilesToCloudThread.start();
 		}
 
 		// verify the index class loaded the dataset
@@ -430,8 +429,10 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 
 			for (String document : sourceNames) {
 				String documentName = FilenameUtils.getName(document);
-				String[] fileNamesToDelete = { documentName + "_dataset.pkl", documentName + "_vectors.pkl",
-						documentName + ".csv" };
+				// Include both new safe extensions and the legacy .pkl pair so this method
+				// works against partially-migrated engines as well as freshly-written ones.
+				String[] fileNamesToDelete = { documentName + "_dataset.parquet", documentName + "_vectors.npy",
+						documentName + "_dataset.pkl", documentName + "_vectors.pkl", documentName + ".csv" };
 
 				// Create a filter for the file names
 				DirectoryStream.Filter<Path> fileNameFilters = entry -> {
@@ -490,13 +491,16 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 		if (indexedFolder.list(new FilenameFilter() {
 			@Override
 			public boolean accept(File dir, String name) {
-				return name.endsWith(".pkl");
+				return name.endsWith(".parquet") || name.endsWith(".npy") || name.endsWith(".pkl");
 			}
 		}).length == 0) {
 			try {
 				File indexClassDirectory = new File(indexedFolder.getParent());
 
-				// remove the master dataset and vector files
+				// remove the master dataset and vector files (include legacy .pkl entries for
+				// engines whose cloud copies have not yet been migrated)
+				filesToRemoveFromCloud.add(new File(indexClassDirectory, "dataset.parquet").getAbsolutePath());
+				filesToRemoveFromCloud.add(new File(indexClassDirectory, "vectors.npy").getAbsolutePath());
 				filesToRemoveFromCloud.add(new File(indexClassDirectory, "dataset.pkl").getAbsolutePath());
 				filesToRemoveFromCloud.add(new File(indexClassDirectory, "vectors.pkl").getAbsolutePath());
 
@@ -510,7 +514,7 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 					.runScript(this.vectorDatabaseSearcher + ".delete_searcher(searcher_name = '" + indexClass + "')");
 			this.indexClasses.remove(indexClass);
 		} else {
-			// Regenerate the master "dataset.pkl" and "vectors.pkl" files
+			// Regenerate the master dataset/vector files
 			StringBuilder updateMasterFilesCommandBuilder = new StringBuilder();
 			updateMasterFilesCommandBuilder.append(this.vectorDatabaseSearcher).append(".searchers['")
 					.append(indexClass).append("']").append(".createMasterFiles(path_to_files = '")
@@ -533,9 +537,8 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 		}
 
 		if (ClusterUtil.IS_CLUSTER) {
-			Thread deleteFilesFromCloudThread = new Thread(new DeleteFilesFromEngineRunner(engineId,
-					this.getCatalogType(), filesToRemoveFromCloud.stream().toArray(String[]::new)));
-			deleteFilesFromCloudThread.start();
+			Thread.ofVirtual().start(new DeleteFilesFromEngineRunner(engineId, this.getCatalogType(),
+					filesToRemoveFromCloud.stream().toArray(String[]::new)));
 		}
 	}
 
@@ -674,9 +677,8 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 				.runDirectPy(executionScript.toString());
 
 		if (ClusterUtil.IS_CLUSTER) {
-			Thread deleteFilesFromCloudThread = new Thread(new DeleteFilesFromEngineRunner(engineId,
-					this.getCatalogType(), corruptedFilesToReason.keySet().stream().toArray(String[]::new)));
-			deleteFilesFromCloudThread.start();
+			Thread.ofVirtual().start(new DeleteFilesFromEngineRunner(engineId, this.getCatalogType(),
+					corruptedFilesToReason.keySet().stream().toArray(String[]::new)));
 		}
 
 		return corruptedFilesToReason;
@@ -740,11 +742,163 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 		return VectorDatabaseTypeEnum.FAISS;
 	}
 
-	////////////////////////////////////////////////////////////////////////
-	////////////////////////////////////////////////////////////////////////
-	////////////////////////////////////////////////////////////////////////
-	////////////////////////////////////////////////////////////////////////
-	////////////////////////////////////////////////////////////////////////
+	/**
+	 * Starts the FAISS python server, ensuring any legacy {@code .pkl} index files
+	 * on disk are migrated to the safe {@code .parquet}/{@code .npy} formats as
+	 * part of startup. Legacy files are detected before Python boots so the
+	 * resulting mapping can be used afterwards to reconcile the cloud copy of the
+	 * engine in cluster mode.
+	 *
+	 * @param port the port the python server should bind to
+	 */
+	@Override
+	protected synchronized void startServer(int port) {
+		// Detect any legacy .pkl files BEFORE Python starts;
+		// FAISSSearcher.__init__ will
+		// auto-migrate them to .parquet/.npy (and delete the .pkl) as part of the init
+		// script.
+		Map<String, String> pendingPickleMigrations = detectLegacyPickleFiles();
+
+		super.startServer(port);
+
+		// In cluster mode the engine folder was just hydrated from cloud and likely
+		// still contains the legacy .pkl entries we just converted locally. Push the
+		// migrated counterparts up and remove the obsolete .pkl from cloud so peers
+		// don't re-pull them.
+		if (!pendingPickleMigrations.isEmpty()) {
+			syncMigratedFilesToCloud(pendingPickleMigrations);
+		}
+	}
+
+	/**
+	 * Walks the schema folder looking for legacy pickle-format FAISS index files
+	 * ({@code *_dataset.pkl}, {@code *_vectors.pkl}, and the master
+	 * {@code dataset.pkl}/ {@code vectors.pkl} pair) under each index class and its
+	 * {@code indexed_files} subdirectory.
+	 *
+	 * @return a map from the absolute path of each legacy {@code .pkl} file to the
+	 *         absolute path of its predicted migrated counterpart
+	 *         ({@code .parquet}/{@code .npy}); empty when no legacy files are
+	 *         present or the schema folder is unavailable
+	 */
+	private Map<String, String> detectLegacyPickleFiles() {
+		Map<String, String> migrations = new HashMap<>();
+		if (this.schemaFolder == null || !this.schemaFolder.isDirectory()) {
+			return migrations;
+		}
+		File[] indexClassDirs = this.schemaFolder.listFiles(File::isDirectory);
+		if (indexClassDirs == null) {
+			return migrations;
+		}
+		for (File indexClassDir : indexClassDirs) {
+			collectLegacyPickleFiles(indexClassDir, migrations);
+			File indexedFiles = new File(indexClassDir, AbstractVectorDatabaseEngine.INDEXED_FOLDER_NAME);
+			if (indexedFiles.isDirectory()) {
+				collectLegacyPickleFiles(indexedFiles, migrations);
+			}
+		}
+		return migrations;
+	}
+
+	/**
+	 * Scans a single directory (non-recursive) for {@code .pkl} files and adds an
+	 * entry to {@code migrations} for each one whose name matches a known legacy
+	 * pattern recognised by {@link #predictMigratedPath(File)}.
+	 *
+	 * @param dir        the directory to scan; may not exist or may not contain any
+	 *                   pickle files, in which case the method returns without
+	 *                   modifying {@code migrations}
+	 * @param migrations accumulator mapping legacy pickle paths to their predicted
+	 *                   safe-format counterparts
+	 */
+	private static void collectLegacyPickleFiles(File dir, Map<String, String> migrations) {
+		File[] pklFiles = dir.listFiles((d, name) -> name.endsWith(".pkl"));
+		if (pklFiles == null) {
+			return;
+		}
+		for (File pkl : pklFiles) {
+			String safePath = predictMigratedPath(pkl);
+			if (safePath != null) {
+				migrations.put(pkl.getAbsolutePath(), safePath);
+			}
+		}
+	}
+
+	/**
+	 * Predicts the on-disk path that a legacy FAISS pickle file will have after the
+	 * Python-side migration completes. Vector pickles ({@code *vectors.pkl}) become
+	 * {@code .npy} and dataset pickles ({@code *dataset.pkl}) become
+	 * {@code .parquet}, matching the conversion logic in {@code FAISSSearcher}.
+	 *
+	 * @param pklFile the legacy pickle file
+	 * @return the absolute path of the migrated counterpart, or {@code null} if the
+	 *         file name does not match a recognised legacy pattern
+	 */
+	private static String predictMigratedPath(File pklFile) {
+		String name = pklFile.getName();
+		String safeName;
+		// Vector pickles -> .npy ; dataset pickles -> .parquet (matches FAISSSearcher
+		// migration)
+		if (name.endsWith("vectors.pkl")) {
+			safeName = name.substring(0, name.length() - ".pkl".length()) + ".npy";
+		} else if (name.endsWith("dataset.pkl")) {
+			safeName = name.substring(0, name.length() - ".pkl".length()) + ".parquet";
+		} else {
+			return null;
+		}
+		return new File(pklFile.getParent(), safeName).getAbsolutePath();
+	}
+
+	/**
+	 * Reconciles the cloud copy of the engine after a local pickle-to-safe-format
+	 * migration: uploads the newly produced {@code .parquet}/{@code .npy} files and
+	 * deletes the obsolete {@code .pkl} entries from cloud storage so peers don't
+	 * re-hydrate them on their next startup. A no-op when not running in cluster
+	 * mode.
+	 *
+	 * <p>
+	 * If Python failed to produce a migrated file the cloud copy is left untouched
+	 * for that entry so a subsequent startup can retry the migration.
+	 *
+	 * @param migrations map from legacy pickle paths to their migrated
+	 *                   counterparts, as produced by
+	 *                   {@link #detectLegacyPickleFiles()}
+	 */
+	private void syncMigratedFilesToCloud(Map<String, String> migrations) {
+		if (!ClusterUtil.IS_CLUSTER || migrations.isEmpty()) {
+			return;
+		}
+		List<String> safePaths = new ArrayList<>();
+		List<String> legacyPathsToDelete = new ArrayList<>();
+		for (Map.Entry<String, String> entry : migrations.entrySet()) {
+			// Only push the migrated counterpart if Python actually produced it, and only
+			// remove the matching .pkl from cloud in that same case. If something went
+			// wrong with the conversion we leave the cloud copy alone so a future startup
+			// can retry the migration.
+			if (new File(entry.getValue()).exists()) {
+				safePaths.add(entry.getValue());
+				legacyPathsToDelete.add(entry.getKey());
+			} else {
+				classLogger.warn(
+						"Expected migrated FAISS index file '{}' missing after Python init; leaving legacy '{}' in cloud so a future startup can retry the migration",
+						entry.getValue(), entry.getKey());
+			}
+		}
+		String[] toUpload = safePaths.toArray(new String[0]);
+		String[] toDelete = legacyPathsToDelete.toArray(new String[0]);
+
+		classLogger.info(
+				"FAISS pickle migration: pushing {} safe-format file(s) to cloud and removing {} legacy .pkl entry/entries for engine '{}'",
+				toUpload.length, toDelete.length, this.engineId);
+
+		if (toUpload.length > 0) {
+			Thread.ofVirtual().start(new CopyFilesToEngineRunner(engineId, this.getCatalogType(), toUpload));
+		}
+		if (toDelete.length > 0) {
+			Thread.ofVirtual().start(new DeleteFilesFromEngineRunner(engineId, this.getCatalogType(), toDelete));
+		}
+	}
+
 	////////////////////////////////////////////////////////////////////////
 
 	/**
@@ -1029,17 +1183,4 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 		return colName;
 	}
 
-//	public static void main(String[] args) throws Exception {
-//		Properties tempSmss = new Properties();
-//		tempSmss.put("CONNECTION_URL", "Semoss_Dev/vector/");
-//		tempSmss.put("VECTOR_TYPE", "FAISS");
-//		tempSmss.put("INDEX_CLASSES", "default");
-//		tempSmss.put("ENCODER_TYPE", "huggingface");
-//		tempSmss.put("ENCODER_NAME", "sentence-transformers/paraphrase-mpnet-base-v2");
-//		
-//		FaissDatabaseEngine engine = new FaissDatabaseEngine();
-//		engine.open(tempSmss);
-//		
-//		engine.close();
-//	}
 }

--- a/src/prerna/engine/impl/vector/PGVectorDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/PGVectorDatabaseEngine.java
@@ -639,11 +639,9 @@ public class PGVectorDatabaseEngine extends RDBMSNativeEngine implements IVector
 		}
 
 		if (ClusterUtil.IS_CLUSTER) {
-			Thread deleteFilesFromCloudThread = new Thread(new DeleteFilesFromEngineRunner(engineId,
-					this.getCatalogType(), filesToRemoveFromCloud.stream().toArray(String[]::new)));
-			deleteFilesFromCloudThread.start();
+			Thread.ofVirtual().start(new DeleteFilesFromEngineRunner(engineId, this.getCatalogType(),
+					filesToRemoveFromCloud.stream().toArray(String[]::new)));
 		}
-
 	}
 
 	@Override
@@ -1247,9 +1245,8 @@ public class PGVectorDatabaseEngine extends RDBMSNativeEngine implements IVector
 
 			if (ClusterUtil.IS_CLUSTER) {
 				// push the actual documents over to the cloud
-				Thread copyFilesToCloudThread = new Thread(new CopyFilesToEngineRunner(this.engineId,
-						this.getCatalogType(), filesToCopyToCloud.stream().toArray(String[]::new)));
-				copyFilesToCloudThread.start();
+				Thread.ofVirtual().start(new CopyFilesToEngineRunner(this.engineId, this.getCatalogType(),
+						filesToCopyToCloud.stream().toArray(String[]::new)));
 			}
 		} catch (Exception e) {
 			classLogger.error("Failed to add documents to PGVector for index class: " + indexClass, e);


### PR DESCRIPTION
The FAISS engine previously persisted its master/per-source index state as dataset.pkl + vectors.pkl. Switched the runtime load/save paths to Parquet (dataset) and .npy with allow_pickle=False (vectors). All pickle use is isolated to a new one-shot migration helper that converts legacy .pkl files to the safe formats once per engine and then deletes the originals; after that there is no pickle code on the runtime path.

Java side:
 - FaissDatabaseEngine.startServer detects legacy .pkl files before Python boots so it can reconcile the cloud copy afterwards. In cluster mode it uploads the migrated .parquet/.npy counterpart and removes the .pkl from cloud — but only when Python actually produced the migrated file, so a failed migration leaves the cloud copy in place for a retry on next startup.
 - removeDocument and the index-empty check accept both new safe extensions and the legacy .pkl pair, so partially-migrated engines still work.

Python side:
 - Dropped the datasets / HF Dataset runtime dependency from faiss_client.py, bm25_client.py, and faiss_database.py in favor of plain pandas. Sidesteps a LocalFileSystem bug in Dataset.from_parquet (datasets 2.14.3) that broke parquet loads and removes the Arrow disk-cache plumbing. `datasets` still appears in _legacy_pickle_migration.py only, to recognize legacy pickled Dataset instances during the one-time migration.
 - _enforce_canonical_schema() casts Source/Divider/Part/Content to str and Tokens to int64 at every parquet write site (save_dataset and the per-source write in _vector_addDocument). Keeps files dtype consistent so _validateEmbeddingFiles concat doesn't produce a mixed-type object column that pyarrow refuses to serialize.

Cold-start performance:
 - bm25_searcher is now a lazy property: the BM25 index + JSON corpus load is skipped entirely on read-only flows (listDocuments, removeDocument, vector-only nearestNeighbor).
 - On engines with hybrid search enabled, __init__ kicks off the BM25 build in a shared 2-worker ThreadPoolExecutor. Callers go through the property, which awaits the same Future; concurrent callers share one load (no duplicates), and a failed background warmup falls back to an inline build under a lock so subsequent reads don't keep re-raising the original error. atexit cleanly shuts down the pool.