### PR TITLE
Normalize Thinking and Reasoning Parameters for GenAI Client

### DIFF
--- a/docs/python_genai_client/reasoning_and_effort.md
+++ b/docs/python_genai_client/reasoning_and_effort.md
@@ -1,0 +1,149 @@
+# Reasoning & Effort / "Thinking" (`message_builders/semoss_base/reasoning.py`)
+
+The `genai_client` exposes a single, provider-agnostic way to control model
+reasoning ("thinking") across every supported provider. Callers send two keys in
+the model param map and the client normalizes them into the correct native shape
+for whichever provider the engine points to:
+
+* **`thinking`** — turn reasoning on/off. Accepts a bool, the strings
+  `"true"`/`"false"`, or an Anthropic/Claude-Code passthrough dict
+  (`{"type": "enabled"|"adaptive"|"disabled", "budget_tokens": N}`).
+* **`effort`** — how hard to think. One of the canonical levels
+  `none | minimal | low | medium | high | xhigh | max`, or an integer token
+  budget (which gets bucketed to a level).
+
+The legacy key **`thinking_budget`** (int) is still honored for backwards
+compatibility.
+
+> The providers split into two camps. **Effort-based**: OpenAI, modern Anthropic
+> (Opus 4.6+/Sonnet 4.6/Fable), Gemini 3.x. **Token-budget-based**: Gemini 2.5,
+> Bedrock Converse, legacy Anthropic. A shared canonical `effort ⇄ budget` ladder
+> lets one set of inputs work everywhere.
+
+## Where these keys come from
+
+The keys live in the **model param map** that reaches the message builders:
+
+* **`RunAgent(...)` pixel** — pass them under `paramValues`:
+  `paramValues=[{"thinking":true, "effort":"high"}]`. (Put them under
+  `paramValues`, the model param map — *not* `agentParams`, which is for harness
+  hooks.)
+* **`LLM(...)` pixel** — same `paramValues=[{...}]` form.
+* **Python client (`gaas_gpt_model`)** — `model.ask(..., param_dict={"thinking": True, "effort": "high"})`
+  (the wrapper serializes `param_dict` to `paramValues`).
+* **SMSS** — `ModelSettings.thinking`, `ModelSettings.effort`, and
+  `ModelSettings.thinking_budget` act as fallbacks when the param map omits them.
+
+## Normalization
+
+`normalize_reasoning(param_map, model_settings)` collapses the inputs into a
+canonical `ResolvedReasoning(enabled, effort, budget)` (or `None` when reasoning
+is off) and **pops** `thinking` / `effort` / `thinking_budget` from the param map
+so they never leak into the request body. Each provider's message builder then
+maps that result onto its native shape:
+
+| Builder | Method | Native shape |
+|---|---|---|
+| `openai/openai_message_builder.py` | `_resolve_extended_reasoning` (Responses), `_resolve_reasoning_effort` (Chat Completions) | `reasoning={"effort": ..., "summary": "auto"}` / `reasoning_effort=...` |
+| `anthropic/anthropic_message_builder.py` | `_resolve_extended_thinking` | modern: `thinking={"type":"adaptive"}` + `output_config={"effort": ...}`; legacy: `thinking={"type":"enabled","budget_tokens": N}` |
+| `google_genai/google_genai_builder.py` | `_resolve_thinking_config` | Gemini 3: `ThinkingConfig(thinking_level=...)`; Gemini 2.5: `ThinkingConfig(thinking_budget=N)` |
+| `bedrock/bedrock_message_builder.py` | `_resolve_reasoning_config` / `_apply_reasoning` | `additionalModelRequestFields.reasoning_config={"type":"enabled","budget_tokens": N}` |
+
+## What each canonical `effort` becomes per provider
+
+You always send one of the 7 canonical values; each builder maps it to that
+provider's native value (budgets have a floor of `1024`):
+
+| You send `effort` | OpenAI `reasoning.effort` | Claude **modern** `output_config.effort` | Claude **legacy** `budget_tokens` | Gemini **3** `thinking_level` | Gemini **2.5** `thinking_budget` | Bedrock `reasoning_config.budget_tokens` |
+|---|---|---|---|---|---|---|
+| `none` | `none` | `low` | 1024 | `MINIMAL` | 1024 | 1024 |
+| `minimal` | `minimal` | `low` | 1024 | `MINIMAL` | 1024 | 1024 |
+| `low` | `low` | `low` | 4096 | `LOW` | 4096 | 4096 |
+| `medium` | `medium` | `medium` | 8192 | `MEDIUM` | 8192 | 8192 |
+| `high` | `high` | `high` | 24576 | `HIGH` | 24576 | 24576 |
+| `xhigh` | `xhigh` | `xhigh` (→ `high` unless Opus 4.7+/Fable) | 32768 | `HIGH` | 32768 | 32768 |
+| `max` | `high` | `max` | 63999 | `HIGH` | 63999 | 63999 |
+
+## What each provider *natively* accepts
+
+This is why the mapping clamps — the native domains differ:
+
+| Provider | Native effort domain |
+|---|---|
+| OpenAI | `none`, `minimal`, `low`, `medium`, `high`, `xhigh` — **but per-model** (gpt-5: minimal/low/medium/high; gpt-5.1: none/low/medium/high; gpt-5.5: +xhigh). No `max`. |
+| Claude modern (Opus 4.6+/Sonnet 4.6/Fable) | `low`, `medium`, `high`, `xhigh`, `max` (`xhigh` only Fable/Opus 4.7+) |
+| Claude legacy / Bedrock / Gemini 2.5 | token budget (no effort) — effort is bucketed to a budget |
+| Gemini 3 | `MINIMAL`, `LOW`, `MEDIUM`, `HIGH` (no xhigh/max) |
+
+## Invalid values — defaults to `medium`
+
+An unrecognized `effort` (typo, `"ultra"`, `"turbo"`, etc.) **never raises**.
+`_coerce_effort` returns `None`, then `normalize_reasoning` falls back in order:
+
+1. SMSS `ModelSettings.effort` (if configured)
+2. an explicit `thinking_budget` (bucketed to a level)
+3. **`DEFAULT_EFFORT = "medium"`** — the final fallback
+
+So `{"thinking": true, "effort": "ultra"}` → **medium**. But
+`{"thinking": true, "effort": "ultra", "thinking_budget": 20000}` → **high** (the
+budget wins over the unusable string before the default applies).
+
+## Nuances
+
+* **Two clamp layers — only the first defaults to `medium`.** An *invalid* value
+  → `medium` (above). A *valid* canonical value the target model doesn't support
+  → the builder clamps it to the nearest supported value deterministically (e.g.
+  `max`→`high` on OpenAI, `none`→`low` on Claude, `xhigh`→`HIGH` on Gemini 3),
+  **not** `medium`.
+* **OpenAI is the one place a valid value can still 400.** The client does not
+  carry OpenAI's per-model matrix, so `xhigh` / `none` / `minimal` pass through
+  as-is. Sending `xhigh` to a model that doesn't accept it (e.g. gpt-5.1) is
+  rejected by **OpenAI**, not the client. `low` / `medium` / `high` are safe on
+  every OpenAI reasoning model. Claude, Gemini, and Bedrock always self-clamp and
+  won't error on effort.
+* **`effort: "none"` is not the same as `thinking: false`.** With
+  `thinking: true, effort: "none"` you still get a minimal-but-on request (budget
+  floored to `1024` / `MINIMAL` / `none`). To fully disable reasoning, send
+  `thinking: false` (or omit `thinking`).
+* **Budgets are approximate; providers enforce their own ranges.** We do not
+  clamp per-model budget ceilings (e.g. Gemini 2.5 Pro caps `thinking_budget` at
+  32768), so `max` / `xhigh` on a small-ceiling model may be clamped or rejected
+  by that provider.
+
+## Examples
+
+Bare boolean — reasoning on at the default `medium` on every provider:
+
+```
+RunAgent(
+  roomId=["my-room-123"],
+  engine=["<model-engine-id>"],
+  command=["<encode>Find the failing test and propose a fix</encode>"],
+  paramValues=[{"thinking":true}]
+);
+```
+
+Explicit effort:
+
+```
+paramValues=[{"thinking":true, "effort":"high"}]
+```
+
+Legacy token budget (bucketed for effort-based providers, used directly for
+budget-based ones):
+
+```
+paramValues=[{"thinking":true, "thinking_budget":12000}]
+```
+
+Turn reasoning off:
+
+```
+paramValues=[{"thinking":false}]
+```
+
+Python client:
+
+```python
+model.ask(command="Summarize this incident", param_dict={"thinking": True, "effort": "high"})
+```

