### PR TITLE
bump Log4j to 2.25.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,7 +231,7 @@
 								<path>
 									<groupId>org.apache.logging.log4j</groupId>
 									<artifactId>log4j-core</artifactId>
-									<version>2.25.1</version>
+									<version>2.25.4</version>
 								</path>
 							</annotationProcessorPaths>
 							<annotationProcessors>
@@ -1338,7 +1338,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.25.1</version>
+			<version>2.25.4</version>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>
@@ -1350,7 +1350,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.25.1</version>
+			<version>2.25.4</version>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>
@@ -1369,7 +1369,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-web</artifactId>
-			<version>2.25.1</version>
+			<version>2.25.4</version>
 			<exclusions>
 				<exclusion>
 					<groupId>*</groupId>
@@ -1380,7 +1380,7 @@
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-slf4j-impl</artifactId>
-			<version>2.25.1</version>
+			<version>2.25.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.github.f4b6a3</groupId>


### PR DESCRIPTION
## Description
Bumps Log4j to 2.25.4 to remediate CVE-2026-34477 (SSL hostname verification bypass) and CVE-2026-34480 (XmlLayout invalid XML). Patch-level upgrade, API-compatible.

## Changes Made
pom.xml: version bumped in 5 spots - log4j-api, log4j-core, log4j-web, log4j-slf4j-impl, and the maven-compiler-plugin annotation-processor path.