### PR TITLE
feat: add provider=bedrock-mantle path to OpenAiClient

### DIFF
--- a/docs/engines/model_engines.md
+++ b/docs/engines/model_engines.md
@@ -85,7 +85,7 @@ The Python `OpenAiClient` wraps the standard OpenAI SDK with an httpx auth class
 
 Credentials resolution follows the standard boto3 default chain when `AWS_ACCESS_KEY` / `AWS_SECRET_KEY` are omitted from the .smss: environment variables, `~/.aws/credentials`, AWS SSO, then EC2/ECS/Lambda instance role. Refreshable credentials (EC2 role, assumed role, SSO) auto-renew between requests, so the engine survives credential rotation without restart. `AWS_REGION` similarly falls back to the session's region (env var `AWS_REGION` / `AWS_DEFAULT_REGION` or EC2 instance metadata) if not set in the .smss.
 
-*   **Example SMSS** (Responses API, `openai.gpt-5.4`, explicit long-term keys):
+*   **Example SMSS** (Responses API, `openai.gpt-5.4`):
 
     ```
     #Base Properties
@@ -103,20 +103,6 @@ Credentials resolution follows the standard boto3 default chain when `AWS_ACCESS
     CONTEXT_WINDOW      400000
 
     INIT_MODEL_ENGINE   import genai_client;${VAR_NAME} = genai_client.OpenAiClient(is_azure=False, api_key='unused', model_name='${MODEL}', provider='${PROVIDER}', aws_region='${AWS_REGION}', aws_access_key='${AWS_ACCESS_KEY}', aws_secret_key='${AWS_SECRET_KEY}', chat_type='${CHAT_TYPE}', max_tokens=${MAX_TOKENS}, context_window=${CONTEXT_WINDOW})
-    ```
-
-*   **Example SMSS** (EC2 instance role — no AWS keys in the .smss):
-
-    ```
-    ENGINE_TYPE         prerna.engine.impl.model.BedrockEngine
-    NAME                GPT 5.4 Bedrock (EC2 role)
-    MODEL_TYPE          BEDROCK
-    PROVIDER            bedrock-mantle
-    MODEL               openai.gpt-5.4
-    VAR_NAME            gpt54Model
-    CHAT_TYPE           responses
-
-    INIT_MODEL_ENGINE   import genai_client;${VAR_NAME} = genai_client.OpenAiClient(is_azure=False, api_key='unused', model_name='${MODEL}', provider='${PROVIDER}', chat_type='${CHAT_TYPE}')
     ```
 
 *   **IAM prerequisites on the principal** (IAM user, EC2 role, or assumed role):

--- a/docs/engines/model_engines.md
+++ b/docs/engines/model_engines.md
@@ -79,7 +79,7 @@ To create a new `MODEL` engine for a different provider or a new type of local m
 
 #### OpenAI models on Bedrock (Mantle)
 
-AWS exposes OpenAI models on Bedrock through the OpenAI-compatible "Mantle" endpoint at `https://bedrock-mantle.<region>.api.aws/openai/v1`. The Java engine class is still `prerna.engine.impl.model.BedrockEngine` — the only difference is the `INIT_MODEL_ENGINE` template, which routes to `genai_client.OpenAiClient` with `provider='bedrock-mantle'` instead of `genai_client.AnthropicClient`.
+AWS exposes OpenAI models on Bedrock through the OpenAI-compatible "Mantle" endpoint at `https://bedrock-mantle.<region>.api.aws/openai/v1`. The Java engine class is still `prerna.engine.impl.model.BedrockEngine` — the only difference is the `INIT_MODEL_ENGINE` template, which routes to `genai_client.OpenAiClient` with `provider='bedrock'` instead of `genai_client.AnthropicClient`.
 
 The Python `OpenAiClient` wraps the standard OpenAI SDK with an httpx auth class that SigV4-signs each request. No separate Bedrock API key is required.
 
