### PR TITLE
fix(assets): stop double URL-decoding saved asset content

### DIFF
--- a/src/prerna/util/FileSystemUtil.java
+++ b/src/prerna/util/FileSystemUtil.java
@@ -549,8 +549,9 @@ public final class FileSystemUtil {
 			}
 
 			String filePath = assetFolder + "/" + fileName;
+			// content is written as-is: the Pixel translation layer already decodes
+			// <encode> blocks (PR #2510); decoding again corrupts literal "%xx" (e.g. %02x)
 			String content = contents.get(i);
-			content = Utility.decodeURIComponent(content);
 
 			File file = new File(filePath);
 			try {


### PR DESCRIPTION
## Summary

Saving an app asset whose content contains a literal `%xx` sequence — e.g. a Java format string like `String.format("%02x", b)`, a `printf("%0A")`, or text like `50%25 off` — corrupts the file on disk. The save path URL-decodes the content **a second time**, after the Pixel translation layer has already decoded it, so `%02x` is read as a percent-escape and mangled (`%02` → `0x02` control byte).

This removes the redundant decode from the shared `FileSystemUtil.saveAssetFiles(...)` helper, fixing the bug for **all four** asset families.

Fixes #2572. Alternative to / supersedes #2576 (which fixes only the project/App reactor).

## Root cause

`<encode>…</encode>`-wrapped content flows through the pipeline like this:

1. **`PixelPreProcessor.preProcessPixel`** URL-**encodes** the inner text so it survives the grammar, and records `encoded → original` in a shared `encodedTextToOriginal` map.
2. **`LazyTranslation.inAWordWordOrId` / `inAWordMapKey`** auto-**decode** any literal found in that map, via `Utility.decodeURIComponent(word, false)`. This is sound and precise: `performCheck=false` is safe *because* the map proves the token was encoded. **By the time the reactor runs, content is already correctly decoded.**
3. **`FileSystemUtil.saveAssetFiles`** then decoded a **second** time with `Utility.decodeURIComponent(content)` → `performCheck=true`. That heuristic asks "does this look encoded?" with the regex `%[0-9A-Fa-f]{2}`. A literal `%02x` matches (`%02`), so `URLDecoder` runs and corrupts the content.

The heuristic cannot distinguish a *literal* `%02x` from an *encoded* one — that question is undecidable from the string alone. The only sound signal is provenance, which the translation layer already has. So the correct fix is to not decode a second time, not to harden the heuristic.

## Why the fix belongs here (and is broader than #2576)

This redundant decode is a leftover from **#2510** ("translation now does a decode of the encode block instead of the reactor being responsible"), which moved decoding into the translation layer and deleted the same `decodeURIComponent` call from ~30 reactors and from the git `SaveAssetReactor`. Its diff never touched `FileSystemUtil` or the `Save*AssetsReactor` families — the call survived only because it had recently been relocated into this shared helper (#1949), one layer below where #2510's reactor-by-reactor sweep reached. The `SaveAssetReactor` line #2510 *did* delete has run decode-free in production since, with no follow-up fix.

All four plain asset reactors call this one helper:

- `SaveAppAssetsReactor`
- `SaveInsightAssetsReactor`
- `SaveUserAssetsReactor`
- `SaveEngineAssetsReactor`

Removing the decode in the shared helper fixes all four with no reactor changes, no new `decode` flag, and no collision with the `Save*AssetsBase64Reactor` family (whose `decode` key means *base64* decode). #2576 adds a flag to the App reactor only, leaving the other three with the identical latent bug.

## Regression analysis

Safe to remove for every real flow:

- **All UI/agent save paths** wrap content in `<encode>` and never URL-encode it themselves (the only `encodeURIComponent` in the client is transport-level body encoding the servlet reverses). Content arrives already decoded by translation; the second decode is pure redundancy.
- **Recipe replay** is safe: `PixelUtility.recreateOriginalPixelExpression` re-wraps content in `<encode>` when escapes exist (so translation re-decodes on replay) and drops the wrapper only when encoding was a byte-identical no-op.
- **Base64 variants** use a separate helper (`saveAssetFilesBase64`) and are unaffected.
- The only theoretical break is an external/hand-crafted pixel that pre-URL-encodes content *without* an `<encode>` wrapper and relies on the reactor to decode it. No such caller exists in either repo, and the `content` key was never documented as requiring self-encoding. (#2576 already accepts this exact risk for the App path.)

## Test plan

Save a Java/text asset containing literal percent sequences through the UI and confirm they survive on disk byte-for-byte:

- `String.format("%02x", b)` stays `%02x` (previously the `%02` became a `0x02` control byte)
- `printf("line%0A")` keeps `%0A` (previously became a newline)
- `50%25 off` stays `50%25 off` (previously became `50% off`)

Verify across all four asset types (app / insight / user / engine).
