### PR TITLE
feat: track attached skills in PROJECTDEPENDENCIES

### DIFF
--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
@@ -330,6 +330,13 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 				throw new IllegalArgumentException("User lacks permission to one of the given skills: " + skillId);
 			}
 			workspaceResources.add(makeSkillResourceEntryMap(workspaceId, skillId));
+			// Skills are projects (type=SKILL), so they belong in PROJECTDEPENDENCIES
+			// alongside MCP engines/projects. ENGINETYPE = "PROJECT" because the
+			// catalog stores skills as projects.
+			Map<String, Object> skillDep = new HashMap<>();
+			skillDep.put("ENGINEID", skillId);
+			skillDep.put("ENGINETYPE", CATALOG_TYPE.PROJECT.name());
+			dependencyList.add(skillDep);
 		}
 
 		if (platformSkills != null) {

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
@@ -28,15 +28,26 @@
 package prerna.engine.impl.model.inferencetracking.reactors.workspaces;
 
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import prerna.auth.User;
 import prerna.auth.utils.SecurityEngineUtils;
+import prerna.auth.utils.SecurityProjectUtils;
 import prerna.engine.api.IEngine.CATALOG_TYPE;
+import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.project.api.IProject;
+import prerna.prompt.PromptUtils;
 import prerna.reactor.AbstractReactor;
+import prerna.reactor.agent.skill.PlatformSkills;
 import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.util.SystemEngineRegistry;
 import prerna.util.Utility;
 
 /**
@@ -151,6 +162,198 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 	 */
 	List<Map<String, Object>> getMcpMapList() {
 		return getList(ReactorKeysEnum.MCP.getKey(), List.of());
+	}
+
+	/**
+	 * Mirrors the workspace's {@code system_prompt}, MCP refs, skill refs, and
+	 * (optionally) platform-skill refs into {@code WORKSPACE.CONFIG_JSON},
+	 * preserving any other fields already present (hooks, subagents, budgets,
+	 * etc.).
+	 *
+	 * <p>Empty {@code engines} + empty {@code projects} writes an empty
+	 * {@code mcps} array, and empty {@code skills} writes an empty {@code skills}
+	 * array - both intentional, since the caller may be removing all of them.
+	 * Null {@code systemPrompt} omits the key (vs. writing JSON null), so the
+	 * loader falls through to the legacy SYSTEM_PROMPT column for that field.
+	 *
+	 * <p>The {@code skills} entry shape - {@code { "skill_id": <id> }} - matches
+	 * what {@code AgentConfigLoader.resolveSkills} and
+	 * {@code ModelInferenceLogsUtils.addSkillToWorkspaceConfigJson} read/write.
+	 * No {@code pinned_version} is emitted because the edit/add inputs carry only
+	 * ids.
+	 *
+	 * <p>{@code platformSkills} differs from {@code skills}/{@code mcps}: a
+	 * {@code null} value leaves any existing {@code platform_skills} array
+	 * untouched (callers that omit the input never clobber it), while a non-null
+	 * value is a full replace (an empty set clears it). Entries are plain slug
+	 * strings, matching {@code CONFIG_JSON.platform_skills[]}.
+	 */
+	protected static void mirrorCoreFieldsIntoConfigJson(String workspaceId, String systemPrompt, Set<String> engines,
+			Set<String> projects, Set<String> skills, Set<String> platformSkills) throws Exception {
+		JSONObject cfg = ModelInferenceLogsUtils.getWorkspaceConfigJson(workspaceId);
+		if (cfg == null) {
+			cfg = new JSONObject();
+			cfg.put("schema_version", 1);
+		}
+		if (systemPrompt != null && !systemPrompt.isEmpty()) {
+			cfg.put("system_prompt", systemPrompt);
+		} else {
+			cfg.remove("system_prompt");
+		}
+
+		JSONArray mcpsJson = new JSONArray();
+		for (String id : engines) {
+			JSONObject entry = new JSONObject();
+			entry.put("id", id);
+			entry.put("name", id);
+			mcpsJson.put(entry);
+		}
+		for (String id : projects) {
+			JSONObject entry = new JSONObject();
+			entry.put("id", id);
+			entry.put("name", id);
+			mcpsJson.put(entry);
+		}
+		cfg.put("mcps", mcpsJson);
+
+		JSONArray skillsJson = new JSONArray();
+		for (String id : skills) {
+			JSONObject entry = new JSONObject();
+			entry.put("skill_id", id);
+			skillsJson.put(entry);
+		}
+		cfg.put("skills", skillsJson);
+
+		if (platformSkills != null) {
+			JSONArray platformSkillsJson = new JSONArray();
+			for (String slug : platformSkills) {
+				platformSkillsJson.put(slug);
+			}
+			cfg.put("platform_skills", platformSkillsJson);
+		}
+
+		ModelInferenceLogsUtils.updateWorkspaceConfigJson(workspaceId, cfg);
+	}
+
+	/**
+	 * Reads the MCP / prompt / skill nouns from the request, validates them, and
+	 * populates the caller-owned accumulators in place. Throws
+	 * {@link IllegalArgumentException} with a human-readable message on
+	 * validation failure (callers catch and convert to {@code getError(...)}).
+	 *
+	 * <p>Platform skills are handled separately by
+	 * {@link #collectPlatformSkillsInput()} because the null-vs-empty distinction
+	 * (input absent vs. input supplied empty) matters for the CONFIG_JSON mirror
+	 * and doesn't fit a simple out-param.
+	 *
+	 * <p>The allowlist parameters carry the "existing attachment" escape hatch
+	 * Edit uses: an id already attached to the workspace passes the permission
+	 * check even if the caller has lost view rights since. Add passes
+	 * {@code null} for both, since on create there are no prior attachments to
+	 * preserve.
+	 */
+	protected void validateWorkspaceInputs(User user, String workspaceId,
+			Set<String> existingDepAllowlist, Set<String> existingSkillAllowlist,
+			Set<String> engines, Set<String> projectDependencies,
+			List<Map<String, Object>> dependencyList,
+			List<Map<String, String>> workspaceResources,
+			Set<String> skillIds) {
+		boolean hasDepAllowlist = existingDepAllowlist != null;
+		boolean hasSkillAllowlist = existingSkillAllowlist != null;
+		List<Map<String, Object>> mcpMapList = getMcpMapList();
+		for (Map<String, Object> mcpMap : mcpMapList) {
+			if (!mcpMap.containsKey("type") || !mcpMap.containsKey("id")) {
+				throw new IllegalArgumentException("Tool map must contain both type and id");
+			}
+			String type = (String) mcpMap.get("type");
+			String id = (String) mcpMap.get("id");
+			CATALOG_TYPE catalogType = CATALOG_TYPE.valueOf(type);
+			switch (catalogType) {
+			case PROJECT:
+				projectDependencies.add(id);
+				break;
+			default:
+				engines.add(id);
+			}
+			Map<String, Object> dependencyEntry = new HashMap<>();
+			dependencyEntry.put("ENGINEID", id);
+			dependencyEntry.put("ENGINETYPE", type);
+			dependencyList.add(dependencyEntry);
+		}
+
+		for (String engine : engines) {
+			if (!SecurityEngineUtils.userCanViewEngine(user, engine)
+					&& !(hasDepAllowlist && existingDepAllowlist.contains(engine))) {
+				throw new IllegalArgumentException("User lacks permission to one of the given engines: " + engine);
+			}
+			workspaceResources.add(makeResourceEntryMap(workspaceId, engine));
+		}
+
+		for (String project : projectDependencies) {
+			if (!SecurityProjectUtils.userCanViewProject(user, project)
+					&& !(hasDepAllowlist && existingDepAllowlist.contains(project))) {
+				throw new IllegalArgumentException(
+						"User lacks permission to one of the mcp tools/projects: " + project);
+			}
+			workspaceResources.add(makeProjectResourceEntryMap(workspaceId, project));
+		}
+
+		// linked to workspaces via WORKSPACE_RESOURCE with RESOURCE_TYPE = "PROMPT"
+		List<String> promptIds = getNounAsStringList(PROMPTS);
+		if (!promptIds.isEmpty()) {
+			if (!SystemEngineRegistry.isPromptDbLoaded()) {
+				throw new IllegalArgumentException("Prompt database is not enabled");
+			}
+			for (String promptId : promptIds) {
+				Map<String, Object> prompt = PromptUtils.getPrompt(promptId, user);
+				if (prompt == null || prompt.isEmpty()) {
+					throw new IllegalArgumentException("Prompt not found or user lacks access: " + promptId);
+				}
+				workspaceResources.add(makePromptResourceEntryMap(workspaceId, promptId));
+			}
+		}
+
+		skillIds.addAll(getNounAsStringList(SKILLS));
+		for (String skillId : skillIds) {
+			if (ModelInferenceLogsUtils.getSkillEntry(skillId) == null) {
+				throw new IllegalArgumentException("Skill not found: " + skillId);
+			}
+			if (!SecurityProjectUtils.userCanViewProject(user, skillId)
+					&& !(hasSkillAllowlist && existingSkillAllowlist.contains(skillId))) {
+				throw new IllegalArgumentException("User lacks permission to one of the given skills: " + skillId);
+			}
+			workspaceResources.add(makeSkillResourceEntryMap(workspaceId, skillId));
+		}
+	}
+
+	/**
+	 * Reads and validates the {@code PLATFORM_SKILLS} noun. Returns {@code null}
+	 * when the noun was not supplied (signal to leave existing CONFIG_JSON
+	 * {@code platform_skills} untouched), a populated set when slugs were
+	 * supplied (possibly empty after trimming), and throws
+	 * {@link IllegalArgumentException} when a slug fails validation. Callers
+	 * catch and convert to {@code getError(...)} when they want the existing
+	 * partial-success response shape.
+	 */
+	protected Set<String> collectPlatformSkillsInput() {
+		if (getGenRowStruct(PLATFORM_SKILLS) == null) {
+			return null;
+		}
+		Set<String> out = new LinkedHashSet<>();
+		for (String slug : getNounAsStringList(PLATFORM_SKILLS)) {
+			if (slug == null) {
+				continue;
+			}
+			String trimmed = slug.trim();
+			if (trimmed.isEmpty()) {
+				continue;
+			}
+			if (!PlatformSkills.exists(trimmed)) {
+				throw new IllegalArgumentException("Platform skill not found: " + trimmed);
+			}
+			out.add(trimmed);
+		}
+		return out;
 	}
 
 }

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
@@ -236,28 +236,32 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 	}
 
 	/**
-	 * Reads the MCP / prompt / skill nouns from the request, validates them, and
-	 * populates the caller-owned accumulators in place. Throws
-	 * {@link IllegalArgumentException} with a human-readable message on
+	 * Reads the MCP / prompt / skill / platform-skill nouns from the request,
+	 * validates them, and populates the caller-owned accumulators in place.
+	 * Throws {@link IllegalArgumentException} with a human-readable message on
 	 * validation failure (callers catch and convert to {@code getError(...)}).
-	 *
-	 * <p>Platform skills are handled separately by
-	 * {@link #collectPlatformSkillsInput()} because the null-vs-empty distinction
-	 * (input absent vs. input supplied empty) matters for the CONFIG_JSON mirror
-	 * and doesn't fit a simple out-param.
 	 *
 	 * <p>The allowlist parameters carry the "existing attachment" escape hatch
 	 * Edit uses: an id already attached to the workspace passes the permission
 	 * check even if the caller has lost view rights since. Add passes
 	 * {@code null} for both, since on create there are no prior attachments to
 	 * preserve.
+	 *
+	 * <p>{@code platformSkills} encodes "did the caller supply
+	 * {@code PLATFORM_SKILLS}?": pass a fresh empty {@code LinkedHashSet} when
+	 * the noun was supplied (helper fills it), or {@code null} to skip
+	 * platform-skill validation. The mirror reads this same null-vs-empty
+	 * signal — null leaves existing {@code CONFIG_JSON.platform_skills}
+	 * untouched, empty/populated replaces the array — so the caller does the
+	 * one-line gate {@code getGenRowStruct(PLATFORM_SKILLS) != null ? new
+	 * LinkedHashSet<>() : null} before calling.
 	 */
 	protected void validateWorkspaceInputs(User user, String workspaceId,
 			Set<String> existingDepAllowlist, Set<String> existingSkillAllowlist,
 			Set<String> engines, Set<String> projectDependencies,
 			List<Map<String, Object>> dependencyList,
 			List<Map<String, String>> workspaceResources,
-			Set<String> skillIds) {
+			Set<String> skillIds, Set<String> platformSkills) {
 		boolean hasDepAllowlist = existingDepAllowlist != null;
 		boolean hasSkillAllowlist = existingSkillAllowlist != null;
 		List<Map<String, Object>> mcpMapList = getMcpMapList();
@@ -324,36 +328,22 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 			}
 			workspaceResources.add(makeSkillResourceEntryMap(workspaceId, skillId));
 		}