@@ -92,7 +92,7 @@ Credentials resolution follows the standard boto3 default chain when `AWS_ACCESS
     ENGINE_TYPE         prerna.engine.impl.model.BedrockEngine
     NAME                GPT 5.4 Bedrock
     MODEL_TYPE          BEDROCK
-    PROVIDER            bedrock-mantle
+    PROVIDER            bedrock
     MODEL               openai.gpt-5.4
     AWS_REGION          us-east-2
     AWS_ACCESS_KEY      <access-key>

--- a/docs/engines/model_engines.md
+++ b/docs/engines/model_engines.md
@@ -77,6 +77,37 @@ To create a new `MODEL` engine for a different provider or a new type of local m
     *   `MODEL_ID`: The specific Amazon Bedrock model ARN (e.g., "anthropic.claude-v2", "amazon.titan-embed-text-v1").
     *   `CONTENT_TYPE`, `ACCEPT_TYPE`: Typically "application/json".
 
+#### OpenAI models on Bedrock (Mantle)
+
+AWS exposes OpenAI models on Bedrock through the OpenAI-compatible "Mantle" endpoint at `https://bedrock-mantle.<region>.api.aws/openai/v1`. The Java engine class is still `prerna.engine.impl.model.BedrockEngine` — the only difference is the `INIT_MODEL_ENGINE` template, which routes to `genai_client.OpenAiClient` with `provider='bedrock-mantle'` instead of `genai_client.AnthropicClient`.
+
+The Python `OpenAiClient` wraps the standard OpenAI SDK with an httpx auth class that SigV4-signs each request using the AWS access/secret key. No separate Bedrock API key is required — the long-term IAM credentials handle authentication directly.
+
+*   **Example SMSS** (Responses API, `openai.gpt-5.4`):
+
+    ```
+    #Base Properties
+    ENGINE_TYPE         prerna.engine.impl.model.BedrockEngine
+    NAME                GPT 5.4 Bedrock
+    MODEL_TYPE          BEDROCK
+    PROVIDER            bedrock-mantle
+    MODEL               openai.gpt-5.4
+    AWS_REGION          us-east-2
+    AWS_ACCESS_KEY      <access-key>
+    AWS_SECRET_KEY      <secret-key>
+    VAR_NAME            gpt54Model
+    CHAT_TYPE           responses
+    MAX_TOKENS          4096
+    CONTEXT_WINDOW      400000
+
+    INIT_MODEL_ENGINE   import genai_client;${VAR_NAME} = genai_client.OpenAiClient(is_azure=False, api_key='unused', model_name='${MODEL}', provider='${PROVIDER}', aws_region='${AWS_REGION}', aws_access_key='${AWS_ACCESS_KEY}', aws_secret_key='${AWS_SECRET_KEY}', chat_type='${CHAT_TYPE}', max_tokens=${MAX_TOKENS}, context_window=${CONTEXT_WINDOW})
+    ```
+
+*   **IAM prerequisites on the principal**:
+    *   `bedrock-mantle:CreateInference` on the relevant Mantle project resources.
+    *   For `openai.gpt-5.4` specifically: an AWS Marketplace subscription to the OpenAI GPT-5.4 listing in the target region (subscribe via the AWS Marketplace console, or grant `aws-marketplace:CreateAgreementRequest` + `aws-marketplace:Subscribe` to let the principal auto-subscribe on first invoke).
+    *   The principal does *not* need `bedrock:InvokeModel` for Mantle calls — Mantle is a separate IAM action namespace from the classic Bedrock runtime.
+
 ### `prerna.engine.impl.model.EmbeddedModelEngine`
 *   **Purpose**: Designed to work with models that are hosted locally or managed directly by the SEMOSS instance. This is often used for Python-based models (e.g., from Hugging Face Transformers, scikit-learn).
 *   **Implementation Highlights**:

--- a/docs/engines/model_engines.md
+++ b/docs/engines/model_engines.md
@@ -81,9 +81,11 @@ To create a new `MODEL` engine for a different provider or a new type of local m
 
 AWS exposes OpenAI models on Bedrock through the OpenAI-compatible "Mantle" endpoint at `https://bedrock-mantle.<region>.api.aws/openai/v1`. The Java engine class is still `prerna.engine.impl.model.BedrockEngine` — the only difference is the `INIT_MODEL_ENGINE` template, which routes to `genai_client.OpenAiClient` with `provider='bedrock-mantle'` instead of `genai_client.AnthropicClient`.
 
-The Python `OpenAiClient` wraps the standard OpenAI SDK with an httpx auth class that SigV4-signs each request using the AWS access/secret key. No separate Bedrock API key is required — the long-term IAM credentials handle authentication directly.
+The Python `OpenAiClient` wraps the standard OpenAI SDK with an httpx auth class that SigV4-signs each request. No separate Bedrock API key is required.
 
-*   **Example SMSS** (Responses API, `openai.gpt-5.4`):
+Credentials resolution follows the standard boto3 default chain when `AWS_ACCESS_KEY` / `AWS_SECRET_KEY` are omitted from the .smss: environment variables, `~/.aws/credentials`, AWS SSO, then EC2/ECS/Lambda instance role. Refreshable credentials (EC2 role, assumed role, SSO) auto-renew between requests, so the engine survives credential rotation without restart. `AWS_REGION` similarly falls back to the session's region (env var `AWS_REGION` / `AWS_DEFAULT_REGION` or EC2 instance metadata) if not set in the .smss.
+
+*   **Example SMSS** (Responses API, `openai.gpt-5.4`, explicit long-term keys):
 
     ```
     #Base Properties
@@ -103,7 +105,21 @@ The Python `OpenAiClient` wraps the standard OpenAI SDK with an httpx auth class
     INIT_MODEL_ENGINE   import genai_client;${VAR_NAME} = genai_client.OpenAiClient(is_azure=False, api_key='unused', model_name='${MODEL}', provider='${PROVIDER}', aws_region='${AWS_REGION}', aws_access_key='${AWS_ACCESS_KEY}', aws_secret_key='${AWS_SECRET_KEY}', chat_type='${CHAT_TYPE}', max_tokens=${MAX_TOKENS}, context_window=${CONTEXT_WINDOW})
     ```
 
-*   **IAM prerequisites on the principal**:
+*   **Example SMSS** (EC2 instance role — no AWS keys in the .smss):
+
+    ```
+    ENGINE_TYPE         prerna.engine.impl.model.BedrockEngine
+    NAME                GPT 5.4 Bedrock (EC2 role)
+    MODEL_TYPE          BEDROCK
+    PROVIDER            bedrock-mantle
+    MODEL               openai.gpt-5.4
+    VAR_NAME            gpt54Model
+    CHAT_TYPE           responses
+
+    INIT_MODEL_ENGINE   import genai_client;${VAR_NAME} = genai_client.OpenAiClient(is_azure=False, api_key='unused', model_name='${MODEL}', provider='${PROVIDER}', chat_type='${CHAT_TYPE}')
+    ```
+
+*   **IAM prerequisites on the principal** (IAM user, EC2 role, or assumed role):
     *   `bedrock-mantle:CreateInference` on the relevant Mantle project resources.
     *   For `openai.gpt-5.4` specifically: an AWS Marketplace subscription to the OpenAI GPT-5.4 listing in the target region (subscribe via the AWS Marketplace console, or grant `aws-marketplace:CreateAgreementRequest` + `aws-marketplace:Subscribe` to let the principal auto-subscribe on first invoke).
     *   The principal does *not* need `bedrock:InvokeModel` for Mantle calls — Mantle is a separate IAM action namespace from the classic Bedrock runtime.

