### PR TITLE
Fixing logic in AbstractModelEngine for full prompt with unnamed room

### DIFF
--- a/src/prerna/engine/impl/model/AbstractModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractModelEngine.java
@@ -179,9 +179,9 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 					}
 				}
 			}
-			
-			fullPrompt=MessageUtils.toJsonArray(room.getMessages());
-			question=MessageUtils.toJsonArray(room.getMessages());
+
+			fullPrompt = MessageUtils.toJsonArray(room.getMessages());
+			question = MessageUtils.toJsonArray(room.getMessages());
 
 		}
 
@@ -247,26 +247,28 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 		// update current usage based on this new request
 		ModelUsageRestrictionUtility.updateRestrictionMapCurrentUsage(userRestrictionMap, askModelResponse, inputTime,
 				outputTime);
-		
+
 		String currentRoomName = room.getRoomName();
 
+		if (fullPrompt != null) {
 
-		// Grabbing room name from first input message if room name is empty and its full prompt..
-		if (fullPrompt != null && (currentRoomName == null || currentRoomName.isEmpty())) {
-			String roomName = null;
-			if (!room.getMessages().isEmpty()) {
-				AbstractMessage first = room.getMessages().get(0);
-				if (first instanceof InputMessage) {
-					String uiPrompt = ((InputMessage) first).getInputUIPrompt();
-					if (uiPrompt != null && !uiPrompt.trim().isEmpty()) {
-						roomName = uiPrompt.substring(0, Math.min(uiPrompt.length(), 100));
+			// Grabbing room name from first input message if room name is empty
+			if (currentRoomName == null || currentRoomName.isEmpty()) {
+				String roomName = null;
+				if (!room.getMessages().isEmpty()) {
+					AbstractMessage first = room.getMessages().get(0);
+					if (first instanceof InputMessage) {
+						String uiPrompt = ((InputMessage) first).getInputUIPrompt();
+						if (uiPrompt != null && !uiPrompt.trim().isEmpty()) {
+							roomName = uiPrompt.substring(0, Math.min(uiPrompt.length(), 100));
+						}
 					}
 				}
-			}
 
-			if (roomName != null && !roomName.trim().isEmpty()) {
-				ModelInferenceLogsUtils.doSetNameForRoom(room.getInsight().getUser().getPrimaryLoginToken().getId(),
-						room.getId(), roomName);
+				if (roomName != null && !roomName.trim().isEmpty()) {
+					ModelInferenceLogsUtils.doSetNameForRoom(room.getInsight().getUser().getPrimaryLoginToken().getId(),
+							room.getId(), roomName);
+				}
 			}
 
 			ResponseMessage response = ResponseMessage.Builder.fromAskModelEngineResponse(askModelResponse).build();


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Before: A single if (fullPrompt != null && (currentRoomName == null || currentRoomName.isEmpty())) gated both the room-name initialization and the response append + llm2_updateRoomMessages call. After turn 1 set the room name in the DB, every subsequent turn skipped the entire block — so the follow-up assistant response after a tool result never made it to ROOM.MESSAGES.

After: Outer guard is just if (fullPrompt != null). The room-name derivation stays nested under if (currentRoomName == null || currentRoomName.isEmpty()) so the name is still only set once. The response append, transaction-id wiring, and persistence now run on every FULL_PROMPT turn.

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->