### PR TITLE
fix: set test query on pooled datasource

### DIFF
--- a/src/prerna/engine/impl/rdbms/RDBMSNativeEngine.java
+++ b/src/prerna/engine/impl/rdbms/RDBMSNativeEngine.java
@@ -379,7 +379,7 @@ public class RDBMSNativeEngine extends AbstractDatabaseEngine implements IRDBMSE
 		dataSource.setMaximumPoolSize(this.poolMaxSize);
 		dataSource.setLeakDetectionThreshold(this.leakDetectionThresholdMilliseconds);
 		dataSource.setIdleTimeout(this.idelTimeout);
-		if (this.connectionTestQuery != null && this.connectionTestQuery.isEmpty()) {
+		if (this.connectionTestQuery != null && !this.connectionTestQuery.isEmpty()) {
 			dataSource.setConnectionTestQuery(this.connectionTestQuery);
 		}
 	}


### PR DESCRIPTION
## Description
When connection pooling is enabled, it was observed that a test query was not being used to evict bad connections. There was a bad condition check in the engine init.

## Changes Made
Change the condition to not isEmpty