--- a/py/genai_client/text_generation/openai_clients/bedrock_sigv4_auth.py
+++ b/py/genai_client/text_generation/openai_clients/bedrock_sigv4_auth.py
@@ -1,0 +1,38 @@
+from typing import TYPE_CHECKING, Generator
+
+import httpx
+
+if TYPE_CHECKING:
+    from botocore.credentials import ReadOnlyCredentials
+
+
+class BedrockSigV4Auth(httpx.Auth):
+    # Mantle uses SigV4, not bearer tokens — overwrite the OpenAI SDK's Authorization header.
+    requires_request_body = True
+
+    def __init__(
+        self,
+        credentials: "ReadOnlyCredentials",
+        service: str = "bedrock-mantle",
+        region: str = "us-east-1",
+    ) -> None:
+        self._credentials = credentials
+        self._service = service
+        self._region = region
+
+    def auth_flow(
+        self, request: httpx.Request
+    ) -> Generator[httpx.Request, httpx.Response, None]:
+        from botocore.auth import SigV4Auth
+        from botocore.awsrequest import AWSRequest
+
+        aws_request = AWSRequest(
+            method=request.method,
+            url=str(request.url),
+            data=request.content,
+            headers={"host": request.url.host},
+        )
+        SigV4Auth(self._credentials, self._service, self._region).add_auth(aws_request)
+        for key, value in aws_request.headers.items():
+            request.headers[key] = value
+        yield request

--- a/py/genai_client/text_generation/openai_clients/bedrock_sigv4_auth.py
+++ b/py/genai_client/text_generation/openai_clients/bedrock_sigv4_auth.py
@@ -3,16 +3,18 @@ from typing import TYPE_CHECKING, Generator
 import httpx
 
 if TYPE_CHECKING:
-    from botocore.credentials import ReadOnlyCredentials
+    from botocore.credentials import Credentials
 
 
 class BedrockSigV4Auth(httpx.Auth):
     # Mantle uses SigV4, not bearer tokens — overwrite the OpenAI SDK's Authorization header.
+    # Hold the live Credentials object (not a frozen snapshot) so refreshable
+    # creds (EC2 role, assumed role, SSO) auto-renew between requests.
     requires_request_body = True
 
     def __init__(
         self,
-        credentials: "ReadOnlyCredentials",
+        credentials: "Credentials",
         service: str = "bedrock-mantle",
         region: str = "us-east-1",
     ) -> None:

--- a/py/genai_client/text_generation/openai_clients/bedrock_sigv4_auth.py
+++ b/py/genai_client/text_generation/openai_clients/bedrock_sigv4_auth.py
@@ -7,9 +7,7 @@ if TYPE_CHECKING:
 
 
 class BedrockSigV4Auth(httpx.Auth):
