### PR TITLE
Create and Update Workspaces with Skills

### DIFF
--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -2301,14 +2301,24 @@ public class ModelInferenceLogsUtils {
 	}
 
 	/**
-	 * Updates a workspace record and replaces its resource associations.
+	 * Updates a workspace record and replaces <b>all</b> of its resource
+	 * associations - MCP engines/projects, prompts, and skills alike.
+	 * <p>
+	 * The supplied {@code resources} list is treated as the complete desired set:
+	 * every existing {@code WORKSPACE_RESOURCE} row for the workspace is deleted and
+	 * replaced with the rows derived from {@code resources}. Callers must therefore
+	 * pass the full resource set (including any skills to keep); a resource omitted
+	 * from the list is detached. (Incremental skill attach/detach without a full
+	 * rewrite is available via {@code AttachSkillToWorkspaceReactor} /
+	 * {@code DetachSkillFromWorkspaceReactor}.)
 	 *
 	 * @param workspaceId          workspace identifier
 	 * @param workspaceName        workspace display name
 	 * @param workspaceDescription workspace description payload
 	 * @param systemPrompt         workspace system prompt payload
 	 * @param isActive             active state
-	 * @param resources            replacement resource list
+	 * @param resources            complete replacement resource list (engines,
+	 *                             projects, prompts, and skills)
 	 * @throws Exception if update fails
 	 */
 	public static void updateWorkspaceEntry(String workspaceId, String workspaceName, String workspaceDescription,
@@ -2334,8 +2344,8 @@ public class ModelInferenceLogsUtils {
 				}
 			}
 
