### PR TITLE
Updating Skills to add to config_json column

### DIFF
--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -47,6 +47,7 @@ import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.javatuples.Pair;
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import com.github.f4b6a3.uuid.alt.GUID;
@@ -2318,7 +2319,9 @@ public class ModelInferenceLogsUtils {
 				}
 			}
 
-			try (PreparedStatement ps = con.prepareStatement("DELETE FROM WORKSPACE_RESOURCE WHERE WORKSPACE_ID = ?")) {
+
+			try (PreparedStatement ps = con.prepareStatement(
+					"DELETE FROM WORKSPACE_RESOURCE WHERE WORKSPACE_ID = ? AND RESOURCE_TYPE != 'SKILL'")) {
 				int index = 1;
 				ps.setString(index++, workspaceId);
 				ps.execute();
@@ -2510,6 +2513,97 @@ public class ModelInferenceLogsUtils {
 		} finally {
 			ConnectionUtils.closeAllConnectionsIfPooling(modelInferenceLogsDb, con, null, null);
 		}
+	}
+
+	/**
+	 * Adds a skill reference to {@code WORKSPACE.CONFIG_JSON.skills[]}, mirroring the
+	 * authoritative {@code WORKSPACE_RESOURCE} row so the two stores stay in sync - the
+	 * same dual-write pattern MCPs use ({@code EditWorkspaceReactor.mirrorCoreFieldsIntoConfigJson}).
+	 * Idempotent: a skill already present (matched by {@code skill_id}) is left untouched
+	 * and no write is issued.
+	 *
+	 * <p>The entry shape matches what {@code AgentConfigLoader.resolveSkills} reads:
+	 * {@code { "skill_id": <id>, "pinned_version": <optional> }}. Note the key is
+	 * {@code skill_id} - NOT {@code id} as the MCP mirror uses.
+	 *
+	 * @param workspaceId   workspace identifier
+	 * @param skillId       skill identifier to add
+	 * @param pinnedVersion optional pinned version; the key is omitted when null/empty
+	 * @throws SQLException if the CONFIG_JSON write fails
+	 */
+	public static void addSkillToWorkspaceConfigJson(String workspaceId, String skillId, String pinnedVersion)
+			throws SQLException {
+		if (workspaceId == null || workspaceId.isEmpty()) {
+			throw new IllegalArgumentException("workspaceId is required");
+		}
+		if (skillId == null || skillId.isEmpty()) {
+			throw new IllegalArgumentException("skillId is required");
+		}
+		JSONObject cfg = getWorkspaceConfigJson(workspaceId);
+		if (cfg == null) {
+			cfg = new JSONObject();
+			cfg.put("schema_version", 1);
+		}
+		JSONArray skills = cfg.optJSONArray("skills");
+		if (skills == null) {
+			skills = new JSONArray();
+		}
+		// Dedup by skill_id - keep the mirror idempotent like the attach reactor itself.
+		for (int i = 0; i < skills.length(); i++) {
+			JSONObject s = skills.optJSONObject(i);
+			if (s != null && skillId.equals(s.optString("skill_id", null))) {
+				return;
+			}
+		}
+		JSONObject entry = new JSONObject();
+		entry.put("skill_id", skillId);
+		if (pinnedVersion != null && !pinnedVersion.isEmpty()) {
+			entry.put("pinned_version", pinnedVersion);
+		}
+		skills.put(entry);
+		cfg.put("skills", skills);
+		updateWorkspaceConfigJson(workspaceId, cfg);
+	}
+
+	/**
+	 * Removes a skill reference from {@code WORKSPACE.CONFIG_JSON.skills[]}, mirroring
+	 * deletion of the {@code WORKSPACE_RESOURCE} row. No-op (no write) when the workspace
+	 * has no CONFIG_JSON, no {@code skills} array, or the skill is not present.
+	 *
+	 * @param workspaceId workspace identifier
+	 * @param skillId     skill identifier to remove
+	 * @throws SQLException if the CONFIG_JSON write fails
+	 */
+	public static void removeSkillFromWorkspaceConfigJson(String workspaceId, String skillId) throws SQLException {
+		if (workspaceId == null || workspaceId.isEmpty()) {
+			throw new IllegalArgumentException("workspaceId is required");
+		}
+		if (skillId == null || skillId.isEmpty()) {
+			throw new IllegalArgumentException("skillId is required");
+		}
+		JSONObject cfg = getWorkspaceConfigJson(workspaceId);
+		if (cfg == null) {
+			return;
+		}
+		JSONArray skills = cfg.optJSONArray("skills");
+		if (skills == null || skills.length() == 0) {
+			return;
+		}
+		JSONArray kept = new JSONArray();
+		boolean removed = false;
+		for (int i = 0; i < skills.length(); i++) {
+			JSONObject s = skills.optJSONObject(i);
+			if (s != null && skillId.equals(s.optString("skill_id", null))) {
+				removed = true;
+				continue;
+			}
+			kept.put(skills.get(i));
+		}
+		if (!removed) {
+			return;
+		}
+		cfg.put("skills", kept);
+		updateWorkspaceConfigJson(workspaceId, cfg);
 	}
 
 	/**

--- a/src/prerna/reactor/agent/skill/AttachSkillToWorkspaceReactor.java
+++ b/src/prerna/reactor/agent/skill/AttachSkillToWorkspaceReactor.java
@@ -121,6 +121,15 @@ public class AttachSkillToWorkspaceReactor extends AbstractReactor {
 			response.put("workspace_id", workspaceId);
 			response.put("skill_id", skillId);
 			response.put("created", created);
+
+			try {
+				ModelInferenceLogsUtils.addSkillToWorkspaceConfigJson(workspaceId, skillId, null);
+			} catch (Exception mirrorEx) {
+				classLogger.warn("Attached skill '{}' to workspace '{}' but failed to mirror into CONFIG_JSON.skills",
+						skillId, workspaceId, mirrorEx);
+				response.put("warning", "Skill attached but CONFIG_JSON sync failed: " + mirrorEx.getMessage());
+			}
+
 			return new NounMetadata(response, PixelDataType.MAP, PixelOperationType.OPERATION);
 		} catch (Exception e) {
 			classLogger.error(Constants.STACKTRACE, e);

--- a/src/prerna/reactor/agent/skill/DetachSkillFromWorkspaceReactor.java
+++ b/src/prerna/reactor/agent/skill/DetachSkillFromWorkspaceReactor.java
@@ -30,6 +30,9 @@ package prerna.reactor.agent.skill;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import prerna.auth.User;
 import prerna.auth.utils.SecurityProjectUtils;
 import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
@@ -56,6 +59,8 @@ import prerna.sablecc2.om.nounmeta.NounMetadata;
  * detaching is always allowed for someone who can edit the workspace.
  */
 public class DetachSkillFromWorkspaceReactor extends AbstractReactor {
+
+	private static final Logger classLogger = LogManager.getLogger(DetachSkillFromWorkspaceReactor.class);
 
 	private static final String SKILL_ID = "skillId";
 
@@ -91,6 +96,16 @@ public class DetachSkillFromWorkspaceReactor extends AbstractReactor {
 		response.put("workspace_id", workspaceId);
 		response.put("skill_id", skillId);
 		response.put("removed", deleted > 0);
+
+
+		try {
+			ModelInferenceLogsUtils.removeSkillFromWorkspaceConfigJson(workspaceId, skillId);
+		} catch (Exception mirrorEx) {
+			classLogger.warn("Detached skill '{}' from workspace '{}' but failed to mirror removal out of CONFIG_JSON.skills",
+					skillId, workspaceId, mirrorEx);
+			response.put("warning", "Skill detached but CONFIG_JSON sync failed: " + mirrorEx.getMessage());
+		}
+
 		return new NounMetadata(response, PixelDataType.MAP, PixelOperationType.OPERATION);
 	}
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Updating the skills logic to be included in the config_json when using attach and detach skills reactor. 

Example:

```json
{"skills":[{"skill_id":"019e4bc5-46c3-7086-863a-4f6d726a8248"}],"mcps":[{"name":"4b4e1df8-cff6-4345-863b-5631a0e51000","id":"4b4e1df8-cff6-4345-863b-5631a0e51000"},{"name":"075650f9-c06d-4850-9ebe-996332b465ff","id":"075650f9-c06d-4850-9ebe-996332b465ff"},{"name":"7832f9cb-6600-4cec-b3e6-e8d94c257373","id":"7832f9cb-6600-4cec-b3e6-e8d94c257373"}],"hooks":[{"kind":"ppt_to_pdf"}]}
```

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->