-    # Mantle uses SigV4, not bearer tokens — overwrite the OpenAI SDK's Authorization header.
-    # Hold the live Credentials object (not a frozen snapshot) so refreshable
-    # creds (EC2 role, assumed role, SSO) auto-renew between requests.
+    # SigV4-sign each request; pass live Credentials (not frozen) so EC2/SSO creds auto-refresh.
     requires_request_body = True
 
     def __init__(

--- a/py/genai_client/text_generation/openai_clients/bedrock_sigv4_auth.py
+++ b/py/genai_client/text_generation/openai_clients/bedrock_sigv4_auth.py
@@ -7,9 +7,6 @@ if TYPE_CHECKING:
 
 
 class BedrockSigV4Auth(httpx.Auth):
-    # SigV4-sign each request; pass live Credentials (not frozen) so EC2/SSO creds auto-refresh.
-    requires_request_body = True
-
     def __init__(
         self,
         credentials: "Credentials",

--- a/py/genai_client/text_generation/openai_clients/openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_client.py
@@ -130,6 +130,9 @@ class OpenAiClient(AbstractTextGenerationClient):
     def _get_client(
         self, api_key: str, is_azure: bool, **kwargs
     ) -> Union[OpenAI, AzureOpenAI]:
+        provider = (kwargs.pop("provider", None) or "").lower()
+        if provider == "bedrock-mantle":
+            return self._get_bedrock_mantle_client(api_key, **kwargs)
         if is_azure:
             endpoint = kwargs.pop("endpoint", None)
             if endpoint is None:
@@ -137,6 +140,59 @@ class OpenAiClient(AbstractTextGenerationClient):
             kwargs["azure_endpoint"] = endpoint
             return AzureOpenAI(api_key=api_key, **kwargs)
         return OpenAI(api_key=api_key, **kwargs)
+
+    def _get_bedrock_mantle_client(self, api_key: str, **kwargs) -> OpenAI:
+        # Lazy import — only this provider needs boto3/httpx.
+        import boto3
+        import httpx
+        from .bedrock_sigv4_auth import BedrockSigV4Auth
+
+        aws_access_key = kwargs.pop("aws_access_key", None) or kwargs.pop(
+            "aws_access_key_id", None
+        )
+        aws_secret_key = kwargs.pop("aws_secret_key", None) or kwargs.pop(
+            "aws_secret_access_key", None
+        )
+        aws_region = kwargs.pop("aws_region", None) or kwargs.pop("region", None)
+        if not aws_region:
+            raise ValueError(
+                "provider='bedrock-mantle' requires aws_region (or region)"
+            )
+
+        session = boto3.Session(
+            aws_access_key_id=aws_access_key,
+            aws_secret_access_key=aws_secret_key,
+            region_name=aws_region,
+        )
+        credentials = session.get_credentials()
+        if credentials is None:
+            raise ValueError(
+                "Could not resolve AWS credentials for provider='bedrock-mantle' "
+                "(pass aws_access_key/aws_secret_key or configure the default chain)"
+            )
+        frozen = credentials.get_frozen_credentials()
+
+        base_url = (
+            kwargs.pop("base_url", None)
+            or kwargs.pop("endpoint", None)
+            or f"https://bedrock-mantle.{aws_region}.api.aws/openai/v1"
+        )
+        # First-invoke Marketplace finalization can take minutes.
+        timeout = kwargs.pop("timeout", 300.0)
+
+        http_client = httpx.Client(
+            auth=BedrockSigV4Auth(
+                credentials=frozen,
+                service="bedrock-mantle",
+                region=aws_region,
+            ),
+            timeout=timeout,
+        )
+        return OpenAI(
+            api_key=api_key or "unused-sigv4-signs-this",
+            base_url=base_url,
+            http_client=http_client,
+        )
 
     def ask_call(
         self, prefix: str = "", **kwargs

--- a/py/genai_client/text_generation/openai_clients/openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_client.py
@@ -155,8 +155,7 @@ class OpenAiClient(AbstractTextGenerationClient):
         )
         aws_region = kwargs.pop("aws_region", None) or kwargs.pop("region", None)
 
-        # When access/secret are omitted, boto3 walks the default credential
-        # chain: env vars, shared file, SSO, EC2/ECS/Lambda instance role.
+        # None values fall through to boto3's default credential / region chain.
         session = boto3.Session(
             aws_access_key_id=aws_access_key,
             aws_secret_access_key=aws_secret_key,

--- a/py/genai_client/text_generation/openai_clients/openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_client.py
@@ -1,10 +1,6 @@
 from typing import Any, Dict, TYPE_CHECKING, Union
 
 if TYPE_CHECKING:
-    # Tokenizers are imported lazily inside _get_tokenizer() to keep heavy
-    # dependencies (e.g. transformers, pulled in by HuggingfaceTokenizer) off
-    # the client-construction path. These TYPE_CHECKING imports keep the type
-    # hints valid without paying the runtime import cost.
     from ...tokenizers.vllm_tokenizer import VLLMTokenizer
     from ...tokenizers.openai_tokenizer import OpenAiTokenizer
 
@@ -50,11 +46,11 @@ class OpenAiClient(AbstractTextGenerationClient):
     def __init__(
         self,
         is_azure: bool,
-        api_key: str,
         **kwargs,
     ):
         self.is_azure = is_azure
         self.endpoint = kwargs.pop("endpoint", None)
+
         if self.endpoint:
             kwargs["base_url"] = self.endpoint
         chat_type = kwargs.pop("chat_type", "chat-completion")
@@ -72,7 +68,7 @@ class OpenAiClient(AbstractTextGenerationClient):
 
         self.chat_type = self.model_settings.chat_type
         self.tokenizer = self._get_tokenizer(kwargs)
-        self.client = self._get_client(api_key, is_azure, **client_kwargs)
+        self.client = self._get_client(is_azure, **client_kwargs)
         self.simplify_messages = string_to_bool(
             parent_kwargs.get("simplify_messages", False)
         )
@@ -86,10 +82,6 @@ class OpenAiClient(AbstractTextGenerationClient):
     def _get_tokenizer(
         self, init_args: Dict = {}
     ) -> "Union[VLLMTokenizer, OpenAiTokenizer]":
-        # Tokenizers are imported lazily so that constructing an OpenAI/Azure
-        # client does not pull in heavy deps it never uses. In particular
-        # HuggingfaceTokenizer imports `transformers` (~2.5s warm / much more
-        # cold), which the default OpenAiTokenizer (tiktoken) path never needs.
         if not self.is_azure and self.endpoint and self.endpoint.strip():
             if self.deployment_type == "vllm":
                 from ...tokenizers.vllm_tokenizer import VLLMTokenizer
@@ -127,12 +119,13 @@ class OpenAiClient(AbstractTextGenerationClient):
             max_completion_tokens=self.model_settings.max_completion_tokens,
         )
 
-    def _get_client(
-        self, api_key: str, is_azure: bool, **kwargs
-    ) -> Union[OpenAI, AzureOpenAI]:
+    def _get_client(self, is_azure: bool, **kwargs) -> Union[OpenAI, AzureOpenAI]:
         provider = (kwargs.pop("provider", None) or "").lower()
-        if provider == "bedrock-mantle":
-            return self._get_bedrock_mantle_client(api_key, **kwargs)
+        if provider == "bedrock":
+            return self._get_bedrock_client(**kwargs)
+        api_key = kwargs.pop("api_key", None)
+        if not api_key:
+            raise ValueError("api_key is required for OpenAI and Azure OpenAI clients")
         if is_azure:
             endpoint = kwargs.pop("endpoint", None)
             if endpoint is None:
@@ -141,8 +134,7 @@ class OpenAiClient(AbstractTextGenerationClient):
             return AzureOpenAI(api_key=api_key, **kwargs)
         return OpenAI(api_key=api_key, **kwargs)
 
-    def _get_bedrock_mantle_client(self, api_key: str, **kwargs) -> OpenAI:
-        # Lazy import — only this provider needs boto3/httpx.
+    def _get_bedrock_client(self, **kwargs) -> OpenAI:
         import boto3
         import httpx
         from .bedrock_sigv4_auth import BedrockSigV4Auth
@@ -155,7 +147,6 @@ class OpenAiClient(AbstractTextGenerationClient):
         )
         aws_region = kwargs.pop("aws_region", None) or kwargs.pop("region", None)
 
-        # None values fall through to boto3's default credential / region chain.
         session = boto3.Session(
             aws_access_key_id=aws_access_key,
             aws_secret_access_key=aws_secret_key,
@@ -164,13 +155,13 @@ class OpenAiClient(AbstractTextGenerationClient):
         credentials = session.get_credentials()
         if credentials is None:
             raise ValueError(
-                "Could not resolve AWS credentials for provider='bedrock-mantle' "
+                "Could not resolve AWS credentials for provider='bedrock' "
                 "(pass aws_access_key/aws_secret_key or configure the default chain)"
             )
         region = aws_region or session.region_name
         if not region:
             raise ValueError(
-                "provider='bedrock-mantle' requires a region "
+                "provider='bedrock' requires a region "
                 "(pass aws_region, set AWS_REGION, or run on EC2 with a region)"
             )
 
@@ -191,7 +182,7 @@ class OpenAiClient(AbstractTextGenerationClient):
             timeout=timeout,
         )
         return OpenAI(
-            api_key=api_key or "unused-sigv4-signs-this",
+            api_key="unused-sigv4-signs-this",
             base_url=base_url,
             http_client=http_client,
         )

--- a/py/genai_client/text_generation/openai_clients/openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_client.py
@@ -173,8 +173,6 @@ class OpenAiClient(AbstractTextGenerationClient):
             or kwargs.pop("endpoint", None)
             or f"https://bedrock-mantle.{region}.api.aws/openai/v1"
         )
