### PR TITLE
fix: isolate per-MCP failures when aggregating room tools

### DIFF
--- a/src/prerna/engine/impl/model/Room.java
+++ b/src/prerna/engine/impl/model/Room.java
@@ -766,9 +766,9 @@ public class Room {
 		Set<String> ensureUnique = new HashSet<>();
 
 		if (o.containsKey("mcp")) {
-			try {
-				List<Map<String, Object>> mapMapList = (List<Map<String, Object>>) o.get("mcp");
-				for (Map<String, Object> mcpMap : mapMapList) {
+			List<Map<String, Object>> mapMapList = (List<Map<String, Object>>) o.get("mcp");
+			for (Map<String, Object> mcpMap : mapMapList) {
+				try {
 					if (mcpMap.containsKey("id")) {
 						String id = (String) mcpMap.get("id");
 						if (!ensureUnique.contains(id)) {
@@ -778,9 +778,9 @@ public class Room {
 					} else {
 						throw new IllegalArgumentException("Tool map must contain both type and id");
 					}
+				} catch (Exception e) {
+					classLogger.error("Unable to add tool map from room mcp", e);
 				}
-			} catch (Exception e) {
-				classLogger.error("Unable to add tool map from room mcp", e);
 			}
 		}
 

--- a/src/prerna/engine/impl/model/Room.java
+++ b/src/prerna/engine/impl/model/Room.java
@@ -766,21 +766,25 @@ public class Room {
 		Set<String> ensureUnique = new HashSet<>();
 
 		if (o.containsKey("mcp")) {
-			List<Map<String, Object>> mapMapList = (List<Map<String, Object>>) o.get("mcp");
-			for (Map<String, Object> mcpMap : mapMapList) {
-				try {
-					if (mcpMap.containsKey("id")) {
-						String id = (String) mcpMap.get("id");
-						if (!ensureUnique.contains(id)) {
-							aggregated.addAll(getToolJson(id, maxLength));
-							ensureUnique.add(id);
+			try {
+				List<Map<String, Object>> mapMapList = (List<Map<String, Object>>) o.get("mcp");
+				for (Map<String, Object> mcpMap : mapMapList) {
+					try {
+						if (mcpMap.containsKey("id")) {
+							String id = (String) mcpMap.get("id");
+							if (!ensureUnique.contains(id)) {
+								aggregated.addAll(getToolJson(id, maxLength));
+								ensureUnique.add(id);
+							}
+						} else {
+							throw new IllegalArgumentException("Tool map must contain both type and id");
 						}
-					} else {
-						throw new IllegalArgumentException("Tool map must contain both type and id");
+					} catch (Exception e) {
+						classLogger.error("Unable to add tool map from room mcp", e);
 					}
-				} catch (Exception e) {
-					classLogger.error("Unable to add tool map from room mcp", e);
 				}
+			} catch (ClassCastException e) {
+				classLogger.error("Malformed 'mcp' value in the options map", e);
 			}
 		}
 
@@ -788,19 +792,23 @@ public class Room {
 			try {
 				Map<String, Object> workspace = (Map<String, Object>) o.get("workspace");
 				if (workspace != null && workspace.containsKey("workspace_id")) {
-					String workspaceId = (String) workspace.get("workspace_id");
-					List<Map<String, Object>> tools = ModelInferenceLogsUtils.getWorkspaceResourcesIgnoringType(
-							workspaceId, List.of(AbstractWorkspaceReactor.PROMPT_RESOURCE_TYPE));
-					for (Map<String, Object> tool : tools) {
-						String toolId = (String) tool.get("resource_id");
-						if (!ensureUnique.contains(toolId)) {
-							aggregated.addAll(getToolJson(toolId, maxLength));
-							ensureUnique.add(toolId);
+					try {
+						String workspaceId = (String) workspace.get("workspace_id");
+						List<Map<String, Object>> tools = ModelInferenceLogsUtils.getWorkspaceResourcesIgnoringType(
+								workspaceId, List.of(AbstractWorkspaceReactor.PROMPT_RESOURCE_TYPE));
+						for (Map<String, Object> tool : tools) {
+							String toolId = (String) tool.get("resource_id");
+							if (!ensureUnique.contains(toolId)) {
+								aggregated.addAll(getToolJson(toolId, maxLength));
+								ensureUnique.add(toolId);
+							}
 						}
+					} catch (Exception e) {
+						classLogger.error("Unable to add tool map from workspace mcp", e);
 					}
 				}
-			} catch (Exception e) {
-				classLogger.error("Unable to add tool map from workspace mcp", e);
+			} catch (ClassCastException e) {
+				classLogger.error("Malformed 'workspace' value in the options map", e);
 			}
 		}
 


### PR DESCRIPTION
## Description

`Room.getAllToolsJsonForRoom` iterates over `options.mcp` and aggregates tools for each entry. The existing `try/catch` wraps the entire `for` loop, so if any single entry throws (e.g. an `id` that resolves to neither an engine nor a project hits the `IllegalArgumentException("Invalid MCP toolbox ...")` in `getToolJson`), the catch fires once and silently abandons every remaining entry. One bad entry can drop every MCP that came after it in the list.

## Changes Made

- Moved the `try/catch` inside the `for` loop in `Room.getAllToolsJsonForRoom` so each `mcp` entry is handled independently. A failure on one MCP logs and the loop continues to the next.

## How to Test

### Steps to reproduce/test the behavior

1. Create a room with multiple entries in `options.mcp`.
2. Make the first entry invalid (e.g. an `id` that doesn't resolve to any engine or project) and leave the rest as valid MCPs.
3. Trigger tool aggregation for the room (any AskPlayground / agent flow that calls `getAllToolsJsonForRoom`).

### Expected outcomes

- Before this change: the invalid entry throws, the catch fires once, and none of the subsequent valid MCPs are aggregated.
- After this change: the invalid entry logs `"Unable to add tool map from room mcp"` and the remaining valid MCPs are aggregated normally.
