### PR TITLE
feat: add autoOpen parameter to mcp_json

### DIFF
--- a/src/prerna/reactor/agent/mcp/MCPUtility.java
+++ b/src/prerna/reactor/agent/mcp/MCPUtility.java
@@ -97,6 +97,7 @@ public final class MCPUtility {
 	public static final String UI_RESOURCE_URI = "resourceURI";
 	public static final String UI_LOADING_MESSAGE = "loadingMessage";
 	public static final String UI_DISPLAY_LOCATION = "displayLocation";
+	public static final String UI_AUTO_OPEN = "autoOpen";
 
 	@Deprecated
 	public static final String SMSS_PROJECT_ID = "SMSS_PROJECT_ID";
@@ -1157,6 +1158,10 @@ public final class MCPUtility {
 			MCPDisplayOption displayEnum = MCPDisplayOption.fromValue(displayLocation);
 			String displayString = (displayEnum != null) ? displayEnum.getValue() : null;
 			validUiJson.put(UI_DISPLAY_LOCATION, displayString);
+		}
+
+		if (uiJson.has(UI_AUTO_OPEN) && !uiJson.isNull(UI_AUTO_OPEN)) {
+			validUiJson.put(UI_AUTO_OPEN, uiJson.getBoolean(UI_AUTO_OPEN));
 		}
 
 		return validUiJson;


### PR DESCRIPTION
## Description
Adds a parameter in the MCP Json strucuture to support auto opening a tool

## How to Test
Create an mcp app with the json:

"SMSS_MCP_UI": {
                    "resourceURI": "/index.html",
                    "displayLocation": "inline",
                    "autoOpen": false
                }

and then when you call that tool, it should open up the tool with the user having to click

## Notes
<!-- Any further notes regarding changes -->