### PR TITLE
fix for scheduler errors related to postgres util null blob handling

### DIFF
--- a/src/prerna/util/sql/PostgresQueryUtil.java
+++ b/src/prerna/util/sql/PostgresQueryUtil.java
@@ -325,7 +325,8 @@ public class PostgresQueryUtil extends AnsiSqlQueryUtil {
 	public void handleInsertionOfBlob(Connection conn, PreparedStatement statement, String object, int index)
 			throws SQLException, UnsupportedEncodingException {
 		if (object == null) {
-			statement.setNull(index, java.sql.Types.BLOB);
+			// blob data type name is BYTEA. so, need Types.BINARY here instead of Types.BLOB
+			statement.setNull(index, java.sql.Types.BINARY);
 		} else {
 			statement.setBytes(index, object.getBytes("UTF-8"));
 		}

--- a/src/prerna/util/sql/PostgresQueryUtil.java
+++ b/src/prerna/util/sql/PostgresQueryUtil.java
@@ -365,12 +365,14 @@ public class PostgresQueryUtil extends AnsiSqlQueryUtil {
 
 	@Override
 	public String handleBlobRetrieval(ResultSet result, String key) throws SQLException, IOException {
-		return new String(result.getBytes(key));
+		byte[] bytes = result.getBytes(key);
+		return bytes != null ? new String(bytes) : null;
 	}
 
 	@Override
 	public String handleBlobRetrieval(ResultSet result, int index) throws SQLException, IOException {
-		return new String(result.getBytes(index));
+		byte[] bytes = result.getBytes(index);
+		return bytes != null ? new String(bytes) : null;
 	}
 
 	@Override


### PR DESCRIPTION
## Description
When creating a scheduled job without a uiState parameter, it was observed that scheduler table inserts were failing with an error message: `org.postgresql.util.PSQLException: ERROR: column "ui_state" is of type bytea but expression is of type oid`

Root cause isolated to `prerna.util.sql.PostgresQueryUtil.handleInsertionOfBlob(Connection, PreparedStatement, String, int)` where a null value was being given the Types.BLOB sqlType code, but the driver uses OID type for this code.

## Changes Made
Update the postgres query util to support null blobs during insertion and retrieval

## How to Test
Before the change, adding a scheduled job would succeed adding to the qrtz tables, but the smss insertion would fail. The job wouldn't be visible on the UI.
After the change, adding a scheduled job would success and be visible on the list of jobs pulled from the smss tables.

## Notes
Any jobs created while this error was present may be silently running without entries in smss audit. Inspect the actual qrtz tables. SchedulerStats reactor should help to inform here as well since the job count is from qrtz trigger inspection