--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -27,6 +27,7 @@ from ..semoss_base.semoss_models import (
 )
 from ...text_generation.abstract_text_generation_client import ModelLimits
 from ...utils import string_to_bool
+from ..semoss_base.reasoning import normalize_reasoning
 
 MODEL_MAX_OUTPUT_TOKENS = {
     # Claude 4.5 family
@@ -712,58 +713,71 @@ class AnthropicMessageBuilder:
 
         return anthropic_tools
 
+    def _supports_adaptive_effort(self, model_name: str) -> bool:
+        """Modern Claude (adaptive thinking + output_config.effort): Fable,
+        Opus 4.6+, Sonnet 4.6+. Everything else uses legacy budget_tokens."""
+        name = (model_name or "").lower()
+        if "fable" in name:
+            return True
+        tier, major, minor = self._parse_claude_model_name(model_name)
+        if tier is None or major is None:
+            return False
+        try:
+            mj, mn = int(major), int(minor) if minor else 0
+        except (TypeError, ValueError):
+            return False
+        if tier in ("opus", "sonnet"):
+            return (mj, mn) >= (4, 6)
+        return False  # haiku / older -> legacy
+
+    def _supports_xhigh(self, model_name: str) -> bool:
+        """`xhigh` effort: Fable and Opus 4.7+ only."""
+        name = (model_name or "").lower()
+        if "fable" in name:
+            return True
+        tier, major, minor = self._parse_claude_model_name(model_name)
+        if tier != "opus" or major is None:
+            return False
+        try:
+            mj, mn = int(major), int(minor) if minor else 0
+        except (TypeError, ValueError):
+            return False
+        return (mj, mn) >= (4, 7)
+
+    def _clamp_effort(self, effort: str) -> str:
+        """Map a canonical effort onto Anthropic's accepted set
+        (low|medium|high|xhigh|max). none/minimal -> low; xhigh -> high on
+        models that don't support it."""
+        if effort in ("none", "minimal"):
+            effort = "low"
+        if effort not in ("low", "medium", "high", "xhigh", "max"):
+            effort = "medium"
+        if effort == "xhigh" and not self._supports_xhigh(self.model_name):
+            effort = "high"
+        return effort
+
     def _resolve_extended_thinking(
         self,
-        thinking: Optional[str | bool] = None,
-        thinking_budget: Optional[int] = None,
         param_map: Optional[Dict[str, Any]] = {},
-    ) -> Dict[str, Any] | None:
+    ) -> tuple[Dict[str, Any] | None, Dict[str, Any] | None]:
+        """Resolve (thinking, output_config) for the request, honoring the param
+        map first then SMSS.
+
+        Modern Claude uses adaptive thinking + ``output_config.effort``; legacy
+        models use ``{"type": "enabled", "budget_tokens": N}``. NOTE: emitting
+        budget_tokens against Opus 4.7/4.8/Fable is a 400 — hence the branch.
+        Claude Code passthrough ({"type": "enabled", "budget_tokens": N}) and the
+        separate SEMOSS keys ('thinking', 'thinking_budget', 'effort') are both
+        handled by normalize_reasoning.
         """
