### PR TITLE
feat(model): add redis room message locking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1102,6 +1102,30 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<!-- Source: https://mvnrepository.com/artifact/redis.clients/jedis -->
+		<dependency>
+			<groupId>redis.clients</groupId>
+			<artifactId>jedis</artifactId>
+			<version>5.2.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.slf4j</groupId>
+					<artifactId>slf4j-api</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-pool2</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.google.code.gson</groupId>
+					<artifactId>gson</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>org.json</groupId>
+					<artifactId>json</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 		<dependency>
 			<groupId>org.apache.tinkerpop</groupId>
 			<artifactId>tinkergraph-gremlin</artifactId>

--- a/src/prerna/engine/impl/model/AbstractModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractModelEngine.java
@@ -100,7 +100,7 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	/**
 	 * This is an abstract method for the implementation class such that tracking
 	 * occurs
-	 * 
+	 *
 	 * @param question
 	 * @param fullPrompt
 	 * @param context
@@ -139,79 +139,82 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 		// AbstractMessages
 		// then set the message_json to be the new abstractMessages
 		Object fullPrompt = parameters.remove(FULL_PROMPT);
-		if (fullPrompt != null) {
-			List<AbstractMessage> messageList = MessageUtils.convertFullPrompt(fullPrompt, room, this);
-			Object appendFullPrompt = parameters.remove(APPEND_FULL_PROMPT);
-			if (appendFullPrompt != null && Boolean.parseBoolean(appendFullPrompt + "")) {
-				room.getMessages().addAll(messageList);
-				messageList = room.getMessages();
-			} else {
-				room.setMessages(messageList);
-			}
-			String messageJson = MessageUtils.toJsonArrayWithImageData(messageList);
-			question = messageJson;
-			parameters.put("message_json", messageJson);
-
-			Object toolChoiceObj = parameters.get("tool_choice");
-			if (toolChoiceObj != null) {
-				Map<String, Object> mcpToolChoice = MessageUtils.toMCPToolChoice(toolChoiceObj);
-				if (mcpToolChoice != null) {
-					parameters.put("tool_choice", mcpToolChoice);
+		try (RoomMessageStore.RoomMutationLock ignored = RoomMessageStore
+				.acquireMutationLock(fullPrompt != null ? room : null)) {
+			if (fullPrompt != null) {
+				List<AbstractMessage> messageList = MessageUtils.convertFullPrompt(fullPrompt, room, this);
+				Object appendFullPrompt = parameters.remove(APPEND_FULL_PROMPT);
+				if (appendFullPrompt != null && Boolean.parseBoolean(appendFullPrompt + "")) {
+					String userId = room.getInsight().getUser().getPrimaryLoginToken().getId();
+					RoomMessageStore.refreshFromLatestProjection(room, userId);
+					room.getMessages().addAll(messageList);
+					messageList = room.getMessages();
+				} else {
+					room.setMessages(messageList);
 				}
-			}
+				String messageJson = RoomMessageStore.providerMessageHistory(room, messageList);
+				question = messageJson;
+				parameters.put("message_json", messageJson);
 
-			Object toolsObj = parameters.get("tools");
-			if (toolsObj instanceof List<?>) {
-				boolean convertable = true;
-				List<?> toolsListRaw = (List<?>) toolsObj;
-				for (Object obj : toolsListRaw) {
-					if (!(obj instanceof Map)) {
-						convertable = false;
-						break;
+				Object toolChoiceObj = parameters.get("tool_choice");
+				if (toolChoiceObj != null) {
+					Map<String, Object> mcpToolChoice = MessageUtils.toMCPToolChoice(toolChoiceObj);
+					if (mcpToolChoice != null) {
+						parameters.put("tool_choice", mcpToolChoice);
 					}
 				}
-				if (convertable) {
-					@SuppressWarnings("unchecked")
-					List<Map<String, Object>> toolsList = (List<Map<String, Object>>) toolsObj;
-					List<Map<String, Object>> mcpTools = MessageUtils.convertOpenAIToMCPTools(toolsList);
-					if (mcpTools != null) {
-						parameters.put("tools", mcpTools);
+
+				Object toolsObj = parameters.get("tools");
+				if (toolsObj instanceof List<?>) {
+					boolean convertable = true;
+					List<?> toolsListRaw = (List<?>) toolsObj;
+					for (Object obj : toolsListRaw) {
+						if (!(obj instanceof Map)) {
+							convertable = false;
+							break;
+						}
+					}
+					if (convertable) {
+						@SuppressWarnings("unchecked")
+						List<Map<String, Object>> toolsList = (List<Map<String, Object>>) toolsObj;
+						List<Map<String, Object>> mcpTools = MessageUtils.convertOpenAIToMCPTools(toolsList);
+						if (mcpTools != null) {
+							parameters.put("tools", mcpTools);
+						}
 					}
 				}
+
+				fullPrompt = MessageUtils.toJsonArray(room.getMessages());
+				question = MessageUtils.toJsonArray(room.getMessages());
 			}
 
-			fullPrompt = MessageUtils.toJsonArray(room.getMessages());
-			question = MessageUtils.toJsonArray(room.getMessages());
+			ZonedDateTime inputTime = ZonedDateTime.now();
+			AskModelEngineResponse askModelResponse = askCall(question, null, context, room.getInsight(), room.getId(),
+					parameters);
+			ZonedDateTime outputTime = ZonedDateTime.now();
 
-		}
+			if (AskModelEngineResponse.ERROR.equals(askModelResponse.getMessageType())) {
+				AskErrorModelEngineResponse errorDetails = (AskErrorModelEngineResponse) askModelResponse;
+				classLogger.error(
+						"An error occurred in the {} client with status code {} for model {}. ERROR: {} TRACEBACK: {}",
+						errorDetails.getClient(), errorDetails.getCode(), errorDetails.getModel(),
+						errorDetails.getStringResponse(), errorDetails.getTraceback());
 
-		ZonedDateTime inputTime = ZonedDateTime.now();
-		AskModelEngineResponse askModelResponse = askCall(question, null, context, room.getInsight(), room.getId(),
-				parameters);
-		ZonedDateTime outputTime = ZonedDateTime.now();
+				askModelResponse.setMessageId(GUID.v7().toUUID().toString());
+				askModelResponse.setRoomId(room.getId());
 
-		if (AskModelEngineResponse.ERROR.equals(askModelResponse.getMessageType())) {
-			AskErrorModelEngineResponse errorDetails = (AskErrorModelEngineResponse) askModelResponse;
-			classLogger.error(
-					"An error occurred in the {} client with status code {} for model {}. ERROR: {} TRACEBACK: {}",
-					errorDetails.getClient(), errorDetails.getCode(), errorDetails.getModel(),
-					errorDetails.getStringResponse(), errorDetails.getTraceback());
+				throw new SemossModelEngineException(askModelResponse);
+			}
 
 			askModelResponse.setMessageId(GUID.v7().toUUID().toString());
 			askModelResponse.setRoomId(room.getId());
 
-			throw new SemossModelEngineException(askModelResponse);
-		}
-
-		askModelResponse.setMessageId(GUID.v7().toUUID().toString());
-		askModelResponse.setRoomId(room.getId());
-
-		String insightId = room.getInsight().getInsightId();
-		String projectId = room.getInsight().getProjectId();
-		// if the insight project id is null, check fi one exists on the room
-		if (projectId == null) {
-			projectId = room.getProjectId();
-		}
+			String insightId = room.getInsight().getInsightId();
+			String projectId = room.getInsight().getProjectId();
+			// if the insight project id is null, check fi one exists on the room
+			if (projectId == null) {
+				projectId = room.getProjectId();
+			}
 
 		// @formatter:off
 		if (inferenceLogsEnbaled) {
@@ -244,52 +247,51 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 		}
 		// @formatter:on
 
-		// update current usage based on this new request
-		ModelUsageRestrictionUtility.updateRestrictionMapCurrentUsage(userRestrictionMap, askModelResponse, inputTime,
-				outputTime);
+			// update current usage based on this new request
+			ModelUsageRestrictionUtility.updateRestrictionMapCurrentUsage(userRestrictionMap, askModelResponse,
+					inputTime, outputTime);
 
-		String currentRoomName = room.getRoomName();
+			String currentRoomName = room.getRoomName();
 
-		if (fullPrompt != null) {
-			// Grabbing room name from first input message if room name is empty
-			if (currentRoomName == null || currentRoomName.isEmpty()) {
-				String roomName = null;
-				if (!room.getMessages().isEmpty()) {
-					AbstractMessage first = room.getMessages().get(0);
-					if (first instanceof InputMessage) {
-						String uiPrompt = ((InputMessage) first).getInputUIPrompt();
-						if (uiPrompt != null && !uiPrompt.trim().isEmpty()) {
-							roomName = uiPrompt.substring(0, Math.min(uiPrompt.length(), 100));
+			if (fullPrompt != null) {
+				// Grabbing room name from first input message if room name is empty
+				if (currentRoomName == null || currentRoomName.isEmpty()) {
+					String roomName = null;
+					if (!room.getMessages().isEmpty()) {
+						AbstractMessage first = room.getMessages().get(0);
+						if (first instanceof InputMessage) {
+							String uiPrompt = ((InputMessage) first).getInputUIPrompt();
+							if (uiPrompt != null && !uiPrompt.trim().isEmpty()) {
+								roomName = uiPrompt.substring(0, Math.min(uiPrompt.length(), 100));
+							}
 						}
+					}
+
+					if (roomName != null && !roomName.trim().isEmpty()) {
+						ModelInferenceLogsUtils.doSetNameForRoom(
+								room.getInsight().getUser().getPrimaryLoginToken().getId(), room.getId(), roomName);
 					}
 				}
 
-				if (roomName != null && !roomName.trim().isEmpty()) {
-					ModelInferenceLogsUtils.doSetNameForRoom(room.getInsight().getUser().getPrimaryLoginToken().getId(),
-							room.getId(), roomName);
-				}
+				ResponseMessage response = ResponseMessage.Builder.fromAskModelEngineResponse(askModelResponse).build();
+				room.getMessages().add(response);
+
+				// set transaction id for both pieces
+				inputMessage.setTransactionId(response.getMessageId());
+				inputMessage.setTokensInMessage(askModelResponse.getNumberOfTokensInPrompt());
+				inputMessage.setCacheReadTokens(askModelResponse.getNumberOfCacheReadTokens());
+				response.setTransactionId(response.getMessageId());
+
+				// Create the assistant's response message and add to history
+				response.setModel(this);
+				response.setParentMessageId(inputMessage.getMessageId());
+				response.setTokensInMessage(askModelResponse.getNumberOfTokensInResponse());
+
+				RoomMessageStore.persist(room, room.getInsight().getUser().getPrimaryLoginToken().getId());
 			}
 
-			ResponseMessage response = ResponseMessage.Builder.fromAskModelEngineResponse(askModelResponse).build();
-			room.getMessages().add(response);
-
-			// set transaction id for both pieces
-			inputMessage.setTransactionId(response.getMessageId());
-			inputMessage.setTokensInMessage(askModelResponse.getNumberOfTokensInPrompt());
-			inputMessage.setCacheReadTokens(askModelResponse.getNumberOfCacheReadTokens());
-			response.setTransactionId(response.getMessageId());
-
-			// Create the assistant's response message and add to history
-			response.setModel(this);
-			response.setParentMessageId(inputMessage.getMessageId());
-			response.setTokensInMessage(askModelResponse.getNumberOfTokensInResponse());
-
-			ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(),
-					room.getInsight().getUser().getPrimaryLoginToken().getId(),
-					MessageUtils.toJsonArray(room.getMessages()));
+			return askModelResponse;
 		}
-
-		return askModelResponse;
 	}
 
 	@Override
@@ -306,7 +308,7 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	/**
 	 * This is an abstract method for the implementation class such that tracking
 	 * occurs
-	 * 
+	 *
 	 * @param stringsToEmbed
 	 * @param insight
 	 * @param parameters
@@ -331,9 +333,9 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 			String messageId = GUID.v7().toUUID().toString();
 			Thread inferenceRecorder = new Thread(new ModelEngineInferenceLogsWorker (
 					/*messageId*/messageId,
