### PR TITLE
feat(openai_client): add AWS SigV4 auth support for bedrock-mantle with test script

### DIFF
--- a/py/genai_client/text_generation/openai_clients/openai_client.py
+++ b/py/genai_client/text_generation/openai_clients/openai_client.py
@@ -22,6 +22,46 @@ from ..model_engine_exception import ModelEngineException, ErrorDetails
 from ...utils import string_to_bool
 
 
+def _build_aws_sigv4_http_client(access_key: str, secret_key: str, region: str, service: str):
+    """Return an httpx.Client that SigV4-signs every request.
+
+    Used for AWS endpoints that accept the OpenAI wire format but require AWS
+    auth instead of a bearer token (e.g. ``bedrock-mantle``).
+    """
+    try:
+        import boto3
+        import httpx
+        from botocore.auth import SigV4Auth
+        from botocore.awsrequest import AWSRequest
+    except ImportError as e:
+        raise ImportError(
+            "boto3, botocore, and httpx are required for AWS SigV4 auth. "
+            "Install them with: pip install boto3 httpx"
+        ) from e
+
+    session = boto3.Session(
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region,
+    )
+    creds = session.get_credentials().get_frozen_credentials()
+
+    class _SigV4Auth(httpx.Auth):
+        def auth_flow(self, request):
+            aws_request = AWSRequest(
+                method=request.method,
+                url=str(request.url),
+                data=request.content,
+                headers={"host": request.url.host},
+            )
+            SigV4Auth(creds, service, region).add_auth(aws_request)
+            for k, v in aws_request.headers.items():
+                request.headers[k] = v
+            yield request
+
+    return httpx.Client(auth=_SigV4Auth())
+
+
 class OpenAiClient(AbstractTextGenerationClient):
     PARENT_PARAMS = {
         "template",
@@ -61,6 +101,11 @@ class OpenAiClient(AbstractTextGenerationClient):
             override = kwargs.setdefault("global_param_override", {})
             if isinstance(override, dict):
                 override.setdefault("stream", stream_kwarg)
+        # AWS SigV4 auth — extracted before splitting parent/client kwargs
+        self._aws_access_key = kwargs.pop("aws_access_key", None)
+        self._aws_secret_key = kwargs.pop("aws_secret_key", None)
+        self._aws_region = kwargs.pop("aws_region", None)
+        self._aws_service = kwargs.pop("aws_service", "bedrock-mantle")
         parent_kwargs = {k: v for k, v in kwargs.items() if k in self.PARENT_PARAMS}
         client_kwargs = {k: v for k, v in kwargs.items() if k not in self.PARENT_PARAMS}
 
@@ -132,6 +177,14 @@ class OpenAiClient(AbstractTextGenerationClient):
                 endpoint = kwargs.pop("base_url", None)
             kwargs["azure_endpoint"] = endpoint
             return AzureOpenAI(api_key=api_key, **kwargs)
+        if self._aws_access_key and self._aws_secret_key and self._aws_region:
+            kwargs["http_client"] = _build_aws_sigv4_http_client(
+                self._aws_access_key,
+                self._aws_secret_key,
+                self._aws_region,
+                self._aws_service,
+            )
+            api_key = "dummy"  # SDK requires a non-empty value; SigV4 handles real auth
         return OpenAI(api_key=api_key, **kwargs)
 
     def _get_bedrock_client(self, **kwargs) -> OpenAI:

--- a/py/testing/bedrock_openai_sigv4_test.py
+++ b/py/testing/bedrock_openai_sigv4_test.py
@@ -1,0 +1,67 @@
+"""
+Smoke-test for the OpenAI-compatible Bedrock endpoint using SigV4 auth.
+
+Requires the IAM user/role to have the `bedrock-mantle:CreateInference` permission.
+
+Usage:
+    python bedrock_openai_sigv4_test.py
+"""
+
+import os
+
+import boto3
+import httpx
+from openai import OpenAI
+from botocore.auth import SigV4Auth
+from botocore.awsrequest import AWSRequest
+
+# ── Config ────────────────────────────────────────────────────────────────────
+AWS_ACCESS_KEY = os.environ.get("AWS_ACCESS_KEY_ID", "")
+AWS_SECRET_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", "")
+REGION = os.environ.get("AWS_DEFAULT_REGION", "us-east-2")
+SERVICE = "bedrock-mantle"
+
+MODEL = "openai.gpt-5.4"
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class BedrockSigV4Auth(httpx.Auth):
+    """httpx auth handler that SigV4-signs every request for AWS bedrock-mantle."""
+
+    def __init__(self, service: str, region: str, credentials):
+        self.service = service
+        self.region = region
+        self.credentials = credentials
+
+    def auth_flow(self, request: httpx.Request):
+        aws_request = AWSRequest(
+            method=request.method,
+            url=str(request.url),
+            data=request.content,
+            headers={"host": request.url.host},
+        )
+        SigV4Auth(self.credentials, self.service, self.region).add_auth(aws_request)
+        for k, v in aws_request.headers.items():
+            request.headers[k] = v
+        yield request
+
+
+def build_client(access_key: str, secret_key: str, region: str) -> OpenAI:
+    session = boto3.Session(
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name=region,
+    )
+    creds = session.get_credentials().get_frozen_credentials()
+    return OpenAI(
+        api_key="dummy",  # satisfies SDK constructor; overridden by SigV4 auth
+        base_url=f"https://{SERVICE}.{region}.api.aws/openai/v1",
+        http_client=httpx.Client(auth=BedrockSigV4Auth(SERVICE, region, creds)),
+    )
+
+
+if __name__ == "__main__":
+    print(f"Testing model: {MODEL} in {REGION}")
+    client = build_client(AWS_ACCESS_KEY, AWS_SECRET_KEY, REGION)
+    response = client.responses.create(model=MODEL, input="What is 2+2?")
+    print("Response:", response.output_text)


### PR DESCRIPTION
## Description
Adds AWS SigV4 authentication support to OpenAiClient, enabling it to call AWS bedrock-mantle OpenAI-compatible endpoints (e.g. openai.gpt-5.4) using IAM credentials instead of a Bedrock API key. A new build_aws_sigv4_http_client helper intercepts outgoing requests and signs them with boto3/botocore SigV4 , passing aws_access_key, aws_secret_key, and aws_region to OpenAiClient is all that's needed to activate it. Also includes a smoke test script for validating the connection.

## Changes Made
Added AWS SigV4 auth support to OpenAiClient so it can call AWS bedrock-mantle endpoints using IAM credentials
Added a smoke test script to validate the connection (just a dev convenience to test the connection outside of SEMOSS.)

## How to Test
Pull changes
Make sure you have a openAi bedrock model. 
Upload model into SEMOSS, and test model.

## Notes
There was another PR done for this recently with slightly different approach.