-        Honor the thinking keys passed in the param map first and then use anything passed from the SMSS.
-        If I get this from Claude Code I get something like: {'budget_tokens': 31999, 'type': 'enabled'}
-        If I get this from SEMOSS I get separate keys 'thinking': True, 'thinking_budget': 1000
-        """
-        ## SMSS THINKING
-        smss_thinking = string_to_bool(thinking)
-        if smss_thinking:
-            smss_thinking = "enabled"
-        else:
-            smss_thinking = "disabled"
+        resolved = normalize_reasoning(param_map, self.model_settings)
+        if resolved is None:
+            return None, None
 
-        smss_thinking_budget = thinking_budget if thinking_budget else 0
+        if self._supports_adaptive_effort(self.model_name):
+            return {"type": "adaptive"}, {"effort": self._clamp_effort(resolved.effort)}
 
-        ## RESOLVING PARAM MAP
-        param_map_thinking = param_map.get("thinking", "disabled")
-        # I get this from Claude Code
-        if isinstance(thinking, dict):
-            param_map_thinking = thinking.get("type", "disabled")
-            param_map_budget_tokens = thinking.get("budget_tokens", 0)
-        else:
-            param_map_thinking = string_to_bool(thinking)
-            if param_map_thinking:
-                param_map_thinking = "enabled"
-            else:
-                param_map_thinking = "disabled"
-            param_map_budget_tokens = param_map.get("thinking_budget", 0)
-
-        resolved_thinking = (
-            "enabled"
-            if param_map_thinking == "enabled" or smss_thinking == "enabled"
-            else "disabled"
-        )
-
-        if resolved_thinking == "disabled":
-            return None
-
-        # If you set thinking as enabled but don't have a thinking budget I am going to set it for you..
-        if param_map_budget_tokens >= 1024:
-            resolved_thinking_budget = param_map_budget_tokens
-        elif smss_thinking_budget >= 1024:
-            resolved_thinking_budget = smss_thinking_budget
-        else:
-            resolved_thinking_budget = 1024
-
-        return {"type": "enabled", "budget_tokens": resolved_thinking_budget}
+        return {"type": "enabled", "budget_tokens": resolved.budget}, None
 
     def _convert_args_to_provider_config(
         self,
@@ -784,11 +798,7 @@ class AnthropicMessageBuilder:
 
         tools = kwargs.pop("tools", None)
 
-        thinking_map = self._resolve_extended_thinking(
-            thinking=model_settings.thinking,  # SMSS SETTING
-            thinking_budget=model_settings.thinking_budget,  # SMSS SETTING
-            param_map=kwargs,
-        )
+        thinking_map, output_config = self._resolve_extended_thinking(kwargs)
 
         max_tokens = (
             kwargs.pop("max_tokens", None)
@@ -796,7 +806,7 @@ class AnthropicMessageBuilder:
             or self.model_limits.max_completion_tokens
         )
 
-        # MAX TOKENS MUST BE STRICTLY GREATER THAN THINKING BUDGET
+        # MAX TOKENS MUST BE STRICTLY GREATER THAN THINKING BUDGET (legacy only)
         if thinking_map and thinking_map.get("type") == "enabled":
             budget_tokens = thinking_map.get("budget_tokens", 0)
             if max_tokens is None or max_tokens <= budget_tokens:
@@ -807,14 +817,15 @@ class AnthropicMessageBuilder:
 
         temperature = kwargs.pop("temperature", None)
         top_p = kwargs.pop("top_p", None)
-        if thinking_map:
-            # top_p between 0.95 to 1 when thinking
+        top_k = kwargs.pop("top_k", None)
+        if thinking_map and thinking_map.get("type") == "adaptive":
+            temperature = top_p = top_k = None
+        elif thinking_map:
             if top_p is not None:
                 if top_p < 0.95:
                     top_p = 0.95
                 elif top_p > 1:
                     top_p = 1
-            # temperature can only be 1 when thinking
             if temperature is not None:
                 temperature = 1
 
@@ -835,11 +846,12 @@ class AnthropicMessageBuilder:
             tool_choice=kwargs.pop("tool_choice", None),
             max_tokens=max_tokens,
             temperature=temperature,
-            top_k=kwargs.pop("top_k", None),
+            top_k=top_k,
             top_p=top_p,
             container=kwargs.pop("container", None),
             stop_sequences=kwargs.pop("stop_sequences", None),
             thinking=thinking_map,
+            output_config=output_config,
         )
 
     def _parse_claude_model_name(

--- a/py/genai_client/message_builders/anthropic/anthropic_models.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_models.py
@@ -134,6 +134,8 @@ class AnthropicRequestConfig(BaseModel):
     container: Optional[str] = None
     stop_sequences: Optional[List[str]] = None
     thinking: Optional[Dict[str, Any]] = None
+    # Modern Claude (Opus 4.6+/Sonnet 4.6/Fable): {"effort": "low|medium|high|xhigh|max"}
+    output_config: Optional[Dict[str, Any]] = None
 
 
 class AnthropicMessageBuilderResponse(BaseModel):

--- a/py/genai_client/message_builders/bedrock/bedrock_message_builder.py
+++ b/py/genai_client/message_builders/bedrock/bedrock_message_builder.py
@@ -5,6 +5,7 @@ from ...utils import (
     get_image_extension,
     fetch_and_encode_image,
 )
+from ..semoss_base.reasoning import normalize_reasoning
 from ..semoss_base.semoss_models import (
     SEMOSSMessage,
     SEMOSSMessageType,
@@ -168,7 +169,7 @@ class BedrockMessageBuilder:
 
                     stream = message.param_map.get("stream", True)
 
-                    param_map = self.clean_param_map(param_map)
+                    param_map = self._apply_reasoning(inference_config, param_map)
 
             else:
                 role = self._message_type_to_role(message.type)
@@ -300,7 +301,7 @@ class BedrockMessageBuilder:
 
                     stream = message.param_map.get("stream", True)
 
-                    param_map = self.clean_param_map(param_map)
+                    param_map = self._apply_reasoning(inference_config, param_map)
 
         messages_dict = [msg.model_dump(exclude_none=True) for msg in bedrock_messages]
         system_dict = (
@@ -552,6 +553,10 @@ class BedrockMessageBuilder:
         param_map.pop("stream", None)
         param_map.pop("streaming", None)
         param_map.pop("schema", None)
+        # reasoning keys are handled via reasoning_config; never pass them raw
+        param_map.pop("thinking", None)
+        param_map.pop("thinking_budget", None)
+        param_map.pop("effort", None)
         return param_map
 
     def _message_type_to_role(self, message_type: SEMOSSMessageType) -> str:
@@ -696,6 +701,38 @@ class BedrockMessageBuilder:
             ),
             param_map,
         )
+
+    def _resolve_reasoning_config(
+        self, param_map: Dict[str, Any]
+    ) -> Dict[str, Any] | None:
+        """Bedrock Converse reasoning (Anthropic Claude on Bedrock). Converse is
+        budget-based — it has no effort knob — so the canonical effort collapses
+        to a token budget. The builder is stateless (no model_settings), so this
+        resolves from the param map only. normalize_reasoning pops the
+        thinking/effort/thinking_budget keys so they don't leak into
+        additionalModelRequestFields.
+        """
+        resolved = normalize_reasoning(param_map)
+        if resolved is None:
+            return None
+        return {"type": "enabled", "budget_tokens": resolved.budget}
+
+    def _apply_reasoning(
+        self, inference_config: "BedrockInferenceConfig", param_map: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Resolve reasoning, clean the param map, then re-attach reasoning_config
+        and reconcile the inference config (maxTokens must exceed the budget;
+        sampling params are incompatible with reasoning)."""
+        reasoning_config = self._resolve_reasoning_config(param_map)
+        param_map = self.clean_param_map(param_map)
+        if reasoning_config:
+            param_map["reasoning_config"] = reasoning_config
+            budget = reasoning_config.get("budget_tokens", 0)
+            if inference_config.maxTokens is None or inference_config.maxTokens <= budget:
+                inference_config.maxTokens = budget + 4096
+            inference_config.temperature = None
+            inference_config.topP = None
+        return param_map
 
     def build_system_block(
         self, system_prompt: str = None

--- a/py/genai_client/message_builders/google_genai/google_genai_builder.py
+++ b/py/genai_client/message_builders/google_genai/google_genai_builder.py
@@ -18,6 +18,7 @@ from ...text_generation.abstract_text_generation_client import ModelLimits
 from .google_genai_models import GoogleRoles
 from google.genai import types
 from ...utils import string_to_bool
+from ..semoss_base.reasoning import normalize_reasoning
 
 
 class GoogleGenAIMessageBuilder:
@@ -236,33 +237,43 @@ class GoogleGenAIMessageBuilder:
             "stream": stream,
         }
 