-        # First-invoke Marketplace finalization can take minutes.
-        timeout = kwargs.pop("timeout", 300.0)
 
         http_client = httpx.Client(
             auth=BedrockSigV4Auth(
@@ -182,7 +180,7 @@ class OpenAiClient(AbstractTextGenerationClient):
                 service="bedrock-mantle",
                 region=region,
             ),
-            timeout=timeout,
+            timeout=kwargs.pop("timeout", 300.0),
         )
         return OpenAI(
             api_key=api_key or "unused-sigv4-signs-this",

--- a/py/genai_client/text_generation/openai_clients/openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_client.py
@@ -147,6 +147,9 @@ class OpenAiClient(AbstractTextGenerationClient):
         )
         aws_region = kwargs.pop("aws_region", None) or kwargs.pop("region", None)
 
+        # Optional openai api key; no idea why you would use it here
+        api_key = kwargs.pop("api_key", None)
+
         session = boto3.Session(
             aws_access_key_id=aws_access_key,
             aws_secret_access_key=aws_secret_key,
@@ -182,7 +185,7 @@ class OpenAiClient(AbstractTextGenerationClient):
             timeout=timeout,
         )
         return OpenAI(
-            api_key="unused-sigv4-signs-this",
+            api_key=api_key or "unused-sigv4-signs-this",
             base_url=base_url,
             http_client=http_client,
         )