-					/*transactionId*/messageId, 
-					/*messageMethod*/"embeddings", 
-					/*engine*/this, 
+					/*transactionId*/messageId,
+					/*messageMethod*/"embeddings",
+					/*engine*/this,
 					/*insightId*/insight.getInsightId(),
 					/*projectContextId*/insight.getContextProjectId(),
 					/*projectId*/insight.getProjectId(),
@@ -344,7 +346,7 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 					/*prompt*/null,
 					/*fullPrompt*/stringsToEmbed,
 					/*promptTokens*/embeddingsResponse.getNumberOfTokensInPrompt(),
-					/*inputTime*/inputTime, 
+					/*inputTime*/inputTime,
 					/*response*/"",
 					/*responseTokens*/embeddingsResponse.getNumberOfTokensInResponse(),
 					/*outputTime*/outputTime
@@ -363,7 +365,7 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	/**
 	 * This is an abstract method for the implementation class such that tracking
 	 * occurs
-	 * 
+	 *
 	 * @param stringsToEmbed
 	 * @param insight
 	 * @param parameters
@@ -387,9 +389,9 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 			String messageId = GUID.v7().toUUID().toString();
 			Thread inferenceRecorder = new Thread(new ModelEngineInferenceLogsWorker (
 					/*messageId*/messageId,
-					/*transactionId*/messageId, 
-					/*messageMethod*/"embeddings", 
-					/*engine*/this, 
+					/*transactionId*/messageId,
+					/*messageMethod*/"embeddings",
+					/*engine*/this,
 					/*insightId*/insight.getInsightId(),
 					/*projectContextId*/insight.getContextProjectId(),
 					/*projectId*/insight.getProjectId(),
@@ -400,7 +402,7 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 					/*prompt*/null,
 					/*fullPrompt*/imagesToEmbed,
 					/*promptTokens*/embeddingsResponse.getNumberOfTokensInPrompt(),
-					/*inputTime*/inputTime, 
+					/*inputTime*/inputTime,
 					/*response*/"",
 					/*responseTokens*/embeddingsResponse.getNumberOfTokensInResponse(),
 					/*outputTime*/outputTime
@@ -417,7 +419,7 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	}
 
 	/**
-	 * 
+	 *
 	 * @return
 	 */
 	@Override

--- a/src/prerna/engine/impl/model/Room.java
+++ b/src/prerna/engine/impl/model/Room.java
@@ -275,90 +275,85 @@ public class Room {
 			return buildAssistantResponseFromModelResponse(llmResponse, modelEngine, msg);
 		}
 