+    # Canonical effort -> Gemini 3 ThinkingLevel. The SDK enum only has
+    # MINIMAL/LOW/MEDIUM/HIGH, so xhigh/max collapse to HIGH and none->MINIMAL.
+    _GEMINI_THINKING_LEVEL = {
+        "none": types.ThinkingLevel.MINIMAL,
+        "minimal": types.ThinkingLevel.MINIMAL,
+        "low": types.ThinkingLevel.LOW,
+        "medium": types.ThinkingLevel.MEDIUM,
+        "high": types.ThinkingLevel.HIGH,
+        "xhigh": types.ThinkingLevel.HIGH,
+        "max": types.ThinkingLevel.HIGH,
+    }
+
     def _resolve_thinking_config(
         self, param_map: Dict[str, Any]
     ) -> types.ThinkingConfig:
         """
-        Honor the thinking keys passed in the param map first and then use anything passed from the SMSS.
+        Honor the thinking/effort keys passed in the param map first, then fall
+        back to SMSS. Gemini 3.x uses `thinking_level`; Gemini 2.5/2.0 uses
+        `thinking_budget` (setting both on a Gemini 3 model returns a 400).
         """
-        thinking = param_map.get("thinking")
-        if thinking and isinstance(thinking, str):
-            try:
-                thinking = string_to_bool(thinking)
-            except ValueError:
-                thinking = None
-        thinking_budget = param_map.get("thinking_budget")
+        resolved = normalize_reasoning(param_map, self.model_settings)
+        if resolved is None:
+            return types.ThinkingConfig(include_thoughts=False)
 