-			try (PreparedStatement ps = con.prepareStatement(
-					"DELETE FROM WORKSPACE_RESOURCE WHERE WORKSPACE_ID = ? AND RESOURCE_TYPE != 'SKILL'")) {
+			try (PreparedStatement ps = con
+					.prepareStatement("DELETE FROM WORKSPACE_RESOURCE WHERE WORKSPACE_ID = ?")) {
 				int index = 1;
 				ps.setString(index++, workspaceId);
 				ps.execute();

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
@@ -61,6 +61,8 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 	static final String SYSTEM_PROMPT = "systemPrompt";
 	/** Request key for prompt collection input. */
 	static final String PROMPTS = "prompts";
+	/** Request key for skill collection input. */
+	static final String SKILLS = "skills";
 	/** Request key for active/inactive workspace state. */
 	static final String IS_ACTIVE = "isActive";
 
@@ -113,6 +115,29 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 		resource.put("workspace_id", workspaceId);
 		resource.put("resource_id", promptId);
 		resource.put("resource_type", PROMPT_RESOURCE_TYPE);
+		resource.put("resource_subtype", null);
+		return resource;
+	}
+
+	/**
+	 * Builds a workspace resource row for a skill.
+	 * <p>
+	 * The {@code resource_subtype} carries the optional pinned skill version
+	 * ({@code AgentConfigLoader.resolveSkills} reads it back as {@code pinned_version}).
+	 * It is left {@code null} here because the workspace edit/add inputs only carry
+	 * skill ids - matching {@link prerna.reactor.agent.skill.AttachSkillToWorkspaceReactor},
+	 * which also attaches with no pinned version.
+	 *
+	 * @param workspaceId workspace identifier that owns the resource
+	 * @param skillId skill identifier being linked to the workspace
+	 * @return map representing a row for workspace resource persistence
+	 */
+	Map<String, String> makeSkillResourceEntryMap(String workspaceId, String skillId) {
+		Map<String, String> resource = new HashMap<>();
+		resource.put("workspace_resource_id", UUID.randomUUID().toString());
+		resource.put("workspace_id", workspaceId);
+		resource.put("resource_id", skillId);
+		resource.put("resource_type", SKILL_RESOURCE_TYPE);
 		resource.put("resource_subtype", null);
 		return resource;
 	}

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AddWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AddWorkspaceReactor.java
@@ -58,8 +58,9 @@ public class AddWorkspaceReactor extends AbstractWorkspaceReactor {
 	private static final String CLASS_NAME = AddWorkspaceReactor.class.getName();
 
 	public AddWorkspaceReactor() {
-		this.keysToGet = new String[] { NAME, DESCRIPTION, SYSTEM_PROMPT, ReactorKeysEnum.MCP.getKey(), PROMPTS };
-		this.keyRequired = new int[] { 1, 0, 0, 0, 0 };
+		this.keysToGet = new String[] { NAME, DESCRIPTION, SYSTEM_PROMPT, ReactorKeysEnum.MCP.getKey(), PROMPTS,
+				SKILLS };
+		this.keyRequired = new int[] { 1, 0, 0, 0, 0, 0 };
 	}
 
 	@Override
@@ -136,6 +137,20 @@ public class AddWorkspaceReactor extends AbstractWorkspaceReactor {
 					return getError("Prompt not found or user lacks access: " + promptId);
 				}
 				workspaceResources.add(makePromptResourceEntryMap(workspaceId, promptId));
+			}
+		}
+
+
+		List<String> skillIds = getNounAsStringList(SKILLS);
+		if (!skillIds.isEmpty()) {
+			for (String skillId : skillIds) {
+				if (ModelInferenceLogsUtils.getSkillEntry(skillId) == null) {
+					return getError("Skill not found: " + skillId);
+				}
+				if (!SecurityProjectUtils.userCanViewProject(user, skillId)) {
+					return getError("User lacks permission to one of the given skills: " + skillId);
+				}
+				workspaceResources.add(makeSkillResourceEntryMap(workspaceId, skillId));
 			}
 		}
 

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/EditWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/EditWorkspaceReactor.java
@@ -57,8 +57,8 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 
 	public EditWorkspaceReactor() {
 		this.keysToGet = new String[] { ReactorKeysEnum.WORKSPACE_ID.getKey(), NAME, DESCRIPTION, SYSTEM_PROMPT,
-				IS_ACTIVE, ReactorKeysEnum.MCP.getKey(), PROMPTS };
-		this.keyRequired = new int[] { 1, 1, 0, 0, 0, 0, 0 };
+				IS_ACTIVE, ReactorKeysEnum.MCP.getKey(), PROMPTS, SKILLS };
+		this.keyRequired = new int[] { 1, 1, 0, 0, 0, 0, 0, 0 };
 	}
 
 	@Override
@@ -166,6 +166,23 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 			}
 		}
 
+
+		Set<String> skillIds = new HashSet<>(getNounAsStringList(SKILLS));
+		if (!skillIds.isEmpty()) {
+			Set<String> curSkillList = ModelInferenceLogsUtils
+					.getWorkspaceResources(workspaceId, SKILL_RESOURCE_TYPE, null).stream()
+					.map(map -> map.get("resource_id")).collect(Collectors.toSet());
+			for (String skillId : skillIds) {
+				if (ModelInferenceLogsUtils.getSkillEntry(skillId) == null) {
+					return getError("Skill not found: " + skillId);
+				}
+				if (!SecurityProjectUtils.userCanViewProject(user, skillId) && !curSkillList.contains(skillId)) {
+					return getError("User lacks permission to one of the given skills: " + skillId);
+				}
+				workspaceResources.add(makeSkillResourceEntryMap(workspaceId, skillId));
+			}
+		}
+
 		try {
 			ModelInferenceLogsUtils.updateWorkspaceEntry(workspaceId, workspaceName, workspaceDescription,
 					workspaceSystemPrompt, isActive, workspaceResources);
@@ -174,17 +191,17 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 			return getError("Error during workspace update: " + e.getMessage());
 		}
 
