### PR TITLE
fix: rename setVisibile → setVisible typo in AbstractMessage

### DIFF
--- a/src/prerna/engine/impl/model/Room.java
+++ b/src/prerna/engine/impl/model/Room.java
@@ -473,7 +473,7 @@ public class Room implements Serializable {
 						.withModelType(modelEngine.getModelType()).build();
 				toolResultsMessage.setParentMessageId(toolResponse.getMessageId());
 				toolResultsMessage.setModel(modelEngine);
-				toolResultsMessage.setVisibile(false);
+				toolResultsMessage.setVisible(false);
 			} else {
 				toolResultsMessage.addPart(new ToolResultMessagePart(new ToolResultPart(toolCallId, toolName,
 						toolExecutionResponse, toolParameterValues, toolStatus, false)));

--- a/src/prerna/engine/impl/model/message/AbstractMessage.java
+++ b/src/prerna/engine/impl/model/message/AbstractMessage.java
@@ -289,8 +289,8 @@ public abstract class AbstractMessage {
 		return visible;
 	}
 
-	public void setVisibile(boolean visibile) {
-		this.visible = visibile;
+	public void setVisible(boolean visible) {
+		this.visible = visible;
 	}
 
 	public boolean isPlatformGenerated() {

--- a/src/prerna/engine/impl/model/message/InputMessage.java
+++ b/src/prerna/engine/impl/model/message/InputMessage.java
@@ -484,7 +484,7 @@ public class InputMessage extends AbstractMessage {
 			Map<String, Object> toolParameterValues, String toolStatus, boolean serverTool) {
 		InputMessage toolExecution = builder(room)
 				.withToolResult(toolCallId, toolName, content, toolParameterValues, toolStatus, serverTool).build();
-		toolExecution.setVisibile(false);
+		toolExecution.setVisible(false);
 		return toolExecution;
 	}
 

--- a/src/prerna/reactor/model/CompactRoomMessagesReactor.java
+++ b/src/prerna/reactor/model/CompactRoomMessagesReactor.java
@@ -217,7 +217,7 @@ public class CompactRoomMessagesReactor extends AbstractReactor {
 
 		// Inherit the parent of the oldest pruned message so other branches stay intact
 		toolPruneMessage.setParentMessageId(branch.getLast().getMessageId());
-		toolPruneMessage.setVisibile(false);
+		toolPruneMessage.setVisible(false);
 
 		// Set token count to last input + response - expected tokens pruned
 		// Will be off by a few tokens but it will get fixed anyway on the next message
@@ -249,7 +249,7 @@ public class CompactRoomMessagesReactor extends AbstractReactor {
 						+ "results were pruned if the user asks for specifics.")
 				.build();
 		toolPruneResponse.setParentMessageId(toolPruneMessage.getMessageId());
-		toolPruneResponse.setVisibile(false);
+		toolPruneResponse.setVisible(false);
 
 		// summary response tokens + last n messages tokens - original tokens in that
 		// span (to avoid double counting)
@@ -403,7 +403,7 @@ public class CompactRoomMessagesReactor extends AbstractReactor {
 		// Inherit the parent of the oldest pruned message so other branches stay intact
 		compactedMessage.setParentMessageId(null);
 		compactedMessage.setSummaryLeafMessageId(messageId);
-		compactedMessage.setVisibile(false);
+		compactedMessage.setVisible(false);
 
 		// Disclaimer:
 		// UI needs a non-zero token count
@@ -414,7 +414,7 @@ public class CompactRoomMessagesReactor extends AbstractReactor {
 		// Pair the compacted input with a response message so the branch is complete
 		ResponseMessage compactedResponse = ResponseMessage.builder().withText(compactedTextMessage).build();
 		compactedResponse.setParentMessageId(compactedMessage.getMessageId());
-		compactedResponse.setVisibile(false);
+		compactedResponse.setVisible(false);
 
 		// summary response tokens + last n messages tokens - original tokens in that
 		// span (to avoid double counting)


### PR DESCRIPTION
## Summary
- Fixes a typo in `AbstractMessage.setVisibile()` — the method and its parameter were both misspelled (`visibile` instead of `visible`)
- Updates all 4 call sites across `Room`, `InputMessage`, and `CompactRoomMessagesReactor`