-	}
 
-	/**
-	 * Reads and validates the {@code PLATFORM_SKILLS} noun. Returns {@code null}
-	 * when the noun was not supplied (signal to leave existing CONFIG_JSON
-	 * {@code platform_skills} untouched), a populated set when slugs were
-	 * supplied (possibly empty after trimming), and throws
-	 * {@link IllegalArgumentException} when a slug fails validation. Callers
-	 * catch and convert to {@code getError(...)} when they want the existing
-	 * partial-success response shape.
-	 */
-	protected Set<String> collectPlatformSkillsInput() {
-		if (getGenRowStruct(PLATFORM_SKILLS) == null) {
-			return null;
+		if (platformSkills != null) {
+			for (String slug : getNounAsStringList(PLATFORM_SKILLS)) {
+				if (slug == null) {
+					continue;
+				}
+				String trimmed = slug.trim();
+				if (trimmed.isEmpty()) {
+					continue;
+				}
+				if (!PlatformSkills.exists(trimmed)) {
+					throw new IllegalArgumentException("Platform skill not found: " + trimmed);
+				}
+				platformSkills.add(trimmed);
+			}
 		}
-		Set<String> out = new LinkedHashSet<>();
-		for (String slug : getNounAsStringList(PLATFORM_SKILLS)) {
-			if (slug == null) {
-				continue;
-			}
-			String trimmed = slug.trim();
-			if (trimmed.isEmpty()) {
-				continue;
-			}
-			if (!PlatformSkills.exists(trimmed)) {
-				throw new IllegalArgumentException("Platform skill not found: " + trimmed);
-			}
-			out.add(trimmed);
-		}
-		return out;
 	}
 
 }

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
@@ -241,11 +241,14 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 	 * Throws {@link IllegalArgumentException} with a human-readable message on
 	 * validation failure (callers catch and convert to {@code getError(...)}).
 	 *