-		// Dual-write CONFIG_JSON: mirror system_prompt + MCP engine/project refs into
-		// WORKSPACE.CONFIG_JSON. Preserve any other CONFIG_JSON fields (e.g. hooks)
-		// the workspace already has. Best-effort - a failure here is logged but does
-		// not fail the reactor, since the legacy SYSTEM_PROMPT column +
+		// Dual-write CONFIG_JSON: mirror system_prompt + MCP engine/project refs +
+		// skill refs into WORKSPACE.CONFIG_JSON. Preserve any other CONFIG_JSON fields
+		// (e.g. hooks) the workspace already has. Best-effort - a failure here is logged
+		// but does not fail the reactor, since the legacy SYSTEM_PROMPT column +
 		// WORKSPACE_RESOURCE rows already landed and AgentConfigLoader still resolves
 		// correctly from those.
 		try {
-			mirrorCoreFieldsIntoConfigJson(workspaceId, workspaceSystemPrompt, engines, projectDependencies);
+			mirrorCoreFieldsIntoConfigJson(workspaceId, workspaceSystemPrompt, engines, projectDependencies, skillIds);
 		} catch (Exception e) {
 			classLogger.warn(
-					"Failed to mirror system_prompt/mcps into CONFIG_JSON for workspaceId '{}' (legacy writes already succeeded)",
+					"Failed to mirror system_prompt/mcps/skills into CONFIG_JSON for workspaceId '{}' (legacy writes already succeeded)",
 					workspaceId, e);
 			Map<String, Object> partial = new HashMap<>();
 			partial.put("success", true);
@@ -196,17 +213,25 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 	}
 
 	/**
-	 * Persist {@code system_prompt} and the engine/project MCP refs into
-	 * {@code WORKSPACE.CONFIG_JSON}, preserving any other fields already there.
+	 * Persist {@code system_prompt}, the engine/project MCP refs, and the skill
+	 * refs into {@code WORKSPACE.CONFIG_JSON}, preserving any other fields already
+	 * there.
 	 *
 	 * <p>
 	 * Empty {@code engines} + empty {@code projects} writes an empty {@code mcps}
-	 * array - intentional, since the user may be removing all MCPs. Null
+	 * array, and empty {@code skills} writes an empty {@code skills} array - both
+	 * intentional, since the user may be removing all MCPs/skills. Null
 	 * {@code systemPrompt} omits the key (vs. writing JSON null), so the loader
 	 * falls through to the legacy SYSTEM_PROMPT column read for that field.
+	 *
+	 * <p>
+	 * The {@code skills} entry shape - {@code { "skill_id": <id> }} - matches what
+	 * {@code AgentConfigLoader.resolveSkills} and
+	 * {@code ModelInferenceLogsUtils.addSkillToWorkspaceConfigJson} read/write. No
+	 * {@code pinned_version} is emitted because the edit input carries only ids.
 	 */
 	private static void mirrorCoreFieldsIntoConfigJson(String workspaceId, String systemPrompt, Set<String> engines,
-			Set<String> projects) throws Exception {
+			Set<String> projects, Set<String> skills) throws Exception {
 		JSONObject cfg = ModelInferenceLogsUtils.getWorkspaceConfigJson(workspaceId);
 		if (cfg == null) {
 			cfg = new JSONObject();
@@ -232,6 +257,14 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 			mcpsJson.put(entry);
 		}
 		cfg.put("mcps", mcpsJson);
+
+		JSONArray skillsJson = new JSONArray();
+		for (String id : skills) {
+			JSONObject entry = new JSONObject();
+			entry.put("skill_id", id);
+			skillsJson.put(entry);
+		}
+		cfg.put("skills", skillsJson);
 
 		ModelInferenceLogsUtils.updateWorkspaceConfigJson(workspaceId, cfg);
 	}


### PR DESCRIPTION
# Support skills in Add/Edit Workspace reactors

## Summary