--- a/py/genai_client/text_generation/openai_clients/openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_client.py
@@ -154,11 +154,9 @@ class OpenAiClient(AbstractTextGenerationClient):
             "aws_secret_access_key", None
         )
         aws_region = kwargs.pop("aws_region", None) or kwargs.pop("region", None)
-        if not aws_region:
-            raise ValueError(
-                "provider='bedrock-mantle' requires aws_region (or region)"
-            )
 
+        # When access/secret are omitted, boto3 walks the default credential
+        # chain: env vars, shared file, SSO, EC2/ECS/Lambda instance role.
         session = boto3.Session(
             aws_access_key_id=aws_access_key,
             aws_secret_access_key=aws_secret_key,
@@ -170,21 +168,26 @@ class OpenAiClient(AbstractTextGenerationClient):
                 "Could not resolve AWS credentials for provider='bedrock-mantle' "
                 "(pass aws_access_key/aws_secret_key or configure the default chain)"
             )
-        frozen = credentials.get_frozen_credentials()
+        region = aws_region or session.region_name
+        if not region:
+            raise ValueError(
+                "provider='bedrock-mantle' requires a region "
+                "(pass aws_region, set AWS_REGION, or run on EC2 with a region)"
+            )
 
         base_url = (
             kwargs.pop("base_url", None)
             or kwargs.pop("endpoint", None)
-            or f"https://bedrock-mantle.{aws_region}.api.aws/openai/v1"
+            or f"https://bedrock-mantle.{region}.api.aws/openai/v1"
         )
         # First-invoke Marketplace finalization can take minutes.
         timeout = kwargs.pop("timeout", 300.0)
 
         http_client = httpx.Client(
             auth=BedrockSigV4Auth(
-                credentials=frozen,
+                credentials=credentials,
                 service="bedrock-mantle",
-                region=aws_region,
+                region=region,
             ),
             timeout=timeout,
         )


### PR DESCRIPTION
Wires AWS Bedrock's OpenAI-compatible Mantle endpoint into the existing genai_client.OpenAiClient. SigV4-signs each OpenAI SDK request using  same auth  key the existing BedrockEngine already uses for Anthropic models. no schema changes to .smss