-	 * <p>The allowlist parameters carry the "existing attachment" escape hatch
-	 * Edit uses: an id already attached to the workspace passes the permission
-	 * check even if the caller has lost view rights since. Add passes
-	 * {@code null} for both, since on create there are no prior attachments to
-	 * preserve.
+	 * <p>{@code existingDependencies} and {@code existingSkills} are the
+	 * workspace's pre-existing attachments — ids already in
+	 * {@code PROJECTDEPENDENCIES} and skill ids already in
+	 * {@code WORKSPACE_RESOURCE} respectively. They carry the "existing
+	 * attachment" escape hatch Edit uses: an id already attached passes the
+	 * permission check even if the caller has lost view rights since. Add
+	 * passes {@code null} for both, since on create there are no prior
+	 * attachments to preserve.
 	 *
 	 * <p>{@code platformSkills} encodes "did the caller supply
 	 * {@code PLATFORM_SKILLS}?": pass a fresh empty {@code LinkedHashSet} when
@@ -257,13 +260,13 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 	 * LinkedHashSet<>() : null} before calling.
 	 */
 	protected void validateWorkspaceInputs(User user, String workspaceId,
-			Set<String> existingDepAllowlist, Set<String> existingSkillAllowlist,
+			Set<String> existingDependencies, Set<String> existingSkills,
 			Set<String> engines, Set<String> projectDependencies,
 			List<Map<String, Object>> dependencyList,
 			List<Map<String, String>> workspaceResources,
 			Set<String> skillIds, Set<String> platformSkills) {
-		boolean hasDepAllowlist = existingDepAllowlist != null;
-		boolean hasSkillAllowlist = existingSkillAllowlist != null;
+		boolean hasExistingDeps = existingDependencies != null;
+		boolean hasExistingSkills = existingSkills != null;
 		List<Map<String, Object>> mcpMapList = getMcpMapList();
 		for (Map<String, Object> mcpMap : mcpMapList) {
 			if (!mcpMap.containsKey("type") || !mcpMap.containsKey("id")) {
@@ -287,7 +290,7 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 
 		for (String engine : engines) {
 			if (!SecurityEngineUtils.userCanViewEngine(user, engine)
-					&& !(hasDepAllowlist && existingDepAllowlist.contains(engine))) {
+					&& !(hasExistingDeps && existingDependencies.contains(engine))) {
 				throw new IllegalArgumentException("User lacks permission to one of the given engines: " + engine);
 			}
 			workspaceResources.add(makeResourceEntryMap(workspaceId, engine));
@@ -295,7 +298,7 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 
 		for (String project : projectDependencies) {
 			if (!SecurityProjectUtils.userCanViewProject(user, project)
-					&& !(hasDepAllowlist && existingDepAllowlist.contains(project))) {
+					&& !(hasExistingDeps && existingDependencies.contains(project))) {
 				throw new IllegalArgumentException(
 						"User lacks permission to one of the mcp tools/projects: " + project);
 			}
@@ -323,7 +326,7 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 				throw new IllegalArgumentException("Skill not found: " + skillId);
 			}
 			if (!SecurityProjectUtils.userCanViewProject(user, skillId)
-					&& !(hasSkillAllowlist && existingSkillAllowlist.contains(skillId))) {
+					&& !(hasExistingSkills && existingSkills.contains(skillId))) {
 				throw new IllegalArgumentException("User lacks permission to one of the given skills: " + skillId);
 			}
 			workspaceResources.add(makeSkillResourceEntryMap(workspaceId, skillId));

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AddWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AddWorkspaceReactor.java
@@ -55,8 +55,8 @@ public class AddWorkspaceReactor extends AbstractWorkspaceReactor {
 
 	public AddWorkspaceReactor() {
 		this.keysToGet = new String[] { NAME, DESCRIPTION, SYSTEM_PROMPT, ReactorKeysEnum.MCP.getKey(), PROMPTS,
-				SKILLS };
-		this.keyRequired = new int[] { 1, 0, 0, 0, 0, 0 };
+				SKILLS, PLATFORM_SKILLS };
+		this.keyRequired = new int[] { 1, 0, 0, 0, 0, 0, 0 };
 	}
 
 	@Override
@@ -83,9 +83,10 @@ public class AddWorkspaceReactor extends AbstractWorkspaceReactor {
 		List<Map<String, Object>> dependencyList = new ArrayList<>();
 		List<Map<String, String>> workspaceResources = new ArrayList<>();
 		Set<String> skillIds = new LinkedHashSet<>();
+		Set<String> platformSkills = getGenRowStruct(PLATFORM_SKILLS) != null ? new LinkedHashSet<>() : null;
 		try {
 			validateWorkspaceInputs(user, workspaceId, null, null, engines, projectDependencies, dependencyList,
-					workspaceResources, skillIds, null);
+					workspaceResources, skillIds, platformSkills);
 		} catch (IllegalArgumentException e) {
 			return getError(e.getMessage());
 		}
@@ -97,6 +98,14 @@ public class AddWorkspaceReactor extends AbstractWorkspaceReactor {
 			SecurityProjectUtils.updateProjectDependencies(user, workspaceId, dependencyList);
 			ModelInferenceLogsUtils.createNewWorkspaceEntry(workspaceId, user.getPrimaryLoginToken().getId(),
 					workspaceName, workspaceDescription, workspaceSystemPrompt, workspaceResources);
+			try {
+				mirrorCoreFieldsIntoConfigJson(workspaceId, workspaceSystemPrompt, engines, projectDependencies,
+						skillIds, platformSkills);
+			} catch (Exception mirrorEx) {
+				classLogger.warn(
+						"Created workspace '{}' but failed to mirror system_prompt/mcps/skills into CONFIG_JSON (legacy writes already succeeded)",
+						workspaceId, mirrorEx);
+			}
 		} catch (Exception e) {
 			classLogger.error("Failed to create workspace '{}' (ID: {}).", workspaceName, workspaceId, e);
 			if (workspaceProject != null) {

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AddWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AddWorkspaceReactor.java
@@ -85,7 +85,7 @@ public class AddWorkspaceReactor extends AbstractWorkspaceReactor {
 		Set<String> skillIds = new LinkedHashSet<>();
 		try {
 			validateWorkspaceInputs(user, workspaceId, null, null, engines, projectDependencies, dependencyList,
-					workspaceResources, skillIds);
+					workspaceResources, skillIds, null);
 		} catch (IllegalArgumentException e) {
 			return getError(e.getMessage());
 		}

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AddWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AddWorkspaceReactor.java
@@ -29,8 +29,8 @@ package prerna.engine.impl.model.inferencetracking.reactors.workspaces;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,16 +40,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import prerna.auth.User;
-import prerna.auth.utils.SecurityEngineUtils;
 import prerna.auth.utils.SecurityProjectUtils;
-import prerna.engine.api.IEngine.CATALOG_TYPE;
 import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.project.api.IProject;
 import prerna.project.impl.ProjectHelper;
-import prerna.prompt.PromptUtils;
 import prerna.sablecc2.om.ReactorKeysEnum;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
-import prerna.util.SystemEngineRegistry;
 import prerna.util.Utility;
 
 public class AddWorkspaceReactor extends AbstractWorkspaceReactor {
@@ -82,76 +78,16 @@ public class AddWorkspaceReactor extends AbstractWorkspaceReactor {
 		String workspaceDescription = this.keyValue.get(DESCRIPTION);
 		String workspaceSystemPrompt = this.keyValue.get(SYSTEM_PROMPT);
 
-		List<Map<String, Object>> mcpMapList = getMcpMapList();
 		Set<String> engines = new HashSet<>();
 		Set<String> projectDependencies = new HashSet<>();
 		List<Map<String, Object>> dependencyList = new ArrayList<>();
-
-		if (!mcpMapList.isEmpty()) {
-			for (Map<String, Object> mcpMap : mcpMapList) {
-				if (mcpMap.containsKey("type") && mcpMap.containsKey("id")) {
-					String type = (String) mcpMap.get("type");
-					String id = (String) mcpMap.get("id");
-					CATALOG_TYPE catalogType = CATALOG_TYPE.valueOf(type);
-					switch (catalogType) {
-					case PROJECT:
-						projectDependencies.add(id);
-						break;
-					default:
-						engines.add(id);
-					}
-					Map<String, Object> dependencyEntry = new HashMap<>();
-					dependencyEntry.put("ENGINEID", id);
-					dependencyEntry.put("ENGINETYPE", type);
-					dependencyList.add(dependencyEntry);
-				} else {
-					return getError("Tool map must contain both type and id");
-				}
-			}
-		}
-
 		List<Map<String, String>> workspaceResources = new ArrayList<>();
-		for (String engine : engines) {
-			if (!SecurityEngineUtils.userCanViewEngine(user, engine)) {
-				return getError("User lacks permission to one of the given engines: " + engine);
-			}
-			workspaceResources.add(makeResourceEntryMap(workspaceId, engine));
-		}
-
-		for (String project : projectDependencies) {
-			if (!SecurityProjectUtils.userCanViewProject(user, project)) {
-				return getError("User lacks permission to one of the mcp tools/projects: " + project);
-			}
-			workspaceResources.add(makeProjectResourceEntryMap(workspaceId, project));
-		}
-
-		// linked to workspaces via WORKSPACE_RESOURCE with RESOURCE_TYPE = "PROMPT"
-		List<String> promptIds = getNounAsStringList(PROMPTS);
-		if (!promptIds.isEmpty()) {
-			if (!SystemEngineRegistry.isPromptDbLoaded()) {
-				return getError("Prompt database is not enabled");
-			}
-			for (String promptId : promptIds) {
-				Map<String, Object> prompt = PromptUtils.getPrompt(promptId, user);
-				if (prompt == null || prompt.isEmpty()) {
-					return getError("Prompt not found or user lacks access: " + promptId);
-				}
-				workspaceResources.add(makePromptResourceEntryMap(workspaceId, promptId));
-			}
-		}
-
-
-		List<String> skillIds = getNounAsStringList(SKILLS);
-		if (!skillIds.isEmpty()) {
-			for (String skillId : skillIds) {
-				if (ModelInferenceLogsUtils.getSkillEntry(skillId) == null) {
-					return getError("Skill not found: " + skillId);
-				}
-				if (!SecurityProjectUtils.userCanViewProject(user, skillId)) {
-					return getError("User lacks permission to one of the given skills: " + skillId);
-				}
-				workspaceResources.add(makeSkillResourceEntryMap(workspaceId, skillId));
-			}
+		Set<String> skillIds = new LinkedHashSet<>();
+		try {
+			validateWorkspaceInputs(user, workspaceId, null, null, engines, projectDependencies, dependencyList,
+					workspaceResources, skillIds);
+		} catch (IllegalArgumentException e) {
+			return getError(e.getMessage());
 		}
 
 		IProject workspaceProject = null;

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/EditWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/EditWorkspaceReactor.java
@@ -38,20 +38,13 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.json.JSONArray;
-import org.json.JSONObject;
 
 import prerna.auth.User;
-import prerna.auth.utils.SecurityEngineUtils;
 import prerna.auth.utils.SecurityProjectUtils;
-import prerna.engine.api.IEngine.CATALOG_TYPE;
 import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
-import prerna.prompt.PromptUtils;
-import prerna.reactor.agent.skill.PlatformSkills;
 import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.ReactorKeysEnum;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
-import prerna.util.SystemEngineRegistry;
 
 public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 
@@ -80,8 +73,7 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 			throw new IllegalArgumentException("Workspace not found");
 		}
 
-		Object currentlyIsActive = current.get("is_active");
-		Boolean currentlyActive = (Boolean) currentlyIsActive;
+		Boolean currentlyActive = (Boolean) current.get("is_active");
 
 		if (!SecurityProjectUtils.userCanEditProject(user, workspaceId)) {
 			throw new IllegalArgumentException(
@@ -104,104 +96,27 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 			}
 		}
 
-		List<Map<String, Object>> currProjectDependencies = SecurityProjectUtils.getProjectDependencies(workspaceId,
-				false);
-		Set<String> curDepList = currProjectDependencies.stream().map(map -> (String) map.get("engine_id"))
-				.collect(Collectors.toSet());
+		Set<String> curDepList = SecurityProjectUtils.getProjectDependencies(workspaceId, false).stream()
+				.map(map -> (String) map.get("engine_id")).collect(Collectors.toSet());
+		Set<String> curSkillList = ModelInferenceLogsUtils
+				.getWorkspaceResources(workspaceId, SKILL_RESOURCE_TYPE, null).stream()
+				.map(map -> (String) map.get("resource_id")).collect(Collectors.toSet());
 
-		List<Map<String, Object>> mcpMapList = getMcpMapList();
 		Set<String> engines = new HashSet<>();
 		Set<String> projectDependencies = new HashSet<>();
-
 		List<Map<String, Object>> dependencyList = new ArrayList<>();
-		if (!mcpMapList.isEmpty()) {
-			for (Map<String, Object> mcpMap : mcpMapList) {
-				if (mcpMap.containsKey("type") && mcpMap.containsKey("id")) {
-					String type = (String) mcpMap.get("type");
-					String id = (String) mcpMap.get("id");
-					CATALOG_TYPE catalogType = CATALOG_TYPE.valueOf(type);
-					switch (catalogType) {
-					case PROJECT:
-						projectDependencies.add(id);
-						break;
-					default:
-						engines.add(id);
-					}
-					Map<String, Object> dependencyEntry = new HashMap<>();
-					dependencyEntry.put("ENGINEID", id);
-					dependencyEntry.put("ENGINETYPE", type);
-					dependencyList.add(dependencyEntry);
-				} else {
-					return getError("Tool map must contain both type and id");
-				}
-			}
-		}
-		SecurityProjectUtils.updateProjectDependencies(user, workspaceId, dependencyList);
-
 		List<Map<String, String>> workspaceResources = new ArrayList<>();
-		for (String engine : engines) {
-			if (!SecurityEngineUtils.userCanViewEngine(user, engine) && !curDepList.contains(engine)) {
-				return getError("User lacks permission to one of the given engines: " + engine);
-			}
-			workspaceResources.add(makeResourceEntryMap(workspaceId, engine));
+		Set<String> skillIds = new LinkedHashSet<>();
+		Set<String> platformSkills;
+		try {
+			validateWorkspaceInputs(user, workspaceId, curDepList, curSkillList, engines, projectDependencies,
+					dependencyList, workspaceResources, skillIds);
+			platformSkills = collectPlatformSkillsInput();
+		} catch (IllegalArgumentException e) {
+			return getError(e.getMessage());
 		}
 
-		for (String project : projectDependencies) {
-			if (!SecurityProjectUtils.userCanViewProject(user, project) && !curDepList.contains(project)) {
-				return getError("User lacks permission to one of the mcp tools/projects: " + project);
-			}
-			workspaceResources.add(makeProjectResourceEntryMap(workspaceId, project));
-		}
-
-		// linked to workspaces via WORKSPACE_RESOURCE with RESOURCE_TYPE = "PROMPT"
-		List<String> promptIds = getNounAsStringList(PROMPTS);
-		if (!promptIds.isEmpty()) {
-			if (!SystemEngineRegistry.isPromptDbLoaded()) {
-				return getError("Prompt database is not enabled");
-			}
-			for (String promptId : promptIds) {
-				Map<String, Object> prompt = PromptUtils.getPrompt(promptId, user);
-				if (prompt == null || prompt.isEmpty()) {
-					return getError("Prompt not found or user lacks access: " + promptId);
-				}
-				workspaceResources.add(makePromptResourceEntryMap(workspaceId, promptId));
-			}
-		}
-
-
-		Set<String> skillIds = new HashSet<>(getNounAsStringList(SKILLS));
-		if (!skillIds.isEmpty()) {
-			Set<String> curSkillList = ModelInferenceLogsUtils
-					.getWorkspaceResources(workspaceId, SKILL_RESOURCE_TYPE, null).stream()
-					.map(map -> map.get("resource_id")).collect(Collectors.toSet());
-			for (String skillId : skillIds) {
-				if (ModelInferenceLogsUtils.getSkillEntry(skillId) == null) {
-					return getError("Skill not found: " + skillId);
-				}
-				if (!SecurityProjectUtils.userCanViewProject(user, skillId) && !curSkillList.contains(skillId)) {
-					return getError("User lacks permission to one of the given skills: " + skillId);
-				}
-				workspaceResources.add(makeSkillResourceEntryMap(workspaceId, skillId));
-			}
-		}
-
-		Set<String> platformSkills = null;
-		if (getGenRowStruct(PLATFORM_SKILLS) != null) {
-			platformSkills = new LinkedHashSet<>();
-			for (String slug : getNounAsStringList(PLATFORM_SKILLS)) {
-				if (slug == null) {
-					continue;
-				}
-				String trimmed = slug.trim();
-				if (trimmed.isEmpty()) {
-					continue;
-				}
-				if (!PlatformSkills.exists(trimmed)) {
-					return getError("Platform skill not found: " + trimmed);
-				}
-				platformSkills.add(trimmed);
-			}
-		}
+		SecurityProjectUtils.updateProjectDependencies(user, workspaceId, dependencyList);
 
 		try {
 			ModelInferenceLogsUtils.updateWorkspaceEntry(workspaceId, workspaceName, workspaceDescription,
@@ -231,78 +146,6 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 		}
 
 		return new NounMetadata(true, PixelDataType.BOOLEAN);
-	}
-
-	/**
-	 * Persist {@code system_prompt}, the engine/project MCP refs, and the skill
-	 * refs into {@code WORKSPACE.CONFIG_JSON}, preserving any other fields already
-	 * there.
-	 *
-	 * <p>
-	 * Empty {@code engines} + empty {@code projects} writes an empty {@code mcps}
-	 * array, and empty {@code skills} writes an empty {@code skills} array - both
-	 * intentional, since the user may be removing all MCPs/skills. Null
-	 * {@code systemPrompt} omits the key (vs. writing JSON null), so the loader
-	 * falls through to the legacy SYSTEM_PROMPT column read for that field.
-	 *
-	 * <p>
-	 * The {@code skills} entry shape - {@code { "skill_id": <id> }} - matches what
-	 * {@code AgentConfigLoader.resolveSkills} and
-	 * {@code ModelInferenceLogsUtils.addSkillToWorkspaceConfigJson} read/write. No
-	 * {@code pinned_version} is emitted because the edit input carries only ids.
-	 *
-	 * <p>
-	 * {@code platformSkills} differs from {@code skills}/{@code mcps}: a {@code null}
-	 * value leaves any existing {@code platform_skills} array untouched (callers that
-	 * omit the input never clobber it), while a non-null value is a full replace (an
-	 * empty set clears it). Entries are plain slug strings, matching
-	 * {@code CONFIG_JSON.platform_skills[]}.
-	 */
-	private static void mirrorCoreFieldsIntoConfigJson(String workspaceId, String systemPrompt, Set<String> engines,
-			Set<String> projects, Set<String> skills, Set<String> platformSkills) throws Exception {
-		JSONObject cfg = ModelInferenceLogsUtils.getWorkspaceConfigJson(workspaceId);
-		if (cfg == null) {
-			cfg = new JSONObject();
-			cfg.put("schema_version", 1);
-		}
-		if (systemPrompt != null && !systemPrompt.isEmpty()) {
-			cfg.put("system_prompt", systemPrompt);
-		} else {
-			cfg.remove("system_prompt");
-		}
-
-		JSONArray mcpsJson = new JSONArray();
-		for (String id : engines) {
-			JSONObject entry = new JSONObject();
-			entry.put("id", id);
-			entry.put("name", id);
-			mcpsJson.put(entry);
-		}
-		for (String id : projects) {
-			JSONObject entry = new JSONObject();
-			entry.put("id", id);
-			entry.put("name", id);
-			mcpsJson.put(entry);
-		}
-		cfg.put("mcps", mcpsJson);
-
-		JSONArray skillsJson = new JSONArray();
-		for (String id : skills) {
-			JSONObject entry = new JSONObject();
-			entry.put("skill_id", id);
-			skillsJson.put(entry);
-		}
-		cfg.put("skills", skillsJson);
-
-		if (platformSkills != null) {
-			JSONArray platformSkillsJson = new JSONArray();
-			for (String slug : platformSkills) {
-				platformSkillsJson.put(slug);
-			}
-			cfg.put("platform_skills", platformSkillsJson);
-		}
-
-		ModelInferenceLogsUtils.updateWorkspaceConfigJson(workspaceId, cfg);
 	}
 
 }

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/EditWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/EditWorkspaceReactor.java
@@ -107,11 +107,10 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 		List<Map<String, Object>> dependencyList = new ArrayList<>();
 		List<Map<String, String>> workspaceResources = new ArrayList<>();
 		Set<String> skillIds = new LinkedHashSet<>();
-		Set<String> platformSkills;
+		Set<String> platformSkills = getGenRowStruct(PLATFORM_SKILLS) != null ? new LinkedHashSet<>() : null;
 		try {
 			validateWorkspaceInputs(user, workspaceId, curDepList, curSkillList, engines, projectDependencies,
-					dependencyList, workspaceResources, skillIds);
-			platformSkills = collectPlatformSkillsInput();
+					dependencyList, workspaceResources, skillIds, platformSkills);
 		} catch (IllegalArgumentException e) {
 			return getError(e.getMessage());
 		}

--- a/src/prerna/reactor/agent/skill/AttachSkillToWorkspaceReactor.java
+++ b/src/prerna/reactor/agent/skill/AttachSkillToWorkspaceReactor.java
@@ -27,7 +27,9 @@
  *******************************************************************************/
 package prerna.reactor.agent.skill;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
@@ -37,6 +39,7 @@ import com.github.f4b6a3.uuid.alt.GUID;
 
 import prerna.auth.User;
 import prerna.auth.utils.SecurityProjectUtils;
+import prerna.engine.api.IEngine.CATALOG_TYPE;
 import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.engine.impl.model.inferencetracking.reactors.workspaces.AbstractWorkspaceReactor;
 import prerna.reactor.AbstractReactor;
@@ -172,6 +175,39 @@ public class AttachSkillToWorkspaceReactor extends AbstractReactor {
 				classLogger.warn("Attached skill '{}' to workspace '{}' but failed to mirror into CONFIG_JSON.skills",
 						skillId, workspaceId, mirrorEx);
 				response.put("warning", "Skill attached but CONFIG_JSON sync failed: " + mirrorEx.getMessage());
+			}
+
+			// Mirror the attachment into PROJECTDEPENDENCIES so the skill shows up as a
+			// project dependency alongside MCP engines/projects. Bulk update via merge:
+			// read current deps, append the skill if not already present, rewrite.
+			// Best-effort - WORKSPACE_RESOURCE row is the source of truth.
+			try {
+				List<Map<String, Object>> current = SecurityProjectUtils.getProjectDependencies(workspaceId, false);
+				List<Map<String, Object>> merged = new ArrayList<>();
+				boolean alreadyPresent = false;
+				for (Map<String, Object> row : current) {
+					String existingId = (String) row.get("engine_id");
+					String existingType = (String) row.get("engine_type");
+					Map<String, Object> entry = new HashMap<>();
+					entry.put("ENGINEID", existingId);
+					entry.put("ENGINETYPE", existingType);
+					merged.add(entry);
+					if (skillId.equals(existingId)) {
+						alreadyPresent = true;
+					}
+				}
+				if (!alreadyPresent) {
+					Map<String, Object> skillDep = new HashMap<>();
+					skillDep.put("ENGINEID", skillId);
+					skillDep.put("ENGINETYPE", CATALOG_TYPE.PROJECT.name());
+					merged.add(skillDep);
+				}
+				SecurityProjectUtils.updateProjectDependencies(user, workspaceId, merged);
+			} catch (Exception depEx) {
+				classLogger.warn("Attached skill '{}' to workspace '{}' but failed to record PROJECTDEPENDENCIES entry",
+						skillId, workspaceId, depEx);
+				response.put("dependency_warning",
+						"Skill attached but PROJECTDEPENDENCIES sync failed: " + depEx.getMessage());
 			}
 
 			return new NounMetadata(response, PixelDataType.MAP, PixelOperationType.OPERATION);

--- a/src/prerna/reactor/agent/skill/AttachSkillToWorkspaceReactor.java
+++ b/src/prerna/reactor/agent/skill/AttachSkillToWorkspaceReactor.java
@@ -201,8 +201,8 @@ public class AttachSkillToWorkspaceReactor extends AbstractReactor {
 					skillDep.put("ENGINEID", skillId);
 					skillDep.put("ENGINETYPE", CATALOG_TYPE.PROJECT.name());
 					merged.add(skillDep);
+					SecurityProjectUtils.updateProjectDependencies(user, workspaceId, merged);
 				}
-				SecurityProjectUtils.updateProjectDependencies(user, workspaceId, merged);
 			} catch (Exception depEx) {
 				classLogger.warn("Attached skill '{}' to workspace '{}' but failed to record PROJECTDEPENDENCIES entry",
 						skillId, workspaceId, depEx);

--- a/src/prerna/reactor/agent/skill/DetachSkillFromWorkspaceReactor.java
+++ b/src/prerna/reactor/agent/skill/DetachSkillFromWorkspaceReactor.java
@@ -139,6 +139,15 @@ public class DetachSkillFromWorkspaceReactor extends AbstractReactor {
 			response.put("warning", "Skill detached but CONFIG_JSON sync failed: " + mirrorEx.getMessage());
 		}
 
+		try {
+			SecurityProjectUtils.removeProjectDependency(user, workspaceId, skillId);
+		} catch (Exception depEx) {
+			classLogger.warn("Detached skill '{}' from workspace '{}' but failed to remove PROJECTDEPENDENCIES entry",
+					skillId, workspaceId, depEx);
+			response.put("dependency_warning",
+					"Skill detached but PROJECTDEPENDENCIES sync failed: " + depEx.getMessage());
+		}
+
 		return new NounMetadata(response, PixelDataType.MAP, PixelOperationType.OPERATION);
 	}
 

--- a/src/prerna/reactor/agent/skill/DetachSkillFromWorkspaceReactor.java
+++ b/src/prerna/reactor/agent/skill/DetachSkillFromWorkspaceReactor.java
@@ -139,13 +139,15 @@ public class DetachSkillFromWorkspaceReactor extends AbstractReactor {
 			response.put("warning", "Skill detached but CONFIG_JSON sync failed: " + mirrorEx.getMessage());
 		}
 
-		try {
-			SecurityProjectUtils.removeProjectDependency(user, workspaceId, skillId);
-		} catch (Exception depEx) {
-			classLogger.warn("Detached skill '{}' from workspace '{}' but failed to remove PROJECTDEPENDENCIES entry",
-					skillId, workspaceId, depEx);
-			response.put("dependency_warning",
-					"Skill detached but PROJECTDEPENDENCIES sync failed: " + depEx.getMessage());
+		if (deleted > 0) {
+			try {
+				SecurityProjectUtils.removeProjectDependency(user, workspaceId, skillId);
+			} catch (Exception depEx) {
+				classLogger.warn("Detached skill '{}' from workspace '{}' but failed to remove PROJECTDEPENDENCIES entry",
+						skillId, workspaceId, depEx);
+				response.put("dependency_warning",
+						"Skill detached but PROJECTDEPENDENCIES sync failed: " + depEx.getMessage());
+			}
 		}
 
 		return new NounMetadata(response, PixelDataType.MAP, PixelOperationType.OPERATION);


### PR DESCRIPTION
## Summary
- Skills are projects (`PROJECT_TYPE.SKILL`), so attaching one to a workspace should also record it in `PROJECTDEPENDENCIES` — the same table where MCP engines/projects already land. Previously only the `WORKSPACE_RESOURCE__` row was written, leaving the project dependency graph incomplete for skills.
- Mirror the CRUD into all four entry points: `AttachSkillToWorkspaceReactor`, `DetachSkillFromWorkspaceReactor`, `EditWorkspaceReactor`, `AddWorkspaceReactor`.
- `ENGINETYPE` = `PROJECT` for skill dependencies (matches `updateProjectDependenciesWithoutType`'s convention for project-typed deps).

### Per-file
- **AttachSkillToWorkspaceReactor** — after the `WORKSPACE_RESOURCE` insert, read current deps via `getProjectDependencies`, append the skill if not already present, bulk-rewrite via `updateProjectDependencies`. Wrapped best-effort like the existing `CONFIG_JSON` mirror — the `WORKSPACE_RESOURCE` row stays the source of truth.
- **DetachSkillFromWorkspaceReactor** — after the row delete, call `SecurityProjectUtils.removeProjectDependency(user, workspaceId, skillId)`. Best-effort.
- **EditWorkspaceReactor** — include `skillIds` in `dependencyList`. Moved the `updateProjectDependencies` call to after the skill block so it actually sees them.
- **AddWorkspaceReactor** — same pattern for parity on the create path.

### Notes / tradeoffs
- Attach uses the existing bulk `updateProjectDependencies` (DELETE + bulk INSERT) after merging current rows. Same race exposure as the existing edit-time flow — fine for now, but a dedicated single-row insert helper would be cleaner long-term.
- All four sync points are best-effort with `classLogger.warn` + a `dependency_warning` field on the response, matching the established pattern for the `CONFIG_JSON` mirror.

## Test plan
- [ ] Attach a skill to a workspace → row appears in `WORKSPACE_RESOURCE__` **and** `PROJECTDEPENDENCIES`
- [ ] Attach the same skill again → idempotent, no duplicate dependency row
- [ ] Detach the skill → both rows removed
- [ ] Edit a workspace with a skills list → `PROJECTDEPENDENCIES` reflects the new full set (skills + MCPs)
- [ ] Add a new workspace with skills → dependencies recorded on create
- [ ] Confirm `mvn compile` passes (verified locally pre-push)