-		// if we dont have to keep history. then wipe all previous messages.
-		if (!modelEngine.keepsConversationHistory()) {
-			messages.clear();
-		}
-
-		// drop orphan tool_use (cancel mid-tool, crash) before building the outbound
-		// branch
-		// - providers reject unpaired tool_use, and the cached in-memory list may have
-		// one
-		// even though sanitize on rehydration covers cold loads
-		List<AbstractMessage> sanitized = MessageUtils.sanitizeOrphanToolCalls(this.messages, this);
-		if (sanitized != this.messages) {
-			setMessages(sanitized);
-		}
-
-		// Set model type and add message to history
-		msg.setModel(modelEngine);
-
-		// Set parentMessageId for this message
-		// first check that messages is not empty. otherwise its the first message of
-		// the thread and parent is null
-		if (!messages.isEmpty()) {
-			// if a parent message id is passed in, validate it exists and use it.
-			if (parentMessageId != null && !parentMessageId.isEmpty()) {
-				msg.setParentMessageId(parentMessageId);
-			} else {
-				// if no parent message id is passed in, use the last message as the parent.
-				AbstractMessage lastMsg = messages.get(messages.size() - 1);
-				msg.setParentMessageId(lastMsg.getMessageId());
+		String userId = insight.getUser().getPrimaryLoginToken().getId();
+		try (RoomMessageStore.RoomMutationLock ignored = RoomMessageStore.acquireMutationLock(this)) {
+			RoomMessageStore.refreshFromLatestProjection(this, userId);
+			// if we dont have to keep history. then wipe all previous messages.
+			if (!modelEngine.keepsConversationHistory()) {
+				messages.clear();
 			}
-		} else {
-			msg.setParentMessageId(null); // first message
-		}
 
-		ResponseMessage response = null;
-		try {
-			String messageJsonString = MessageUtils.getMessageHistoryWithNewMessage(this.messages, msg);
-			kwArgMap.put("message_json", messageJsonString);
+			// drop orphan tool_use (cancel mid-tool, crash) before building the outbound
+			// branch so providers do not reject the next payload
+			RoomMessageStore.normalizeForProviderPayload(this);
 
-			AskModelEngineResponse llmResponse = modelEngine.askRoom(msg.getInputPrompt(), this, msg, kwArgMap);
-			applyInputUsageFromModelResponse(msg, llmResponse);
-			response = buildAssistantResponseFromModelResponse(llmResponse, modelEngine, msg);
-		} catch (Exception e) {
-			classLogger.error("Failed to run new room message for roomId '{}'", room_id, e);
-			throw e;
-		}
-		// on success, add the message
-		if (appendToHistory) {
-			messages.add(msg);
-			messages.add(response);
-		}
+			// Set model type and add message to history
+			msg.setModel(modelEngine);
 
-		// Save the old (before) roomName for comparison
-		String prevRoomName = this.roomName;
+			// Set parentMessageId for this message
+			// first check that messages is not empty. otherwise its the first message of
+			// the thread and parent is null
+			if (!messages.isEmpty()) {
+				// if a parent message id is passed in, validate it exists and use it.
+				if (parentMessageId != null && !parentMessageId.isEmpty()) {
+					msg.setParentMessageId(parentMessageId);
+				} else {
+					// if no parent message id is passed in, use the last message as the parent.
+					AbstractMessage lastMsg = messages.get(messages.size() - 1);
+					msg.setParentMessageId(lastMsg.getMessageId());
+				}
+			} else {
+				msg.setParentMessageId(null); // first message
+			}
 
-		// Try to infer/set roomName if missing
-		if (prevRoomName == null || prevRoomName.trim().isEmpty()) {
-			for (AbstractMessage m : this.messages) {
-				if (m instanceof InputMessage) {
-					InputMessage im = (InputMessage) m;
-					String prompt = im.getInputUIPrompt();
-					if (prompt != null && !prompt.trim().isEmpty()) {
-						this.roomName = prompt.substring(0, Math.min(prompt.length(), 100));
-						break;
+			ResponseMessage response = null;
+			try {
+				String messageJsonString = RoomMessageStore.messageHistoryWithNewMessage(this, msg);
+				kwArgMap.put("message_json", messageJsonString);
+
+				AskModelEngineResponse llmResponse = modelEngine.askRoom(msg.getInputPrompt(), this, msg, kwArgMap);
+				applyInputUsageFromModelResponse(msg, llmResponse);
+				response = buildAssistantResponseFromModelResponse(llmResponse, modelEngine, msg);
+			} catch (Exception e) {
+				classLogger.error("Error running new message in room", e);
+				throw e;
+			}
+			// on success, add the message
+			if (appendToHistory) {
+				messages.add(msg);
+				messages.add(response);
+			}
+
+			// Save the old (before) roomName for comparison
+			String prevRoomName = this.roomName;
+
+			// Try to infer/set roomName if missing
+			if (prevRoomName == null || prevRoomName.trim().isEmpty()) {
+				for (AbstractMessage m : this.messages) {
+					if (m instanceof InputMessage) {
+						InputMessage im = (InputMessage) m;
+						String prompt = im.getInputUIPrompt();
+						if (prompt != null && !prompt.trim().isEmpty()) {
+							this.roomName = prompt.substring(0, Math.min(prompt.length(), 100));
+							break;
+						}
 					}
 				}
 			}
-		}
 
-		// Persist message history - room name was just updated
-		if (appendToHistory) {
-			if ((prevRoomName == null || prevRoomName.trim().isEmpty()) && this.roomName != null
-					&& !this.roomName.trim().isEmpty()) {
-				// Only update with room name if we just set it now!
-				ModelInferenceLogsUtils.llm2_updateRoomMessages(room_id,
-						insight.getUser().getPrimaryLoginToken().getId(), getMessagesAsString(), this.roomName,
-						modelEngine.getEngineId());
-			} else {
-				// Otherwise, regular update
-				ModelInferenceLogsUtils.llm2_updateRoomMessages(room_id,
-						insight.getUser().getPrimaryLoginToken().getId(), getMessagesAsString());
+			// Persist message history - room name was just updated
+			if (appendToHistory) {
+				if ((prevRoomName == null || prevRoomName.trim().isEmpty()) && this.roomName != null
+						&& !this.roomName.trim().isEmpty()) {
+					// Only update with room name if we just set it now!
+					RoomMessageStore.persist(this, userId, this.roomName, modelEngine.getEngineId());
+				} else {
+					// Otherwise, regular update
+					RoomMessageStore.persist(this, userId);
+				}
 			}
+			return response;
 		}
-		return response;
 	}
 
 	/**
@@ -386,18 +381,21 @@ public class Room {
 	public synchronized AskModelEngineResponse addToolExecutionResult(String toolCallId, String toolName,
 			String toolExecutionResponse, Map<String, Object> toolParameterValues, Map<String, Object> paramValuesMap,
 			String parentMessageId, IModelEngine modelEngine, Insight insight, String toolStatus) {
-		if (messages.isEmpty()) {
-			throw new IllegalStateException("No messages to match tool call context");
-		}
+		String userId = insight.getUser().getPrimaryLoginToken().getId();
+		try (RoomMessageStore.RoomMutationLock ignored = RoomMessageStore.acquireMutationLock(this)) {
+			RoomMessageStore.refreshFromLatestProjection(this, userId);
+			if (messages.isEmpty()) {
+				throw new IllegalStateException("No messages to match tool call context");
+			}
 
-		String lastMessageId = null;
-		if (parentMessageId != null && !parentMessageId.isEmpty()) {
-			lastMessageId = parentMessageId;
-		} else {
-			// if no parent message id is passed in, use the last message as the parent.
-			AbstractMessage lastMsg = messages.get(messages.size() - 1);
-			lastMessageId = lastMsg.getMessageId();
-		}
+			String lastMessageId = null;
+			if (parentMessageId != null && !parentMessageId.isEmpty()) {
+				lastMessageId = parentMessageId;
+			} else {
+				// if no parent message id is passed in, use the last message as the parent.
+				AbstractMessage lastMsg = messages.get(messages.size() - 1);
+				lastMessageId = lastMsg.getMessageId();
+			}
 
 		// 1. Find the last RESPONSE_TOOL message (assistant tool_calls)
 		ResponseMessage toolResponse = null;
@@ -518,8 +516,7 @@ public class Room {
 		// otherwise, we add the message and save the result
 		if (!answeredIds.containsAll(allIds) || allIds.size() == 0) {
 			// persist the new message (or just the part) into the room
-			ModelInferenceLogsUtils.llm2_updateRoomMessages(room_id, insight.getUser().getPrimaryLoginToken().getId(),
-					getMessagesAsString());
+			RoomMessageStore.persist(this, userId);
 		} else {
 			// we have to add the tool results into the message history
 			// so that we can track for multiple tools
@@ -528,7 +525,7 @@ public class Room {
 			// as opposed to the normal
 			// getMessageHistoryWithNewMessage(List<AbstractMessage> messages,
 			// AbstractMessage newMessage) method
-			String messageJsonString = MessageUtils.getCurrentMessageHistory(this.messages);
+			String messageJsonString = RoomMessageStore.currentMessageHistory(this);
 			if (paramValuesMap == null) {
 				paramValuesMap = new HashMap<>();
 			}
@@ -560,7 +557,7 @@ public class Room {
 			} catch (Exception e) {
 				// remove the entire input message since it failed
 				messages.removeLast();
-				classLogger.error("Failed to append tool result message and get follow-up model response: {}",
+				classLogger.error("Error adding the tool result message and getting a model response. Error: {}",
 						e.getMessage(), e);
 				throw e;
 			}
@@ -590,13 +587,13 @@ public class Room {
 			}
 			// --------- END TRANSACTION ID PROPAGATION ---------
 
-			ModelInferenceLogsUtils.llm2_updateRoomMessages(room_id, insight.getUser().getPrimaryLoginToken().getId(),
-					getMessagesAsString());
+			RoomMessageStore.persist(this, userId);
 
 			return llmResponse;
 		}
 		// Not all tool_calls fulfilled yet
 		return null;
+		}
 	}
 
 	/**
@@ -1681,7 +1678,7 @@ public class Room {
 			this.setMessages(new ArrayList<>());
 			return;
 		}
-		List<AbstractMessage> loaded = MessageUtils.fromJsonArray(messagesJson, this);
+		List<AbstractMessage> loaded = RoomMessageStore.loadFromPersistedJson(this, messagesJson);
 
 		this.setMessages(loaded != null ? loaded : new ArrayList<>());
 	}

--- a/src/prerna/engine/impl/model/RoomMessageRedisClient.java
+++ b/src/prerna/engine/impl/model/RoomMessageRedisClient.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.engine.impl.model;
+
+import java.util.Collections;
+
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.params.SetParams;
+
+/**
+ * Narrow Redis client for room-message coordination and cache keys.
+ */
+public final class RoomMessageRedisClient {
+
+	private static final String UNLOCK_SCRIPT =
+			"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('del', KEYS[1]) else return 0 end";
+	private static final String RENEW_SCRIPT =
+			"if redis.call('get', KEYS[1]) == ARGV[1] then return redis.call('pexpire', KEYS[1], ARGV[2]) else return 0 end";
+
+	private final JedisPool pool;
+
+	RoomMessageRedisClient(JedisPool pool) {
+		this.pool = pool;
+	}
+
+	boolean tryAcquireLock(String roomId, String token, long ttlMs) {
+		return withJedis(jedis -> "OK".equals(jedis.set(lockKey(roomId), token,
+				SetParams.setParams().nx().px(ttlMs))));
+	}
+
+	void releaseLock(String roomId, String token) {
+		withJedis(jedis -> jedis.eval(UNLOCK_SCRIPT, Collections.singletonList(lockKey(roomId)),
+				Collections.singletonList(token)));
+	}
+
+	void renewLock(String roomId, String token, long ttlMs) {
+		withJedis(jedis -> jedis.eval(RENEW_SCRIPT, Collections.singletonList(lockKey(roomId)),
+				java.util.Arrays.asList(token, String.valueOf(ttlMs))));
+	}
+
+	String getMessages(String roomId) {
+		return withJedis(jedis -> jedis.get(messagesKey(roomId)));
+	}
+
+	void setMessages(String roomId, String value) {
+		withJedis(jedis -> jedis.set(messagesKey(roomId), value));
+	}
+
+	void deleteMessages(String roomId) {
+		withJedis(jedis -> jedis.del(messagesKey(roomId)));
+	}
+
+	void incrementVersion(String roomId) {
+		withJedis(jedis -> jedis.incr(versionKey(roomId)));
+	}
+
+	private <T> T withJedis(JedisCallback<T> callback) {
+		try (Jedis jedis = pool.getResource()) {
+			return callback.apply(jedis);
+		} catch (Exception e) {
+			throw new IllegalStateException("Redis room-message command failed: " + e.getMessage(), e);
+		}
+	}
+
+	private static String messagesKey(String roomId) {
+		return "room:" + roomId + ":messages";
+	}
+
+	private static String versionKey(String roomId) {
+		return "room:" + roomId + ":version";
+	}
+
+	private static String lockKey(String roomId) {
+		return "room:" + roomId + ":lock";
+	}
+
+	private interface JedisCallback<T> {
+		T apply(Jedis jedis);
+	}
+}

--- a/src/prerna/engine/impl/model/RoomMessageStore.java
+++ b/src/prerna/engine/impl/model/RoomMessageStore.java
@@ -1,0 +1,489 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.engine.impl.model;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
+import prerna.engine.impl.model.message.AbstractMessage;
+import prerna.engine.impl.model.message.MessagePart;
+import prerna.engine.impl.model.message.MessageUtils;
+import prerna.engine.impl.model.message.ToolCallMessagePart;
+import prerna.engine.impl.model.message.ToolResultMessagePart;
+import prerna.engine.impl.model.message.ToolResultPart;
+import prerna.redis.RedisConnectionConfig;
+import prerna.redis.RedisConnectionFactory;
+import prerna.util.Utility;
+
+/**
+ * Internal boundary for room-message projection reads/writes.
+ * <p>
+ * The durable source of truth remains {@code modellogs.ROOM.MESSAGES}. Redis is
+ * optional hot coordination/cache and is disabled by default.
+ */
+public final class RoomMessageStore {
+
+	private static final Logger classLogger = LogManager.getLogger(RoomMessageStore.class);
+
+	private static final String REDIS_ENABLED = "ROOM_MESSAGE_STORE_REDIS_ENABLED";
+	private static final String LOCK_TTL_MS = "ROOM_MESSAGE_STORE_LOCK_TTL_MS";
+	private static final String LOCK_WAIT_MS = "ROOM_MESSAGE_STORE_LOCK_WAIT_MS";
+
+	private static final ThreadLocal<Map<String, HeldLock>> HELD_LOCKS = ThreadLocal.withInitial(HashMap::new);
+	private static volatile RoomMessageRedisClient cachedRedisClient;
+	private static volatile String cachedRedisClientKey;
+
+	private RoomMessageStore() {
+	}
+
+	public static List<AbstractMessage> loadFromPersistedJson(Room room, String messagesJson) {
+		String projection = messagesJson;
+		if (projection == null || projection.trim().isEmpty()) {
+			return new ArrayList<>();
+		}
+		List<AbstractMessage> loaded = MessageUtils.fromJsonArrayPreservingToolState(projection, room);
+		List<AbstractMessage> messages = loaded != null ? loaded : new ArrayList<>();
+		validateForPersistence(room, messages);
+		warmRedisProjection(room, projection);
+		return messages;
+	}
+
+	public static void refreshFromStore(Room room, String userId) {
+		if (room == null || room.getId() == null || userId == null || !isRedisEnabled()) {
+			return;
+		}
+		Room persistedRoom = ModelInferenceLogsUtils.getRoomById(room.getId(), userId);
+		if (persistedRoom == null) {
+			return;
+		}
+		String persistedJson = persistedRoom.getMessageJson();
+		List<AbstractMessage> messages = loadFromPersistedJson(room, persistedJson);
+		room.setMessages(messages);
+		room.setMessagesJson(persistedJson);
+		if (room.getRoomName() == null || room.getRoomName().trim().isEmpty()) {
+			room.setRoomName(persistedRoom.getRoomName());
+		}
+		if (room.getModelId() == null || room.getModelId().trim().isEmpty()) {
+			room.setModelId(persistedRoom.getModelId());
+		}
+	}
+
+	public static void refreshFromLatestProjection(Room room, String userId) {
+		if (room == null || room.getId() == null || userId == null || !isRedisEnabled()) {
+			return;
+		}
+		if (!refreshFromHotProjection(room)) {
+			refreshFromStore(room, userId);
+		}
+	}
+
+	public static boolean refreshFromHotProjection(Room room) {
+		if (room == null || room.getId() == null || !isRedisEnabled()) {
+			return false;
+		}
+		try {
+			String projection = redisClient().getMessages(room.getId());
+			if (projection == null || projection.trim().isEmpty()) {
+				return false;
+			}
+			List<AbstractMessage> loaded = MessageUtils.fromJsonArrayPreservingToolState(projection, room);
+			List<AbstractMessage> messages = loaded != null ? loaded : new ArrayList<>();
+			validateForPersistence(room, messages);
+			room.setMessages(messages);
+			room.setMessagesJson(projection);
+			return true;
+		} catch (Exception e) {
+			classLogger.warn("Failed to refresh Redis room-message projection for room={}", room.getId(), e);
+			return false;
+		}
+	}
+
+	public static String messageHistoryWithNewMessage(Room room, AbstractMessage newMessage) {
+		List<AbstractMessage> branch = MessageUtils.getMessageBranchWithNewMessage(room.getMessages(), newMessage);
+		validateProviderPayload(room, branch);
+		return MessageUtils.toJsonArrayWithImageData(branch);
+	}
+
+	public static String currentMessageHistory(Room room) {
+		List<AbstractMessage> branch = MessageUtils.getMessageBranchWithNewMessage(room.getMessages(), null);
+		validateProviderPayload(room, branch);
+		return MessageUtils.toJsonArrayWithImageData(branch);
+	}
+
+	public static String providerMessageHistory(Room room, List<AbstractMessage> messages) {
+		validateProviderPayload(room, messages);
+		return MessageUtils.toJsonArrayWithImageData(messages);
+	}
+
+	public static void normalizeForProviderPayload(Room room) {
+		List<AbstractMessage> messages = room.getMessages();
+		List<AbstractMessage> sanitized = MessageUtils.sanitizeOrphanToolCalls(messages, room);
+		if (sanitized != messages) {
+			room.setMessages(sanitized);
+		}
+		validateForPersistence(room, room.getMessages());
+	}
+
+	public static boolean persist(Room room, String userId) {
+		try (RoomMutationLock ignored = acquireMutationLock(room)) {
+			String messageHistory = room.getMessagesAsString();
+			validateSerializedProjection(room, messageHistory);
+			boolean updated = ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(), userId, messageHistory);
+			updateRedisProjection(room, messageHistory);
+			return updated;
+		}
+	}
+
+	public static boolean persist(Room room, String userId, String roomName, String engineId) {
+		try (RoomMutationLock ignored = acquireMutationLock(room)) {
+			String messageHistory = room.getMessagesAsString();
+			validateSerializedProjection(room, messageHistory);
+			boolean updated = ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(), userId, messageHistory,
+					roomName, engineId);
+			updateRedisProjection(room, messageHistory);
+			return updated;
+		}
+	}
+
+	public static RoomMutationLock acquireMutationLock(Room room) {
+		if (room == null) {
+			return RoomMutationLock.NO_OP;
+		}
+		return acquireMutationLock(room.getId());
+	}
+
+	public static RoomMutationLock acquireMutationLock(String roomId) {
+		if (roomId == null || roomId.trim().isEmpty() || !isRedisEnabled()) {
+			return RoomMutationLock.NO_OP;
+		}
+		roomId = roomId.trim();
+		Map<String, HeldLock> heldLocks = HELD_LOCKS.get();
+		HeldLock held = heldLocks.get(roomId);
+		if (held != null) {
+			held.count++;
+			return new RoomMutationLock(roomId, held, false);
+		}
+
+		RoomMessageRedisClient redis = redisClient();
+		String token = UUID.randomUUID().toString();
+		long ttlMs = getLongProperty(LOCK_TTL_MS, 300000L);
+		long waitMs = getLongProperty(LOCK_WAIT_MS, 5000L);
+		long deadline = System.currentTimeMillis() + Math.max(0L, waitMs);
+		do {
+			if (redis.tryAcquireLock(roomId, token, ttlMs)) {
+				HeldLock newLock = new HeldLock(redis, roomId, token, ttlMs);
+				heldLocks.put(roomId, newLock);
+				newLock.startRenewal();
+				return new RoomMutationLock(roomId, newLock, true);
+			}
+			sleepQuietly(100L);
+		} while (System.currentTimeMillis() < deadline);
+
+		throw new IllegalStateException("Room is busy; another request is updating room messages. Please retry.");
+	}
+
+	private static void validateSerializedProjection(Room room, String messageHistory) {
+		List<AbstractMessage> parsed = parseWithoutSanitizing(room, messageHistory);
+		validateForPersistence(room, parsed);
+	}
+
+	private static void validateForPersistence(Room room, List<AbstractMessage> messages) {
+		if (messages == null || messages.isEmpty()) {
+			return;
+		}
+		Set<String> messageIds = new HashSet<>();
+		for (AbstractMessage message : messages) {
+			if (message == null) {
+				throw new IllegalStateException("Room message list contains a null message.");
+			}
+			String messageId = trimToNull(message.getMessageId());
+			if (messageId == null) {
+				throw new IllegalStateException("Room message list contains a message without a messageId.");
+			}
+			if (!messageIds.add(messageId)) {
+				throw new IllegalStateException("Room message list contains duplicate messageId: " + messageId);
+			}
+		}
+		for (AbstractMessage message : messages) {
+			String parentMessageId = trimToNull(message.getParentMessageId());
+			if (parentMessageId == null) {
+				continue;
+			}
+			if (parentMessageId.equals(message.getMessageId())) {
+				throw new IllegalStateException("Room message cannot be its own parent: " + parentMessageId);
+			}
+			if (!messageIds.contains(parentMessageId)) {
+				String roomId = room != null ? room.getId() : "<unknown>";
+				throw new IllegalStateException("Room " + roomId + " message parent does not exist: "
+						+ parentMessageId);
+			}
+		}
+	}
+
+	private static void validateProviderPayload(Room room, List<AbstractMessage> messages) {
+		validateForPersistence(room, messages);
+
+		Set<String> toolCallIds = new HashSet<>();
+		Set<String> toolResultIds = new HashSet<>();
+		for (AbstractMessage message : messages) {
+			for (MessagePart part : message.getParts()) {
+				if (part instanceof ToolCallMessagePart) {
+					String toolCallId = toolCallId((ToolCallMessagePart) part);
+					if (toolCallId != null) {
+						toolCallIds.add(toolCallId);
+					}
+				} else if (part instanceof ToolResultMessagePart) {
+					String toolResultId = toolResultId((ToolResultMessagePart) part);
+					if (toolResultId != null) {
+						toolResultIds.add(toolResultId);
+					}
+				}
+			}
+		}
+
+		if (!toolCallIds.containsAll(toolResultIds)) {
+			Set<String> unmatched = new HashSet<>(toolResultIds);
+			unmatched.removeAll(toolCallIds);
+			throw new IllegalStateException("Room message payload contains tool results without tool calls: "
+					+ unmatched);
+		}
+		if (!toolResultIds.containsAll(toolCallIds)) {
+			Set<String> unmatched = new HashSet<>(toolCallIds);
+			unmatched.removeAll(toolResultIds);
+			throw new IllegalStateException("Room message payload contains unresolved tool calls: " + unmatched);
+		}
+	}
+
+	private static List<AbstractMessage> parseWithoutSanitizing(Room room, String jsonArrayString) {
+		if (jsonArrayString == null || jsonArrayString.trim().isEmpty()) {
+			return new ArrayList<>();
+		}
+		JsonArray array = JsonParser.parseString(jsonArrayString).getAsJsonArray();
+		List<AbstractMessage> result = new ArrayList<>();
+		for (JsonElement element : array) {
+			AbstractMessage message = MessageUtils.fromJson(element.toString(), room);
+			if (message != null) {
+				result.add(message);
+			}
+		}
+		return result;
+	}
+
+	private static String toolCallId(ToolCallMessagePart part) {
+		Map<String, Object> toolCall = part.getToolCall();
+		if (toolCall == null) {
+			return null;
+		}
+		return trimToNull(String.valueOf(toolCall.get("id")));
+	}
+
+	private static String toolResultId(ToolResultMessagePart part) {
+		ToolResultPart result = part.getToolResult();
+		return result == null ? null : trimToNull(result.getToolCallId());
+	}
+
+	private static String trimToNull(String value) {
+		if (value == null) {
+			return null;
+		}
+		String trimmed = value.trim();
+		return trimmed.isEmpty() ? null : trimmed;
+	}
+
+	private static void warmRedisProjection(Room room, String messageHistory) {
+		if (room == null || room.getId() == null || !isRedisEnabled()) {
+			return;
+		}
+		try {
+			RoomMessageRedisClient redis = redisClient();
+			if (redis.getMessages(room.getId()) == null) {
+				redis.setMessages(room.getId(), messageHistory);
+				redis.incrementVersion(room.getId());
+			}
+		} catch (Exception e) {
+			classLogger.warn("Failed to warm Redis room-message projection for room={}", room.getId(), e);
+		}
+	}
+
+	private static void updateRedisProjection(Room room, String messageHistory) {
+		if (room == null || room.getId() == null || !isRedisEnabled()) {
+			return;
+		}
+		try {
+			RoomMessageRedisClient redis = redisClient();
+			redis.setMessages(room.getId(), messageHistory);
+			redis.incrementVersion(room.getId());
+		} catch (Exception e) {
+			classLogger.warn("Failed to update Redis room-message projection for room={}", room.getId(), e);
+			invalidateRedisProjection(room);
+		}
+	}
+
+	private static void invalidateRedisProjection(Room room) {
+		if (room == null || room.getId() == null || !isRedisEnabled()) {
+			return;
+		}
+		try {
+			redisClient().deleteMessages(room.getId());
+		} catch (Exception e) {
+			classLogger.warn("Failed to invalidate Redis room-message projection for room={}", room.getId(), e);
+		}
+	}
+
+	public static boolean isRedisEnabled() {
+		return Boolean.parseBoolean(String.valueOf(Utility.getDIHelperProperty(REDIS_ENABLED)));
+	}
+
+	public static RoomMessageRedisClient redisClient() {
+		RedisConnectionConfig config = RedisConnectionConfig.fromDIHelper();
+		String cacheKey = config.cacheKey();
+		RoomMessageRedisClient client = cachedRedisClient;
+		if (client != null && cacheKey.equals(cachedRedisClientKey)) {
+			return client;
+		}
+		synchronized (RoomMessageStore.class) {
+			client = cachedRedisClient;
+			if (client != null && cacheKey.equals(cachedRedisClientKey)) {
+				return client;
+			}
+			RoomMessageRedisClient next = new RoomMessageRedisClient(RedisConnectionFactory.getPool(config));
+			cachedRedisClient = next;
+			cachedRedisClientKey = cacheKey;
+			return next;
+		}
+	}
+
+	private static long getLongProperty(String key, long defaultValue) {
+		String value = Utility.getDIHelperProperty(key);
+		if (value == null || value.trim().isEmpty()) {
+			return defaultValue;
+		}
+		try {
+			return Long.parseLong(value.trim());
+		} catch (NumberFormatException e) {
+			return defaultValue;
+		}
+	}
+
+	private static void sleepQuietly(long millis) {
+		try {
+			Thread.sleep(millis);
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+		}
+	}
+
+	public static final class RoomMutationLock implements AutoCloseable {
+		private static final RoomMutationLock NO_OP = new RoomMutationLock(null, null, false);
+
+		private final String roomId;
+		private final HeldLock heldLock;
+		private final boolean owner;
+		private boolean closed;
+
+		private RoomMutationLock(String roomId, HeldLock heldLock, boolean owner) {
+			this.roomId = roomId;
+			this.heldLock = heldLock;
+			this.owner = owner;
+		}
+
+		@Override
+		public void close() {
+			if (closed || heldLock == null || roomId == null) {
+				return;
+			}
+			closed = true;
+			Map<String, HeldLock> heldLocks = HELD_LOCKS.get();
+			heldLock.count--;
+			if (heldLock.count > 0) {
+				return;
+			}
+			heldLocks.remove(roomId);
+			if (heldLocks.isEmpty()) {
+				HELD_LOCKS.remove();
+			}
+			if (owner) {
+				heldLock.close();
+			}
+		}
+	}
+
+	private static final class HeldLock implements Closeable {
+		private final RoomMessageRedisClient redis;
+		private final String roomId;
+		private final String token;
+		private final long ttlMs;
+		private volatile boolean closed;
+		private int count = 1;
+		private Thread renewalThread;
+
+		private HeldLock(RoomMessageRedisClient redis, String roomId, String token, long ttlMs) {
+			this.redis = redis;
+			this.roomId = roomId;
+			this.token = token;
+			this.ttlMs = ttlMs;
+		}
+
+		private void startRenewal() {
+			if (ttlMs <= 0L) {
+				return;
+			}
+			renewalThread = new Thread(() -> {
+				long sleepMs = Math.max(1000L, ttlMs / 3L);
+				while (!closed) {
+					sleepQuietly(sleepMs);
+					if (!closed) {
+						redis.renewLock(roomId, token, ttlMs);
+					}
+				}
+			}, "room-message-lock-renewal");
+			renewalThread.setDaemon(true);
+			renewalThread.start();
+		}
+
+		@Override
+		public void close() {
+			closed = true;
+			redis.releaseLock(roomId, token);
+		}
+	}
+}

--- a/src/prerna/engine/impl/model/RoomUtils.java
+++ b/src/prerna/engine/impl/model/RoomUtils.java
@@ -121,55 +121,52 @@ public final class RoomUtils {
 			roomId = insight.getInsightId();
 		}
 
-		boolean roomExistsInDB = ModelInferenceLogsUtils.doCheckRoomExists(roomId);
-		if (!roomExistsInDB) {
-			String agentType = null;
-			String engineId = null;
-			if (modelEngine != null) {
-				agentType = modelEngine.getCatalogSubType(modelEngine.getSmssProp());
-				engineId = modelEngine.getEngineId();
+		try (RoomMessageStore.RoomMutationLock ignored = RoomMessageStore.acquireMutationLock(roomId)) {
+			boolean roomExistsInDB = ModelInferenceLogsUtils.doCheckRoomExists(roomId);
+			if (!roomExistsInDB) {
+				String agentType = null;
+				String engineId = null;
+				if (modelEngine != null) {
+					agentType = modelEngine.getCatalogSubType(modelEngine.getSmssProp());
+					engineId = modelEngine.getEngineId();
+				}
+				User user = insight.getUser();
+				AccessToken userToken = user.getPrimaryLoginToken();
+				String userName = userToken.getName();
+				String userEmail = userToken.getEmail();
+				if (projectId == null) {
+					projectId = insight.getContextProjectId();
+				}
+				if (projectId == null) {
+					projectId = insight.getProjectId();
+				}
+				String projectName = null;
+				// ignore playground project id
+				if (projectId != null && !projectId.equals(PlaygroundUtils.PLAYGROUND_PROJECT_ID)) {
+					IProject project = Utility.getProject(projectId);
+					projectName = project != null ? project.getProjectName() : null;
+				}
+				String roomName = (question != null) ? question.substring(0, Math.min(question.length(), 100)) : null;
+				// @formatter:off
+				ModelInferenceLogsUtils.doCreateNewConversation(
+						insight.getInsightId(),
+						roomId,
+						roomName,
+						context,
+						userToken.getId(),
+						userName,
+						userEmail,
+						agentType,
+						engineId,
+						true,
+						projectId,
+						projectName,
+						workspaceId,
+						options,
+						parentRoomId
+				);
+				// @formatter:on
 			}
-			User user = insight.getUser();
-			AccessToken userToken = user.getPrimaryLoginToken();
-			String userName = userToken.getName();
-			String userEmail = userToken.getEmail();
-			if (projectId == null) {
-				projectId = insight.getContextProjectId();
-			}
-			if (projectId == null) {
-				projectId = insight.getProjectId();
-			}
-			String projectName = null;
-			// ignore playground project id
-			if (projectId != null && !projectId.equals(PlaygroundUtils.PLAYGROUND_PROJECT_ID)) {
-				IProject project = Utility.getProject(projectId);
-				projectName = project != null ? project.getProjectName() : null;
-			}
-			String roomName = (question != null) ? question.substring(0, Math.min(question.length(), 100)) : null;
-			// @formatter:off
-            ModelInferenceLogsUtils.doCreateNewConversation(
-            		insight.getInsightId(),
-                    roomId,
-                    roomName,
-                    context,
-                    userToken.getId(),
-                    userName,
-                    userEmail,
-                    agentType,
-                    engineId,
-                    true,
-                    projectId,
-                    projectName,
-                    workspaceId,
-                    options,
-                    parentRoomId
-            );
-    		// @formatter:on
-
-			// Always get the loaded room object (avoiding any skipping, ensures in-memory
-			// cache is filled)
-			return RoomUtils.getOrLoadRoom(roomId, insight);
-		} else {
 			return RoomUtils.getOrLoadRoom(roomId, insight);
 		}
 	}
@@ -188,6 +185,7 @@ public final class RoomUtils {
 		if (insight.getUser().getRoomHash().containsKey(roomId)) {
 			try {
 				room = (Room) insight.getUser().getRoomHash().get(roomId);
+				refreshCachedRoomMessagesIfRedisEnabled(room, insight);
 				ensureRoomMessagesUpToDate(room, insight);
 				symlinkRoomFolderIfNeeded(room, insight);
 				return room;
@@ -227,6 +225,13 @@ public final class RoomUtils {
 		insight.getUser().getRoomHash().put(roomId, room);
 		symlinkRoomFolderIfNeeded(room, insight);
 		return room;
+	}
+
+	private static void refreshCachedRoomMessagesIfRedisEnabled(Room room, Insight insight) {
+		if (room == null || insight == null || insight.getUser() == null || !RoomMessageStore.isRedisEnabled()) {
+			return;
+		}
+		RoomMessageStore.refreshFromLatestProjection(room, insight.getUser().getPrimaryLoginToken().getId());
 	}
 
 	/**
@@ -310,8 +315,7 @@ public final class RoomUtils {
 		if (!changed && upgraded.equals(json)) {
 			return;
 		}
-		ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(), insight.getUser().getPrimaryLoginToken().getId(),
-				upgraded);
+		RoomMessageStore.persist(room, insight.getUser().getPrimaryLoginToken().getId());
 	}
 
 	/**
@@ -336,9 +340,7 @@ public final class RoomUtils {
 
 		// set and persist the normalized messages in one pass
 		room.setMessages(messages);
-		String messageJson = room.getMessagesAsString();
-		ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(), insight.getUser().getPrimaryLoginToken().getId(),
-				messageJson);
+		RoomMessageStore.persist(room, insight.getUser().getPrimaryLoginToken().getId());
 	}
 
 	/**

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/SubmitLlmFeedbackReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/SubmitLlmFeedbackReactor.java
@@ -32,6 +32,7 @@ import java.util.List;
 import prerna.auth.User;
 import prerna.engine.impl.model.MessageFeedback;
 import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.RoomMessageStore;
 import prerna.engine.impl.model.RoomUtils;
 import prerna.engine.impl.model.message.MessageIO;
 import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
@@ -110,9 +111,7 @@ public class SubmitLlmFeedbackReactor extends AbstractReactor {
 			}
 
 			// Flush messages to db
-			ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(),
-					insight.getUser().getPrimaryLoginToken().getId(),
-					room.getMessagesAsString());
+			RoomMessageStore.persist(room, insight.getUser().getPrimaryLoginToken().getId());
 
 			// Now can add to the feedback table. If neither true or false was parsed,
 			// remove from db

--- a/src/prerna/engine/impl/model/message/MessageUtils.java
+++ b/src/prerna/engine/impl/model/message/MessageUtils.java
@@ -335,6 +335,21 @@ public class MessageUtils {
 	 * @return ordered list of deserialized messages
 	 */
 	public static List<AbstractMessage> fromJsonArray(String jsonArrayString, Room room) {
+		List<AbstractMessage> result = fromJsonArrayPreservingToolState(jsonArrayString, room);
+		// drop orphan tool_use (cancel mid-tool, crash) so the next turn doesn't get rejected by the provider
+		return sanitizeOrphanToolCalls(result, room);
+	}
+
+	/**
+	 * Deserializes a JSON array of messages without trimming unresolved tool-call
+	 * state. Use this for room projection storage/hydration where a tool batch may
+	 * be partially persisted while parallel tool executions are still completing.
+	 *
+	 * @param jsonArrayString message-array JSON
+	 * @param room            room context used during message parsing
+	 * @return ordered list of deserialized messages
+	 */
+	public static List<AbstractMessage> fromJsonArrayPreservingToolState(String jsonArrayString, Room room) {
 		if (jsonArrayString == null || jsonArrayString.trim().isEmpty()) {
 			return new ArrayList<>();
 		}
@@ -346,8 +361,7 @@ public class MessageUtils {
 				result.add(message);
 			}
 		}
-		// drop orphan tool_use (cancel mid-tool, crash) so the next turn doesn't get rejected by the provider
-		return sanitizeOrphanToolCalls(result, room);
+		return result;
 	}
 
 	/**

--- a/src/prerna/playground/reactors/AddCOTLLMReasoningReactor.java
+++ b/src/prerna/playground/reactors/AddCOTLLMReasoningReactor.java
@@ -34,8 +34,8 @@ import java.util.Map;
 
 import prerna.engine.api.IModelEngine;
 import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.RoomMessageStore;
 import prerna.engine.impl.model.RoomUtils;
-import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.engine.impl.model.message.AbstractMessage;
 import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.message.MessageType;
@@ -94,8 +94,7 @@ public class AddCOTLLMReasoningReactor extends AbstractReactor {
 		// parse the response for code blocks
 		// this should only be response text
 		if (response.getMessageType() == MessageType.RESPONSE_TEXT) {
-			ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(),
-					insight.getUser().getPrimaryLoginToken().getId(), room.getMessagesAsString());
+			RoomMessageStore.persist(room, insight.getUser().getPrimaryLoginToken().getId());
 		} else if (response.getMessageType() == MessageType.RESPONSE_TOOL) {
 			room.updateToolResponseMeta(response);
 		}

--- a/src/prerna/playground/reactors/AddCOTToolExecutionReactor.java
+++ b/src/prerna/playground/reactors/AddCOTToolExecutionReactor.java
@@ -35,6 +35,7 @@ import prerna.auth.User;
 import prerna.auth.utils.SecurityEngineUtils;
 import prerna.engine.api.IModelEngine;
 import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.RoomMessageStore;
 import prerna.engine.impl.model.RoomUtils;
 import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.engine.impl.model.message.AbstractMessage;
@@ -132,8 +133,7 @@ public class AddCOTToolExecutionReactor extends AbstractReactor {
 		pixelReturn.put("toolExecution", jsonToMap(MessageUtils.toJson(toolExecutionMessage)));
 		pixelReturn.put("toolResponse", jsonToMap(MessageUtils.toJson(toolAcknowledgedMessage)));
 
-		ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(), insight.getUser().getPrimaryLoginToken().getId(),
-				room.getMessagesAsString());
+		RoomMessageStore.persist(room, insight.getUser().getPrimaryLoginToken().getId());
 
 		return new NounMetadata(pixelReturn, PixelDataType.MAP);
 	}

--- a/src/prerna/playground/reactors/AddPlaygroundToolExecutionReactor.java
+++ b/src/prerna/playground/reactors/AddPlaygroundToolExecutionReactor.java
@@ -39,6 +39,7 @@ import prerna.auth.utils.SecurityEngineUtils;
 import prerna.cluster.util.ClusterUtil;
 import prerna.engine.api.IModelEngine;
 import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.RoomMessageStore;
 import prerna.engine.impl.model.RoomUtils;
 import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.engine.impl.model.message.AbstractMessage;
@@ -136,8 +137,7 @@ public class AddPlaygroundToolExecutionReactor extends AbstractReactor {
 				AbstractMessage inputMessage = room.getMessages().get(room.getMessages().size() - 2);
 				ResponseMessage lastMessage = (ResponseMessage) room.getMessages().getLast();
 				if (lastMessage.getMessageType() == MessageType.RESPONSE_TEXT) {
-					ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(),
-							insight.getUser().getPrimaryLoginToken().getId(), room.getMessagesAsString());
+					RoomMessageStore.persist(room, insight.getUser().getPrimaryLoginToken().getId());
 				} else if (lastMessage.getMessageType() == MessageType.RESPONSE_TOOL) {
 					room.updateToolResponseMeta(lastMessage);
 				}

--- a/src/prerna/playground/reactors/AskPlaygroundReactor.java
+++ b/src/prerna/playground/reactors/AskPlaygroundReactor.java
@@ -40,8 +40,8 @@ import prerna.auth.User;
 import prerna.auth.utils.SecurityEngineUtils;
 import prerna.engine.api.IModelEngine;
 import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.RoomMessageStore;
 import prerna.engine.impl.model.RoomUtils;
-import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.message.MessageType;
 import prerna.engine.impl.model.message.MessageUtils;
@@ -113,8 +113,7 @@ public class AskPlaygroundReactor extends AbstractReactor {
 
 		// parse the response for code blocks
 		if (response.getMessageType() == MessageType.RESPONSE_TEXT) {
-			ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(),
-					insight.getUser().getPrimaryLoginToken().getId(), room.getMessagesAsString());
+			RoomMessageStore.persist(room, insight.getUser().getPrimaryLoginToken().getId());
 		} else if (response.getMessageType() == MessageType.RESPONSE_TOOL) {
 			room.updateToolResponseMeta(response);
 		}

--- a/src/prerna/playground/reactors/COTRoomResultReactor.java
+++ b/src/prerna/playground/reactors/COTRoomResultReactor.java
@@ -35,8 +35,8 @@ import prerna.auth.User;
 import prerna.auth.utils.SecurityEngineUtils;
 import prerna.engine.api.IModelEngine;
 import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.RoomMessageStore;
 import prerna.engine.impl.model.RoomUtils;
-import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.message.MessageType;
 import prerna.engine.impl.model.message.MessageUtils;
@@ -87,8 +87,7 @@ public class COTRoomResultReactor extends AbstractReactor {
 		// parse the response for code blocks
 		// this should only be response text
 		if (response.getMessageType() == MessageType.RESPONSE_TEXT) {
-			ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(),
-					insight.getUser().getPrimaryLoginToken().getId(), room.getMessagesAsString());
+			RoomMessageStore.persist(room, insight.getUser().getPrimaryLoginToken().getId());
 		} else if (response.getMessageType() == MessageType.RESPONSE_TOOL) {
 			room.updateToolResponseMeta(response);
 		}

--- a/src/prerna/playground/reactors/COTToolPredictionReactor.java
+++ b/src/prerna/playground/reactors/COTToolPredictionReactor.java
@@ -34,8 +34,8 @@ import java.util.Map;
 
 import prerna.engine.api.IModelEngine;
 import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.RoomMessageStore;
 import prerna.engine.impl.model.RoomUtils;
-import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.engine.impl.model.message.AbstractMessage;
 import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.message.MessageType;
@@ -93,8 +93,7 @@ public class COTToolPredictionReactor extends AbstractReactor {
 		// parse the response for code blocks
 		// this should really only be a response tool ...
 		if (response.getMessageType() == MessageType.RESPONSE_TEXT) {
-			ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(),
-					insight.getUser().getPrimaryLoginToken().getId(), room.getMessagesAsString());
+			RoomMessageStore.persist(room, insight.getUser().getPrimaryLoginToken().getId());
 		} else if (response.getMessageType() == MessageType.RESPONSE_TOOL) {
 			room.updateToolResponseMeta(response);
 		}

--- a/src/prerna/reactor/model/CompactRoomMessagesReactor.java
+++ b/src/prerna/reactor/model/CompactRoomMessagesReactor.java
@@ -42,8 +42,8 @@ import prerna.auth.User;
 import prerna.auth.utils.SecurityEngineUtils;
 import prerna.engine.api.IModelEngine;
 import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.RoomMessageStore;
 import prerna.engine.impl.model.RoomUtils;
-import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.engine.impl.model.message.AbstractMessage;
 import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.message.MessagePart;
@@ -259,8 +259,7 @@ public class CompactRoomMessagesReactor extends AbstractReactor {
 		messages.add(toolPruneResponse);
 
 		try {
-			ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(),
-					this.insight.getUser().getPrimaryLoginToken().getId(), room.getMessagesAsString());
+			RoomMessageStore.persist(room, this.insight.getUser().getPrimaryLoginToken().getId());
 		} catch (Exception e) {
 			// Roll back the in-memory mutations so the cached Room stays in sync with the
 			// DB.
@@ -427,8 +426,7 @@ public class CompactRoomMessagesReactor extends AbstractReactor {
 		messages.add(compactedResponse);
 
 		try {
-			ModelInferenceLogsUtils.llm2_updateRoomMessages(room.getId(),
-					this.insight.getUser().getPrimaryLoginToken().getId(), room.getMessagesAsString());
+			RoomMessageStore.persist(room, this.insight.getUser().getPrimaryLoginToken().getId());
 		} catch (Exception e) {
 			// Roll back the in-memory mutations so the cached Room stays in sync with the
 			// DB.

--- a/src/prerna/redis/RedisConnectionConfig.java
+++ b/src/prerna/redis/RedisConnectionConfig.java
@@ -1,0 +1,120 @@
+package prerna.redis;
+
+import prerna.util.Utility;
+
+/**
+ * Shared Redis connection settings resolved from DI/RDF properties.
+ */
+public final class RedisConnectionConfig {
+
+	public static final String REDIS_HOST = "REDIS_HOST";
+	public static final String REDIS_PORT = "REDIS_PORT";
+	public static final String REDIS_PASSWORD = "REDIS_PASSWORD";
+	public static final String REDIS_TIMEOUT_MS = "REDIS_TIMEOUT_MS";
+	public static final String REDIS_POOL_MAX_TOTAL = "REDIS_POOL_MAX_TOTAL";
+	public static final String REDIS_POOL_MAX_IDLE = "REDIS_POOL_MAX_IDLE";
+	public static final String REDIS_POOL_MIN_IDLE = "REDIS_POOL_MIN_IDLE";
+
+	private final String host;
+	private final int port;
+	private final String password;
+	private final int timeoutMs;
+	private final int poolMaxTotal;
+	private final int poolMaxIdle;
+	private final int poolMinIdle;
+
+	private RedisConnectionConfig(String host, int port, String password, int timeoutMs,
+			int poolMaxTotal, int poolMaxIdle, int poolMinIdle) {
+		this.host = host;
+		this.port = port;
+		this.password = password;
+		this.timeoutMs = timeoutMs;
+		this.poolMaxTotal = poolMaxTotal;
+		this.poolMaxIdle = poolMaxIdle;
+		this.poolMinIdle = poolMinIdle;
+	}
+
+	public static RedisConnectionConfig fromDIHelper() {
+		String host = trimToNull(property(REDIS_HOST));
+		if (host == null) {
+			host = "localhost";
+		}
+		int port = (int) getLongProperty(REDIS_PORT, 6379L);
+		int timeoutMs = (int) getLongProperty(REDIS_TIMEOUT_MS, 2000L);
+		String password = trimToNull(property(REDIS_PASSWORD));
+		int poolMaxTotal = Math.max(1,
+				(int) getLongProperty(REDIS_POOL_MAX_TOTAL, 64L));
+		int poolMaxIdle = Math.max(1,
+				(int) getLongProperty(REDIS_POOL_MAX_IDLE, 16L));
+		poolMaxIdle = Math.min(poolMaxIdle, poolMaxTotal);
+		int poolMinIdle = Math.max(0,
+				(int) getLongProperty(REDIS_POOL_MIN_IDLE, 1L));
+		poolMinIdle = Math.min(poolMinIdle, poolMaxIdle);
+		return new RedisConnectionConfig(host.trim(), port, password, timeoutMs,
+				poolMaxTotal, poolMaxIdle, poolMinIdle);
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public int getPort() {
+		return port;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public int getTimeoutMs() {
+		return timeoutMs;
+	}
+
+	public int getPoolMaxTotal() {
+		return poolMaxTotal;
+	}
+
+	public int getPoolMaxIdle() {
+		return poolMaxIdle;
+	}
+
+	public int getPoolMinIdle() {
+		return poolMinIdle;
+	}
+
+	public String cacheKey() {
+		return host + "|" + port + "|" + timeoutMs + "|" + nullToEmpty(password)
+				+ "|" + poolMaxTotal + "|" + poolMaxIdle + "|" + poolMinIdle;
+	}
+
+	private static long getLongProperty(String key, long defaultValue) {
+		String value = trimToNull(property(key));
+		if (value == null) {
+			return defaultValue;
+		}
+		try {
+			return Long.parseLong(value.trim());
+		} catch (NumberFormatException e) {
+			return defaultValue;
+		}
+	}
+
+	private static String property(String key) {
+		if (key == null || key.trim().isEmpty()) {
+			return null;
+		}
+		return Utility.getDIHelperProperty(key);
+	}
+
+	private static String trimToNull(String value) {
+		if (value == null) {
+			return null;
+		}
+		String trimmed = value.trim();
+		return trimmed.isEmpty() ? null : trimmed;
+	}
+
+	private static String nullToEmpty(String value) {
+		return value == null ? "" : value;
+	}
+}

--- a/src/prerna/redis/RedisConnectionFactory.java
+++ b/src/prerna/redis/RedisConnectionFactory.java
@@ -1,0 +1,40 @@
+package prerna.redis;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.JedisPoolConfig;
+
+/**
+ * Shared Redis pool factory for SEMOSS features that need Redis coordination.
+ */
+public final class RedisConnectionFactory {
+
+	private static final ConcurrentMap<String, JedisPool> POOLS = new ConcurrentHashMap<>();
+
+	private RedisConnectionFactory() {
+	}
+
+	public static JedisPool getPool() {
+		return getPool(RedisConnectionConfig.fromDIHelper());
+	}
+
+	public static JedisPool getPool(RedisConnectionConfig config) {
+		return POOLS.computeIfAbsent(config.cacheKey(), ignored -> createPool(config));
+	}
+
+	private static JedisPool createPool(RedisConnectionConfig config) {
+		JedisPoolConfig poolConfig = new JedisPoolConfig();
+		poolConfig.setMaxTotal(config.getPoolMaxTotal());
+		poolConfig.setMaxIdle(config.getPoolMaxIdle());
+		poolConfig.setMinIdle(config.getPoolMinIdle());
+		poolConfig.setTestOnBorrow(true);
+		poolConfig.setTestWhileIdle(true);
+		String password = config.getPassword();
+		if (password != null && !password.trim().isEmpty()) {
+			return new JedisPool(poolConfig, config.getHost(), config.getPort(), config.getTimeoutMs(), password);
+		}
+		return new JedisPool(poolConfig, config.getHost(), config.getPort(), config.getTimeoutMs());
+	}
+}


### PR DESCRIPTION
## Description

Adds a DB-first `RoomMessageStore` boundary around `modellogs.ROOM.MESSAGES` and optional Redis coordination for room-message mutation.

The durable source of truth is still the DB `ROOM.MESSAGES` column. Redis is used as a hot projection/cache and distributed room mutation lock when enabled. This PR is intentionally limited to room/message locking and does **not** include the AgentRun table, async `RunAgent` queueing, MCP HITL pause/resume, or new public agent lifecycle APIs.

## Changes Made

- Adds `RoomMessageStore` as the internal hydrate/validate/persist path for room message projections.
- Adds a narrow `RoomMessageRedisClient` backed by `JedisPool`.
- Adds shared Redis connection config classes under `prerna.redis` so Redis connection settings are not room-specific.
- Refreshes cached `RoomUtils.getOrLoadRoom(...)` hits from the Redis hot projection when Redis is enabled, with DB fallback when the Redis projection is missing or invalid.
- Refreshes mutation paths from the Redis hot projection first, with DB fallback, so normal Redis-enabled room writes avoid an extra JDBC room read.
- Invalidates the Redis message projection if a Redis projection update fails, so later refreshes fall back to DB instead of trusting stale hot cache data.
- Routes room-message write paths through the store:
  - `Room.ask(...)`
  - `Room.addToolExecutionResult(...)`
  - `RoomUtils` room create/load/upgrade persistence
  - `AbstractModelEngine` full-prompt room persistence
  - playground/COT/feedback/compact-room persistence paths
- Adds provider-safety validation before persistence/model payload use:
  - message JSON parses back into messages
  - message ids are unique
  - parent ids exist or are null roots
  - unresolved/orphan tool-call states are normalized or rejected before provider payloads
- Redis keys used by this slice:
  - `room:{roomId}:messages`
  - `room:{roomId}:version`
  - `room:{roomId}:lock`

## RDF / Config

Minimal local Redis config:

```properties
ROOM_MESSAGE_STORE_REDIS_ENABLED=true
REDIS_HOST=localhost
REDIS_PORT=6379
```

Full optional config with current defaults:

```properties
# Room-message feature flag. Default: false
ROOM_MESSAGE_STORE_REDIS_ENABLED=false

# Shared Redis connection settings. Defaults shown.
REDIS_HOST=localhost
REDIS_PORT=6379
REDIS_PASSWORD=
REDIS_TIMEOUT_MS=2000
REDIS_POOL_MAX_TOTAL=64
REDIS_POOL_MAX_IDLE=16
REDIS_POOL_MIN_IDLE=1

# Room-message lock behavior. Defaults shown.
ROOM_MESSAGE_STORE_LOCK_TTL_MS=300000
ROOM_MESSAGE_STORE_LOCK_WAIT_MS=5000
```

Notes:

- Redis disabled is still valid for local/dev/single-node use, but it does not provide multi-node room-message safety.
- Production multi-node deployments should set `ROOM_MESSAGE_STORE_REDIS_ENABLED=true`.
- `ROOM_MESSAGE_STORE_LOCK_WAIT_MS` controls how long a same-room writer waits for the Redis lock before returning a busy/retry error.
- `room:{roomId}:version` is a Redis-side projection change counter. It is not the source of locking correctness; `room:{roomId}:lock` is.

## How to Test

Redis disabled:

1. Run regular `LLM2(...)` / `RunAgent(...)` room flows.
2. Confirm sequential same-room calls preserve context.
3. Confirm `GetPlaygroundMessages(roomId)` returns the expected persisted messages.

Redis enabled:

1. Start local Redis, for example `brew services start redis`.
2. Add the minimal RDF properties above.
3. Fire multiple same-room `LLM2(...)` calls concurrently.
4. Confirm successful writes do not corrupt `ROOM.MESSAGES`.
5. Confirm lock contention returns a clear busy/retry error instead of producing invalid provider message state.
6. Confirm a Redis miss hydrates from DB `ROOM.MESSAGES`.
7. Confirm stale Redis projection does not override the DB projection on cold load.
8. Confirm a cached room hit on another node sees Redis-refreshed messages after a different node updates the room.

## Notes

This is the foundation PR. AgentRun durability, same-room `RunAgent` queueing, and human-in-the-loop MCP pause/resume should be separate follow-on PRs built on top of this room-state boundary.