-        if not thinking and self.model_settings.thinking:
-            thinking = self.model_settings.thinking
-        if not thinking_budget and self.model_settings.thinking_budget:
-            thinking_budget = self.model_settings.thinking_budget
+        model_name = (self.model_settings.model_name or "").lower()
+        if "gemini-3" in model_name:
+            return types.ThinkingConfig(
+                include_thoughts=True,
+                thinking_level=self._GEMINI_THINKING_LEVEL.get(
+                    resolved.effort, types.ThinkingLevel.HIGH
+                ),
+            )
 
-        if thinking:
-            if thinking_budget is not None:
-                return types.ThinkingConfig(
-                    include_thoughts=True, thinking_budget=thinking_budget
-                )
-            else:
-                return types.ThinkingConfig(include_thoughts=True)
-        return types.ThinkingConfig(include_thoughts=False)
+        # Gemini 2.5 / 2.0 family -> explicit token budget.
+        return types.ThinkingConfig(
+            include_thoughts=True, thinking_budget=resolved.budget
+        )
 
     def _convert_args_to_provider_config(
         self, **kwargs

--- a/py/genai_client/message_builders/openai/openai_message_builder.py
+++ b/py/genai_client/message_builders/openai/openai_message_builder.py
@@ -2,6 +2,7 @@ from typing import List, Dict, Any, Optional, Tuple, Union
 import json
 from pydantic import BaseModel
 from ...utils import get_image_extension, string_to_bool
+from ..semoss_base.reasoning import normalize_reasoning
 from .openai_models import (
     OpenAIResponsesToolCall,
     OpenAIRoles,
@@ -550,6 +551,14 @@ class OpenAIMessageBuilder:
 
                 if is_last:
                     param_map.update(message.param_map)
+
+        try:
+            reasoning_effort = self._resolve_reasoning_effort(param_map)
+            if reasoning_effort:
+                param_map["reasoning_effort"] = reasoning_effort
+                param_map.pop("temperature", None)
+        except Exception:
+            pass
 
         has_schema = param_map.get("schema", False)
         if has_schema:
@@ -1108,52 +1117,36 @@ class OpenAIMessageBuilder:
                 )
                 return OpenAIFileContentPart(file=file_data)
 
+    # Canonical effort -> OpenAI effort. OpenAI has no "max"; clamp it to "high".
+    # "none"/"minimal"/"xhigh" pass through (support varies by model — e.g. only
+    # gpt-5.1+ accepts "none", only gpt-5.5 accepts "xhigh" — so only emit those
+    # when the caller explicitly asked for them).
+    _OPENAI_EFFORT = {
+        "none": "none",
+        "minimal": "minimal",
+        "low": "low",
+        "medium": "medium",
+        "high": "high",
+        "xhigh": "xhigh",
+        "max": "high",
+    }
+
     def _resolve_extended_reasoning(self, param_map: Dict[str, Any]) -> Dict[str, Any]:
-        thinking = param_map.pop("thinking", None)
-        if thinking and isinstance(thinking, str):
-            try:
-                thinking = string_to_bool(thinking)
-            except ValueError:
-                thinking = None
-        thinking_budget = param_map.pop("thinking_budget", None)
+        """Responses API: returns {"effort": ..., "summary": "auto"} or None."""
+        resolved = normalize_reasoning(param_map, self.model_settings)
+        if resolved is None:
+            return None
+        return {
+            "effort": self._OPENAI_EFFORT.get(resolved.effort, "medium"),
+            "summary": "auto",
+        }
 
-        if not thinking and self.model_settings.thinking:
-            thinking = self.model_settings.thinking
-        if not thinking_budget and self.model_settings.thinking_budget:
-            thinking_budget = self.model_settings.thinking_budget
-
-        if thinking:
-            return {
-                "effort": self._budget_to_effort(thinking_budget),
-                "summary": "auto",
-            }
-        return None
-
-    def _budget_to_effort(self, budget_tokens=None) -> str:
-        """
-        Accepts either a string ('low', 'medium', 'high') or an int (tokens), and returns 'low', 'medium', or 'high'.
-        """
-        if budget_tokens is None:
-            return "medium"
-        if isinstance(budget_tokens, str):
-            s = budget_tokens.strip().lower()
-            if s in ("low", "medium", "high"):
-                return s
-            try:  # Try to parse string integer
-                n = int(s)
-                budget_tokens = n
-            except Exception:
-                return "medium"  # fallback
-        # If not string, must be int now
-        try:
-            val = int(budget_tokens)
-        except Exception:
-            return "medium"
-        if val >= 20000:
-            return "high"
-        if val >= 5000:
-            return "medium"
-        return "low"
+    def _resolve_reasoning_effort(self, param_map: Dict[str, Any]) -> str | None:
+        """Chat Completions API: returns the flat reasoning_effort string or None."""
+        resolved = normalize_reasoning(param_map, self.model_settings)
+        if resolved is None:
+            return None
+        return self._OPENAI_EFFORT.get(resolved.effort, "medium")
 
     # def _truncate_by_tokens(
     #     self,

--- a/py/genai_client/message_builders/semoss_base/reasoning.py
+++ b/py/genai_client/message_builders/semoss_base/reasoning.py
@@ -1,0 +1,152 @@
+"""Shared reasoning / "thinking" normalization across provider message builders.
+
+Java always sends two keys in the param map: ``thinking`` (bool) and ``effort``
+(a canonical string). The providers we support split into two camps:
+
+* effort-based ........ OpenAI, modern Anthropic (Opus 4.6+/Sonnet 4.6/Fable),
+                        Gemini 3.x (``thinking_level``)
+* token-budget-based .. Gemini 2.5 (``thinking_budget``), Bedrock Converse
+                        (``reasoning_config.budget_tokens``), legacy Anthropic
+
+``normalize_reasoning`` collapses the incoming param map (and, where available,
+the SMSS ``ModelSettings``) into a single canonical result. Each builder then
+maps that result onto its provider-native shape via the small ``effort``<->
+``budget`` ladder below, branching on model family where needed.
+"""
+
+from typing import Any, Dict, Optional
+from pydantic import BaseModel
+from ...utils import string_to_bool
+
+CANONICAL_EFFORTS = ("none", "minimal", "low", "medium", "high", "xhigh", "max")
+
+DEFAULT_EFFORT = "medium"
+
+MIN_BUDGET = 1024
+
+EFFORT_TO_BUDGET = {
+    "none": 0,
+    "minimal": 512,
+    "low": 4096,
+    "medium": 8192,
+    "high": 24576,
+    "xhigh": 32768,
+    "max": 63999,
+}
+
+
+def budget_to_effort(budget: Any) -> str:
+    """Map an integer-ish token budget onto the canonical effort ladder."""
+    try:
+        n = int(budget)
+    except (TypeError, ValueError):
+        return DEFAULT_EFFORT
+    if n <= 0:
+        return "none"
+    if n < 1024:
+        return "minimal"
+    if n < 6144:
+        return "low"
+    if n < 16384:
+        return "medium"
+    if n < 28672:
+        return "high"
+    if n < 49152:
+        return "xhigh"
+    return "max"
+
+
+def effort_to_budget(effort: Optional[str]) -> int:
+    """Map a canonical effort onto an approximate token budget."""
+    return EFFORT_TO_BUDGET.get(
+        (effort or DEFAULT_EFFORT).lower(), EFFORT_TO_BUDGET[DEFAULT_EFFORT]
+    )
+
+
+def _coerce_effort(value: Any) -> Optional[str]:
+    """Return a canonical effort string, or None if the value isn't usable.
+
+    Accepts a canonical string, a numeric token budget (str or int), and treats
+    anything else as "not specified".
+    """
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, str):
+        v = value.strip().lower()
+        if v in CANONICAL_EFFORTS:
+            return v
+        if v.lstrip("-").isdigit():
+            return budget_to_effort(int(v))
+        return None
+    if isinstance(value, (int, float)):
+        return budget_to_effort(int(value))
+    return None
+
+
+class ResolvedReasoning(BaseModel):
+    """Canonical, provider-agnostic reasoning settings."""
+
+    enabled: bool
+    effort: str
+    budget: int
+
+
+def normalize_reasoning(
+    param_map: Dict[str, Any],
+    model_settings: Any = None,
+    *,
+    pop: bool = True,
+) -> Optional[ResolvedReasoning]:
+    """Resolve thinking/effort from the param map first, then SMSS settings.
+
+    Returns ``None`` when reasoning is disabled (the builder should then emit the
+    provider's "off"/omitted shape). When ``pop`` is True (default) the recognized
+    keys (``thinking``, ``thinking_budget``, ``effort``) are removed from
+    ``param_map`` so they never leak into the provider request body.
+    """
+    grab = param_map.pop if pop else param_map.get
+    thinking_raw = grab("thinking", None)
+    budget_raw = grab("thinking_budget", None)
+    effort_raw = grab("effort", None)
+
+    # ---- is thinking enabled? ----
+    passthrough_budget = None
+    if isinstance(thinking_raw, dict):
+        # Claude Code / Anthropic passthrough: {"type": "enabled"|"adaptive"|
+        # "disabled", "budget_tokens": N}
+        enabled: Optional[bool] = thinking_raw.get("type") in ("enabled", "adaptive")
+        passthrough_budget = thinking_raw.get("budget_tokens")
+    elif thinking_raw is None:
+        enabled = None
+    else:
+        enabled = string_to_bool(thinking_raw)
+
+    if enabled is None and model_settings is not None:
+        enabled = bool(getattr(model_settings, "thinking", False))
+    enabled = bool(enabled)
+
+    if not enabled:
+        return None
+
+    effort = _coerce_effort(effort_raw)
+    if effort is None and model_settings is not None:
+        effort = _coerce_effort(getattr(model_settings, "effort", None))
+    if effort is None and passthrough_budget:
+        effort = budget_to_effort(passthrough_budget)
+    if effort is None and budget_raw is not None:
+        effort = budget_to_effort(budget_raw)
+    if effort is None:
+        effort = DEFAULT_EFFORT
+
+    budget = passthrough_budget or budget_raw
+    if not budget and model_settings is not None:
+        budget = getattr(model_settings, "thinking_budget", None)
+    if not budget:
+        budget = effort_to_budget(effort)
+    try:
+        budget = int(budget)
+    except (TypeError, ValueError):
+        budget = effort_to_budget(effort)
+    budget = max(budget, MIN_BUDGET)
+
+    return ResolvedReasoning(enabled=True, effort=effort, budget=budget)