Workspaces could attach skills only through the dedicated `AttachSkillToWorkspace` /
`DetachSkillFromWorkspace` reactors. This adds a `skills` input to the workspace
create/update reactors so skills can be set as part of the normal workspace payload,
alongside `mcp` and `prompts`.

- **`EditWorkspaceReactor`** — accepts `skills` (list of skill IDs) and treats it as a
  **full replace**, consistent with how it already handles `mcp`/`prompts`: the provided
  list becomes the workspace's complete skill set, and the change is dual-written to both
  the authoritative `WORKSPACE_RESOURCE` rows and the `CONFIG_JSON.skills` mirror that
  `AgentConfigLoader.resolveSkills` reads.
- **`AddWorkspaceReactor`** — accepts an optional `skills` list to seed skills at creation
  (persisted as `WORKSPACE_RESOURCE` rows; no `CONFIG_JSON` write, matching how it already
  handles `mcp`).
- **`ModelInferenceLogsUtils.updateWorkspaceEntry`** — the resource replace now covers
  skills too (removed the prior `RESOURCE_TYPE != 'SKILL'` carve-out). Its only caller is
  `EditWorkspaceReactor`.
- **`AbstractWorkspaceReactor`** — added the `SKILLS` request key and a
  `makeSkillResourceEntryMap(...)` row builder.

Skills are validated like `AttachSkillToWorkspace` does (must exist + be viewable by the
user); edit additionally allows re-saving an already-attached skill the user can no longer
view. Each skill is identified by skill ID — the same string contract as `prompts`.

### ⚠️ Front-end impact

Because edit is a full replace, the FE must send the **complete** `skills` list on every
`EditWorkspace` call — omitting it (or sending `skills=[]`) detaches all skills, exactly as
omitting `mcp`/`prompts` already wipes those. Incremental, non-destructive changes remain
available via `AttachSkillToWorkspace` / `DetachSkillFromWorkspace`. `GetWorkspace` already
returns a `skills` bucket (unchanged).

### Files changed

- `Semoss/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AddWorkspaceReactor.java`
- `Semoss/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/EditWorkspaceReactor.java`
- `Semoss/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java`
- `Semoss/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java`

---

## How to call them

`skillId`s are UUIDs — list them with `GetSkills()` (optionally `filter="mine"` /
`"platform"`).

### 1. Create a workspace with skills

```
AddWorkspace(
  name="Research Agent",
  description="With analysis skills",
  systemPrompt="",
  mcp=[],
  skills=["a1b2c3d4-...skillId1", "e5f6...-skillId2"]
);
```

### 2. Edit a workspace's skills (full replace)

```
EditWorkspace(
  workspaceId="d745bf76-7c4e-42fa-af7a-8d991885c1bd",
  name="Research Agent",
  mcp=[{"name":"Sales DB","id":"efbc7a2e-...","type":"PROJECT"}],
  skills=["a1b2c3d4-...skillId1", "e5f6...-skillId2"]
);
```

The workspace ends up with exactly those two skills — any others previously attached are
detached.

### 3. Remove all skills via edit

Send an empty list (or omit `skills` entirely):

```
EditWorkspace(workspaceId="d745bf76-...", name="Research Agent", skills=[]);
```

### 4. Read skills back

```
GetWorkspace(workspaceId=["d745bf76-..."]);
```

Returns a `skills` array of `{ "id", "type":"SKILL", "name", "slug" }` (alongside `mcp` and
`prompts`). Feed the `id`s back into `AddWorkspace`/`EditWorkspace`.

### 5. Incremental attach/detach (unchanged — non-destructive)

```
AttachSkillToWorkspace(workspaceId=["d745bf76-..."], skillId=["a1b2c3d4-..."]);
DetachSkillFromWorkspace(workspaceId=["d745bf76-..."], skillId=["a1b2c3d4-..."]);
```

A practical pattern for an edit screen: call `GetWorkspace` to populate the current skills,
let the user add/remove, then send the full resulting list back via `EditWorkspace`.