--- a/py/genai_client/message_builders/semoss_base/semoss_models.py
+++ b/py/genai_client/message_builders/semoss_base/semoss_models.py
@@ -444,5 +444,6 @@ class ModelSettings(BaseModel):
     tokens_param_name: Optional[str] = None
     thinking: Optional[bool] = False
     thinking_budget: Optional[int] = None
+    effort: Optional[str] = None
     global_param_override: Optional[Dict[str, Any]] = None
     modalities: Optional[List[str]] = None


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Adds a single, provider-agnostic way to control model reasoning. Callers send thinking (bool) and effort (none|minimal|low|medium|high|xhigh|max) in the model param map (e.g. RunAgent(..., paramValues=[{"thinking":true,"effort":"high"}])); a shared normalizer maps them to each provider's native shape and defaults sensibly so a bare thinking:true always produces a valid request.

## What changed
New shared normalizer message_builders/semoss_base/reasoning.py — normalize_reasoning() + a canonical effort ⇄ budget ladder. Reads the param map first, then SMSS, and strips the reasoning keys so they don't leak into request bodies.
ModelSettings.effort added as an SMSS-level fallback.
OpenAI — Responses (reasoning.effort) and Chat Completions (reasoning_effort) wired to the normalizer.
Anthropic — branches modern (Opus 4.6+/Sonnet 4.6/Fable → thinking:{type:"adaptive"} + output_config.effort) vs legacy (budget_tokens); drops sampling params on adaptive. Added output_config to AnthropicRequestConfig.
Google — branches Gemini 3 (thinking_level) vs 2.5/2.0 (thinking_budget).
Bedrock — added reasoning_config support (was previously unhandled), bumps maxTokens, nulls sampling params, and strips reasoning keys from additionalModelRequestFields.
Docs — new docs/python_genai_client/reasoning_and_effort.md with the full effort matrix, defaults, and examples.
### Bugs fixed along the way
Anthropic emitted legacy budget_tokens on all models → 400 on Opus 4.7/4.8/Fable (budget_tokens removed there).
Google only set thinking_budget → broke on Gemini 3 (requires thinking_level).
Bedrock had no reasoning handling → thinking/effort leaked into additionalModelRequestFields and were rejected.
Behavior notes
Invalid effort → falls back to medium (or to a provided thinking_budget/SMSS effort first); never errors.
Valid-but-unsupported levels are clamped per model (e.g. max→high on OpenAI, xhigh→high on non-Opus-4.7+ Claude).
Verified against the pinned SDKs (anthropic output_config/adaptive, google-genai ThinkingLevel).