### PR TITLE
feat: role-based feature visibility — App Profiles + Platform Profiles

### DIFF
--- a/src/prerna/auth/utils/AbstractSecurityUtils.java
+++ b/src/prerna/auth/utils/AbstractSecurityUtils.java
@@ -2414,6 +2414,198 @@ public abstract class AbstractSecurityUtils {
 				}
 			}
 
+			// APP_PROFILE — named profiles per app
+			colNames = new String[] { "PROFILE_ID", "APP_ID", "PROFILE_NAME", "DESCRIPTION", "IS_DEFAULT", "CREATED_BY", "CREATED_AT" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(2000)", BOOLEAN_DATATYPE_NAME, "VARCHAR(255)", TIMESTAMP_DATATYPE_NAME };
+			defaultValues = new Object[] { null, null, null, null, false, null, null };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExistsWithDefaults("APP_PROFILE", colNames, types, defaultValues);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "APP_PROFILE", database, schema)) {
+					String sql = queryUtil.createTable("APP_PROFILE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "APP_PROFILE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("APP_PROFILE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
+			// APP_FEATURE — feature key definitions per app
+			colNames = new String[] { "FEATURE_ID", "APP_ID", "FEATURE_KEY", "DESCRIPTION", "CREATED_BY", "CREATED_AT" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(2000)", "VARCHAR(255)", TIMESTAMP_DATATYPE_NAME };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExists("APP_FEATURE", colNames, types);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "APP_FEATURE", database, schema)) {
+					String sql = queryUtil.createTable("APP_FEATURE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "APP_FEATURE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("APP_FEATURE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
+			// APP_PROFILE_FEATURE — which features are ON per profile (missing row = OFF)
+			colNames = new String[] { "APP_ID", "PROFILE_ID", "FEATURE_ID", "ENABLED" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(255)", BOOLEAN_DATATYPE_NAME };
+			defaultValues = new Object[] { null, null, null, true };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExistsWithDefaults("APP_PROFILE_FEATURE", colNames, types, defaultValues);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "APP_PROFILE_FEATURE", database, schema)) {
+					String sql = queryUtil.createTable("APP_PROFILE_FEATURE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "APP_PROFILE_FEATURE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("APP_PROFILE_FEATURE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
+			// APP_USER_PROFILE — user-to-profile assignment per app (one per user per app)
+			colNames = new String[] { "APP_ID", "USER_ID", "PROFILE_ID", "ASSIGNED_BY", "ASSIGNED_AT" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(255)", TIMESTAMP_DATATYPE_NAME };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExists("APP_USER_PROFILE", colNames, types);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "APP_USER_PROFILE", database, schema)) {
+					String sql = queryUtil.createTable("APP_USER_PROFILE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "APP_USER_PROFILE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("APP_USER_PROFILE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
+			// PLATFORM_PROFILE — named platform-level profiles
+			colNames = new String[] { "PROFILE_ID", "PROFILE_NAME", "DESCRIPTION", "CREATED_BY", "CREATED_AT" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(2000)", "VARCHAR(255)", TIMESTAMP_DATATYPE_NAME };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExists("PLATFORM_PROFILE", colNames, types);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "PLATFORM_PROFILE", database, schema)) {
+					String sql = queryUtil.createTable("PLATFORM_PROFILE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "PLATFORM_PROFILE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("PLATFORM_PROFILE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
+			// PLATFORM_PROFILE_FEATURE — predefined nav keys ON/OFF per platform profile
+			colNames = new String[] { "PROFILE_ID", "FEATURE_KEY", "ENABLED" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(100)", BOOLEAN_DATATYPE_NAME };
+			defaultValues = new Object[] { null, null, true };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExistsWithDefaults("PLATFORM_PROFILE_FEATURE", colNames, types, defaultValues);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "PLATFORM_PROFILE_FEATURE", database, schema)) {
+					String sql = queryUtil.createTable("PLATFORM_PROFILE_FEATURE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "PLATFORM_PROFILE_FEATURE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("PLATFORM_PROFILE_FEATURE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
+			// PLATFORM_USER_PROFILE — user-to-platform-profile assignment (one per user)
+			colNames = new String[] { "USER_ID", "PROFILE_ID", "ASSIGNED_BY", "ASSIGNED_AT" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(255)", TIMESTAMP_DATATYPE_NAME };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExists("PLATFORM_USER_PROFILE", colNames, types);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "PLATFORM_USER_PROFILE", database, schema)) {
+					String sql = queryUtil.createTable("PLATFORM_USER_PROFILE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "PLATFORM_USER_PROFILE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("PLATFORM_USER_PROFILE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
 			if (!conn.getAutoCommit()) {
 				conn.commit();
 			}

--- a/src/prerna/auth/utils/AppProfileUtils.java
+++ b/src/prerna/auth/utils/AppProfileUtils.java
@@ -220,30 +220,30 @@ public class AppProfileUtils {
 	public static List<Map<String, Object>> getProfiles(String appId) {
 		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
 		List<Map<String, Object>> profiles = new ArrayList<>();
-		SelectQueryStruct qs = new SelectQueryStruct();
-		qs.addSelector(new QueryColumnSelector("APP_PROFILE__PROFILE_ID"));
-		qs.addSelector(new QueryColumnSelector("APP_PROFILE__PROFILE_NAME"));
-		qs.addSelector(new QueryColumnSelector("APP_PROFILE__DESCRIPTION"));
-		qs.addSelector(new QueryColumnSelector("APP_PROFILE__IS_DEFAULT"));
-		qs.addSelector(new QueryColumnSelector("APP_PROFILE__CREATED_BY"));
-		qs.addSelector(new QueryColumnSelector("APP_PROFILE__CREATED_AT"));
-		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("APP_PROFILE__APP_ID", "==", appId));
-		qs.addOrderBy("APP_PROFILE__PROFILE_NAME", "ASC");
-		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
-			while (wrapper.hasNext()) {
-				Object[] row = wrapper.next().getValues();
+		String sql = "SELECT PROFILE_ID, PROFILE_NAME, DESCRIPTION, IS_DEFAULT, CREATED_BY, CREATED_AT "
+				+ "FROM APP_PROFILE WHERE APP_ID=? ORDER BY PROFILE_NAME ASC";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, appId);
+			rs = ps.executeQuery();
+			while (rs.next()) {
+				String profileId = rs.getString("PROFILE_ID");
 				Map<String, Object> profile = new HashMap<>();
-				profile.put("profileId", row[0]);
-				profile.put("profileName", row[1]);
-				profile.put("description", row[2]);
-				profile.put("isDefault", row[3]);
-				profile.put("createdBy", row[4]);
-				profile.put("createdAt", row[5]);
-				profile.put("userCount", getAssignedUserCount(securityDb, appId, (String) row[0]));
+				profile.put("profileId", profileId);
+				profile.put("profileName", rs.getString("PROFILE_NAME"));
+				profile.put("description", rs.getString("DESCRIPTION"));
+				profile.put("isDefault", rs.getBoolean("IS_DEFAULT"));
+				profile.put("createdBy", rs.getString("CREATED_BY"));
+				profile.put("createdAt", rs.getTimestamp("CREATED_AT"));
+				profile.put("userCount", getAssignedUserCount(securityDb, appId, profileId));
 				profiles.add(profile);
 			}
-		} catch (Exception e) {
+		} catch (SQLException e) {
 			classLogger.error("Failed to get app profiles", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
 		}
 		return profiles;
 	}
@@ -342,27 +342,27 @@ public class AppProfileUtils {
 	public static List<Map<String, Object>> getFeatures(String appId) {
 		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
 		List<Map<String, Object>> features = new ArrayList<>();
-		SelectQueryStruct qs = new SelectQueryStruct();
-		qs.addSelector(new QueryColumnSelector("APP_FEATURE__FEATURE_ID"));
-		qs.addSelector(new QueryColumnSelector("APP_FEATURE__FEATURE_KEY"));
-		qs.addSelector(new QueryColumnSelector("APP_FEATURE__DESCRIPTION"));
-		qs.addSelector(new QueryColumnSelector("APP_FEATURE__CREATED_BY"));
-		qs.addSelector(new QueryColumnSelector("APP_FEATURE__CREATED_AT"));
-		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("APP_FEATURE__APP_ID", "==", appId));
-		qs.addOrderBy("APP_FEATURE__FEATURE_KEY", "ASC");
-		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
-			while (wrapper.hasNext()) {
-				Object[] row = wrapper.next().getValues();
+		String sql = "SELECT FEATURE_ID, FEATURE_KEY, DESCRIPTION, CREATED_BY, CREATED_AT "
+				+ "FROM APP_FEATURE WHERE APP_ID=? ORDER BY FEATURE_KEY ASC";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, appId);
+			rs = ps.executeQuery();
+			while (rs.next()) {
 				Map<String, Object> feature = new HashMap<>();
-				feature.put("featureId", row[0]);
-				feature.put("featureKey", row[1]);
-				feature.put("description", row[2]);
-				feature.put("createdBy", row[3]);
-				feature.put("createdAt", row[4]);
+				feature.put("featureId", rs.getString("FEATURE_ID"));
+				feature.put("featureKey", rs.getString("FEATURE_KEY"));
+				feature.put("description", rs.getString("DESCRIPTION"));
+				feature.put("createdBy", rs.getString("CREATED_BY"));
+				feature.put("createdAt", rs.getTimestamp("CREATED_AT"));
 				features.add(feature);
 			}
-		} catch (Exception e) {
+		} catch (SQLException e) {
 			classLogger.error("Failed to get app features", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
 		}
 		return features;
 	}

--- a/src/prerna/auth/utils/AppProfileUtils.java
+++ b/src/prerna/auth/utils/AppProfileUtils.java
@@ -1,0 +1,709 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.auth.utils;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.AccessToken;
+import prerna.auth.User;
+import prerna.engine.api.IRDBMSEngine;
+import prerna.engine.api.IRawSelectWrapper;
+import prerna.query.querystruct.SelectQueryStruct;
+import prerna.query.querystruct.filters.SimpleQueryFilter;
+import prerna.query.querystruct.selectors.QueryColumnSelector;
+import prerna.rdf.engine.wrappers.WrapperManager;
+import prerna.util.ConnectionUtils;
+import prerna.util.SystemEngineRegistry;
+import prerna.util.Utility;
+
+public class AppProfileUtils {
+
+	private static final Logger classLogger = LogManager.getLogger(AppProfileUtils.class);
+	private static final String FEATURE_KEY_PATTERN = "^[a-zA-Z0-9\\-]+$";
+	private static final int FEATURE_KEY_MAX_LENGTH = 100;
+
+	private AppProfileUtils() {
+	}
+
+	// ─── Permission checks ──────────────────────────────────────────────────
+
+	public static boolean canManageProfiles(User user, String appId) {
+		if (!appExists(appId)) {
+			throw new IllegalArgumentException("App not found: " + appId);
+		}
+		if (SecurityAdminUtils.userIsAdmin(user)) return true;
+		if (SecurityProjectUtils.userIsOwner(user, appId)) return true;
+		if (SecurityProjectUtils.userCanEditProject(user, appId)) return true;
+		return false;
+	}
+
+	public static boolean canEvaluateFeatures(User user, String appId) {
+		return SecurityProjectUtils.userCanViewProject(user, appId);
+	}
+
+	private static boolean appExists(String appId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("PROJECTPERMISSION__PROJECTID"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("PROJECTPERMISSION__PROJECTID", "==", appId));
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			return wrapper.hasNext();
+		} catch (Exception e) {
+			classLogger.error("Error checking app existence", e);
+			return false;
+		}
+	}
+
+	// ─── Profile CRUD ───────────────────────────────────────────────────────
+
+	public static Map<String, Object> createProfile(String appId, String name, String description,
+			boolean isDefault, User user) {
+		if (name == null || name.trim().isEmpty()) {
+			throw new IllegalArgumentException("Profile name cannot be blank.");
+		}
+		if (name.trim().length() > 100) {
+			throw new IllegalArgumentException("Profile name cannot exceed 100 characters.");
+		}
+		String profileName = name.trim();
+		String profileId = UUID.randomUUID().toString();
+		String actorId = getUserId(user);
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+
+		if (isDefault) {
+			clearDefaultProfile(securityDb, appId);
+		}
+
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"INSERT INTO APP_PROFILE (PROFILE_ID, APP_ID, PROFILE_NAME, DESCRIPTION, IS_DEFAULT, CREATED_BY, CREATED_AT) VALUES (?,?,?,?,?,?,?)");
+			int i = 1;
+			ps.setString(i++, profileId);
+			ps.setString(i++, appId);
+			ps.setString(i++, profileName);
+			ps.setString(i++, description);
+			ps.setBoolean(i++, isDefault);
+			ps.setString(i++, actorId);
+			ps.setTimestamp(i++, Utility.getCurrentSqlTimestampUTC());
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error("Failed to create app profile", e);
+			throw new IllegalArgumentException("An error occurred creating the app profile.");
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+
+		Map<String, Object> result = new HashMap<>();
+		result.put("profileId", profileId);
+		result.put("profileName", profileName);
+		result.put("description", description);
+		result.put("isDefault", isDefault);
+		return result;
+	}
+
+	public static void updateProfile(String appId, String profileId, String name, String description,
+			Boolean isDefault, User user) {
+		if (name != null) {
+			if (name.trim().isEmpty()) throw new IllegalArgumentException("Profile name cannot be blank.");
+			if (name.trim().length() > 100) throw new IllegalArgumentException("Profile name cannot exceed 100 characters.");
+		}
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		if (isDefault != null && isDefault) {
+			clearDefaultProfile(securityDb, appId);
+		}
+		StringBuilder sb = new StringBuilder("UPDATE APP_PROFILE SET");
+		List<Object> params = new ArrayList<>();
+		if (name != null) { sb.append(" PROFILE_NAME=?,"); params.add(name.trim()); }
+		if (description != null) { sb.append(" DESCRIPTION=?,"); params.add(description); }
+		if (isDefault != null) { sb.append(" IS_DEFAULT=?,"); params.add(isDefault); }
+		if (params.isEmpty()) return;
+		sb.setLength(sb.length() - 1);
+		sb.append(" WHERE PROFILE_ID=? AND APP_ID=?");
+		params.add(profileId);
+		params.add(appId);
+
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(sb.toString());
+			for (int i = 0; i < params.size(); i++) {
+				Object val = params.get(i);
+				if (val instanceof Boolean) {
+					ps.setBoolean(i + 1, (Boolean) val);
+				} else {
+					ps.setString(i + 1, (String) val);
+				}
+			}
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error("Failed to update app profile", e);
+			throw new IllegalArgumentException("An error occurred updating the app profile.");
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static void deleteProfile(String appId, String profileId, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		int count = getAssignedUserCount(securityDb, appId, profileId);
+		if (count > 0) {
+			throw new IllegalArgumentException(
+					"Cannot delete: " + count + " user(s) are assigned to this profile. Reassign them first.");
+		}
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement("DELETE FROM APP_PROFILE WHERE PROFILE_ID=? AND APP_ID=?");
+			ps.setString(1, profileId);
+			ps.setString(2, appId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to delete app profile", e);
+			throw new IllegalArgumentException("An error occurred deleting the app profile.");
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		ps = null;
+		try {
+			ps = securityDb.getPreparedStatement("DELETE FROM APP_PROFILE_FEATURE WHERE PROFILE_ID=? AND APP_ID=?");
+			ps.setString(1, profileId);
+			ps.setString(2, appId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to cascade delete app profile features", e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static List<Map<String, Object>> getProfiles(String appId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		List<Map<String, Object>> profiles = new ArrayList<>();
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__PROFILE_ID"));
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__PROFILE_NAME"));
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__DESCRIPTION"));
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__IS_DEFAULT"));
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__CREATED_BY"));
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__CREATED_AT"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("APP_PROFILE__APP_ID", "==", appId));
+		qs.addOrderBy("APP_PROFILE__PROFILE_NAME", "ASC");
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			while (wrapper.hasNext()) {
+				Object[] row = wrapper.next().getValues();
+				Map<String, Object> profile = new HashMap<>();
+				profile.put("profileId", row[0]);
+				profile.put("profileName", row[1]);
+				profile.put("description", row[2]);
+				profile.put("isDefault", row[3]);
+				profile.put("createdBy", row[4]);
+				profile.put("createdAt", row[5]);
+				profile.put("userCount", getAssignedUserCount(securityDb, appId, (String) row[0]));
+				profiles.add(profile);
+			}
+		} catch (Exception e) {
+			classLogger.error("Failed to get app profiles", e);
+		}
+		return profiles;
+	}
+
+	// ─── Feature CRUD ───────────────────────────────────────────────────────
+
+	public static Map<String, Object> createFeature(String appId, String featureKey,
+			String description, User user) {
+		validateFeatureKey(featureKey);
+		String featureId = UUID.randomUUID().toString();
+		String actorId = getUserId(user);
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"INSERT INTO APP_FEATURE (FEATURE_ID, APP_ID, FEATURE_KEY, DESCRIPTION, CREATED_BY, CREATED_AT) VALUES (?,?,?,?,?,?)");
+			int i = 1;
+			ps.setString(i++, featureId);
+			ps.setString(i++, appId);
+			ps.setString(i++, featureKey);
+			ps.setString(i++, description);
+			ps.setString(i++, actorId);
+			ps.setTimestamp(i++, Utility.getCurrentSqlTimestampUTC());
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to create app feature", e);
+			throw new IllegalArgumentException("An error occurred creating the feature.");
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		Map<String, Object> result = new HashMap<>();
+		result.put("featureId", featureId);
+		result.put("featureKey", featureKey);
+		result.put("description", description);
+		return result;
+	}
+
+	public static void updateFeature(String appId, String featureId, String featureKey,
+			String description, User user) {
+		if (featureKey != null) validateFeatureKey(featureKey);
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		StringBuilder sb = new StringBuilder("UPDATE APP_FEATURE SET");
+		List<String> params = new ArrayList<>();
+		if (featureKey != null) { sb.append(" FEATURE_KEY=?,"); params.add(featureKey); }
+		if (description != null) { sb.append(" DESCRIPTION=?,"); params.add(description); }
+		if (params.isEmpty()) return;
+		sb.setLength(sb.length() - 1);
+		sb.append(" WHERE FEATURE_ID=? AND APP_ID=?");
+		params.add(featureId);
+		params.add(appId);
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(sb.toString());
+			for (int i = 0; i < params.size(); i++) {
+				ps.setString(i + 1, params.get(i));
+			}
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to update app feature", e);
+			throw new IllegalArgumentException("An error occurred updating the feature.");
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static void deleteFeature(String appId, String featureId, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement("DELETE FROM APP_FEATURE WHERE FEATURE_ID=? AND APP_ID=?");
+			ps.setString(1, featureId);
+			ps.setString(2, appId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to delete app feature", e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		ps = null;
+		try {
+			ps = securityDb.getPreparedStatement("DELETE FROM APP_PROFILE_FEATURE WHERE FEATURE_ID=? AND APP_ID=?");
+			ps.setString(1, featureId);
+			ps.setString(2, appId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to cascade delete feature from profile mappings", e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static List<Map<String, Object>> getFeatures(String appId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		List<Map<String, Object>> features = new ArrayList<>();
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("APP_FEATURE__FEATURE_ID"));
+		qs.addSelector(new QueryColumnSelector("APP_FEATURE__FEATURE_KEY"));
+		qs.addSelector(new QueryColumnSelector("APP_FEATURE__DESCRIPTION"));
+		qs.addSelector(new QueryColumnSelector("APP_FEATURE__CREATED_BY"));
+		qs.addSelector(new QueryColumnSelector("APP_FEATURE__CREATED_AT"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter("APP_FEATURE__APP_ID", "==", appId));
+		qs.addOrderBy("APP_FEATURE__FEATURE_KEY", "ASC");
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			while (wrapper.hasNext()) {
+				Object[] row = wrapper.next().getValues();
+				Map<String, Object> feature = new HashMap<>();
+				feature.put("featureId", row[0]);
+				feature.put("featureKey", row[1]);
+				feature.put("description", row[2]);
+				feature.put("createdBy", row[3]);
+				feature.put("createdAt", row[4]);
+				features.add(feature);
+			}
+		} catch (Exception e) {
+			classLogger.error("Failed to get app features", e);
+		}
+		return features;
+	}
+
+	// ─── Profile-Feature Assignment ─────────────────────────────────────────
+
+	public static void setProfileFeature(String appId, String profileId, String featureId,
+			boolean enabled, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"DELETE FROM APP_PROFILE_FEATURE WHERE APP_ID=? AND PROFILE_ID=? AND FEATURE_ID=?");
+			ps.setString(1, appId);
+			ps.setString(2, profileId);
+			ps.setString(3, featureId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to delete existing profile feature row", e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"INSERT INTO APP_PROFILE_FEATURE (APP_ID, PROFILE_ID, FEATURE_ID, ENABLED) VALUES (?,?,?,?)");
+			ps.setString(1, appId);
+			ps.setString(2, profileId);
+			ps.setString(3, featureId);
+			ps.setBoolean(4, enabled);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to insert profile feature", e);
+			throw new IllegalArgumentException("An error occurred setting the profile feature.");
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static List<Map<String, Object>> getProfileFeatures(String appId, String profileId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		List<Map<String, Object>> results = new ArrayList<>();
+		String sql = "SELECT f.FEATURE_ID, f.FEATURE_KEY, f.DESCRIPTION, pf.ENABLED "
+				+ "FROM APP_FEATURE f "
+				+ "LEFT JOIN APP_PROFILE_FEATURE pf ON f.FEATURE_ID = pf.FEATURE_ID "
+				+ "AND f.APP_ID = pf.APP_ID AND pf.PROFILE_ID = ? "
+				+ "WHERE f.APP_ID = ? ORDER BY f.FEATURE_KEY";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, profileId);
+			ps.setString(2, appId);
+			rs = ps.executeQuery();
+			while (rs.next()) {
+				Map<String, Object> row = new HashMap<>();
+				row.put("featureId", rs.getString("FEATURE_ID"));
+				row.put("featureKey", rs.getString("FEATURE_KEY"));
+				row.put("description", rs.getString("DESCRIPTION"));
+				Object enabledObj = rs.getObject("ENABLED");
+				row.put("enabled", enabledObj != null && rs.getBoolean("ENABLED"));
+				results.add(row);
+			}
+		} catch (SQLException e) {
+			classLogger.error("Failed to get profile features", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return results;
+	}
+
+	// ─── User-Profile Assignment ────────────────────────────────────────────
+
+	public static void assignUserProfile(String appId, String userId, String profileId, User actor) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		String actorId = getUserId(actor);
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement("DELETE FROM APP_USER_PROFILE WHERE APP_ID=? AND USER_ID=?");
+			ps.setString(1, appId);
+			ps.setString(2, userId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to remove existing user profile assignment", e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"INSERT INTO APP_USER_PROFILE (APP_ID, USER_ID, PROFILE_ID, ASSIGNED_BY, ASSIGNED_AT) VALUES (?,?,?,?,?)");
+			ps.setString(1, appId);
+			ps.setString(2, userId);
+			ps.setString(3, profileId);
+			ps.setString(4, actorId);
+			ps.setTimestamp(5, Utility.getCurrentSqlTimestampUTC());
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to assign user profile", e);
+			throw new IllegalArgumentException("An error occurred assigning the user profile.");
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static void removeUserProfile(String appId, String userId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement("DELETE FROM APP_USER_PROFILE WHERE APP_ID=? AND USER_ID=?");
+			ps.setString(1, appId);
+			ps.setString(2, userId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to remove user profile assignment", e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static Map<String, Object> getUserProfile(String appId, String userId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		String sql = "SELECT p.PROFILE_ID, p.PROFILE_NAME FROM APP_USER_PROFILE up "
+				+ "JOIN APP_PROFILE p ON up.PROFILE_ID = p.PROFILE_ID "
+				+ "WHERE up.APP_ID = ? AND up.USER_ID = ?";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, appId);
+			ps.setString(2, userId);
+			rs = ps.executeQuery();
+			if (rs.next()) {
+				Map<String, Object> result = new HashMap<>();
+				result.put("profileId", rs.getString("PROFILE_ID"));
+				result.put("profileName", rs.getString("PROFILE_NAME"));
+				result.put("isExplicitAssignment", true);
+				return result;
+			}
+		} catch (SQLException e) {
+			classLogger.error("Failed to get user profile", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return getDefaultProfile(securityDb, appId);
+	}
+
+	public static List<Map<String, Object>> getProfileUsers(String appId, String profileId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		List<Map<String, Object>> users = new ArrayList<>();
+		String sql = "SELECT up.USER_ID, up.ASSIGNED_BY, up.ASSIGNED_AT "
+				+ "FROM APP_USER_PROFILE up "
+				+ "INNER JOIN PROJECTPERMISSION pp ON up.USER_ID = pp.USERID AND up.APP_ID = pp.PROJECTID "
+				+ "WHERE up.APP_ID = ? AND up.PROFILE_ID = ?";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, appId);
+			ps.setString(2, profileId);
+			rs = ps.executeQuery();
+			while (rs.next()) {
+				Map<String, Object> row = new HashMap<>();
+				row.put("userId", rs.getString("USER_ID"));
+				row.put("assignedBy", rs.getString("ASSIGNED_BY"));
+				row.put("assignedAt", rs.getTimestamp("ASSIGNED_AT"));
+				users.add(row);
+			}
+		} catch (SQLException e) {
+			classLogger.error("Failed to get profile users", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return users;
+	}
+
+	// ─── Feature evaluation ──────────────────────────────────────────────────
+
+	public static boolean checkFeature(String appId, String featureKey, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		String featureId = resolveFeatureId(securityDb, appId, featureKey);
+		if (featureId == null) return false;
+		String userId = getUserId(user);
+		Map<String, Object> profile = getUserProfile(appId, userId);
+		if (profile == null) return false;
+		String profileId = (String) profile.get("profileId");
+		return queryFeatureEnabled(securityDb, appId, profileId, featureId);
+	}
+
+	public static Map<String, Object> getUserFeatures(String appId, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		String userId = getUserId(user);
+		Map<String, Object> profile = getUserProfile(appId, userId);
+		if (profile == null) return new HashMap<>();
+		String profileId = (String) profile.get("profileId");
+		String profileName = (String) profile.get("profileName");
+		boolean isDefaultProfile = !(Boolean) profile.getOrDefault("isExplicitAssignment", Boolean.TRUE);
+
+		Map<String, Object> result = new HashMap<>();
+		// Return only features with ENABLED=true — callers cannot infer what features exist but are hidden
+		String sql = "SELECT f.FEATURE_KEY, f.FEATURE_ID "
+				+ "FROM APP_PROFILE_FEATURE pf "
+				+ "JOIN APP_FEATURE f ON pf.FEATURE_ID = f.FEATURE_ID AND pf.APP_ID = f.APP_ID "
+				+ "WHERE pf.APP_ID = ? AND pf.PROFILE_ID = ? AND pf.ENABLED = true";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, appId);
+			ps.setString(2, profileId);
+			rs = ps.executeQuery();
+			while (rs.next()) {
+				Map<String, Object> featureInfo = new HashMap<>();
+				featureInfo.put("featureId", rs.getString("FEATURE_ID"));
+				featureInfo.put("profileName", profileName);
+				featureInfo.put("isDefaultProfile", isDefaultProfile);
+				result.put(rs.getString("FEATURE_KEY"), featureInfo);
+			}
+		} catch (SQLException e) {
+			classLogger.error("Failed to get user features", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return result;
+	}
+
+	// ─── Private helpers ─────────────────────────────────────────────────────
+
+	private static void validateFeatureKey(String key) {
+		if (key == null || key.isEmpty()) {
+			throw new IllegalArgumentException("Feature key cannot be blank.");
+		}
+		if (key.length() > FEATURE_KEY_MAX_LENGTH) {
+			throw new IllegalArgumentException("Feature key cannot exceed " + FEATURE_KEY_MAX_LENGTH + " characters.");
+		}
+		if (!key.matches(FEATURE_KEY_PATTERN)) {
+			throw new IllegalArgumentException(
+					"Feature key must contain only alphanumeric characters and hyphens.");
+		}
+	}
+
+	private static void clearDefaultProfile(IRDBMSEngine securityDb, String appId) {
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement("UPDATE APP_PROFILE SET IS_DEFAULT=false WHERE APP_ID=?");
+			ps.setString(1, appId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to clear default profile", e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	private static int getAssignedUserCount(IRDBMSEngine securityDb, String appId, String profileId) {
+		String sql = "SELECT COUNT(*) FROM APP_USER_PROFILE WHERE APP_ID=? AND PROFILE_ID=?";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, appId);
+			ps.setString(2, profileId);
+			rs = ps.executeQuery();
+			if (rs.next()) return rs.getInt(1);
+		} catch (SQLException e) {
+			classLogger.error("Failed to count profile users", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return 0;
+	}
+
+	private static Map<String, Object> getDefaultProfile(IRDBMSEngine securityDb, String appId) {
+		String sql = "SELECT PROFILE_ID, PROFILE_NAME FROM APP_PROFILE WHERE APP_ID=? AND IS_DEFAULT=true";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, appId);
+			rs = ps.executeQuery();
+			if (rs.next()) {
+				Map<String, Object> result = new HashMap<>();
+				result.put("profileId", rs.getString("PROFILE_ID"));
+				result.put("profileName", rs.getString("PROFILE_NAME"));
+				result.put("isExplicitAssignment", false);
+				return result;
+			}
+		} catch (SQLException e) {
+			classLogger.error("Failed to get default profile", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return null;
+	}
+
+	private static String resolveFeatureId(IRDBMSEngine securityDb, String appId, String featureKey) {
+		String sql = "SELECT FEATURE_ID FROM APP_FEATURE WHERE APP_ID=? AND FEATURE_KEY=?";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, appId);
+			ps.setString(2, featureKey);
+			rs = ps.executeQuery();
+			if (rs.next()) return rs.getString("FEATURE_ID");
+		} catch (SQLException e) {
+			classLogger.error("Failed to resolve feature ID", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return null;
+	}
+
+	private static boolean queryFeatureEnabled(IRDBMSEngine securityDb, String appId, String profileId, String featureId) {
+		String sql = "SELECT ENABLED FROM APP_PROFILE_FEATURE WHERE APP_ID=? AND PROFILE_ID=? AND FEATURE_ID=?";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, appId);
+			ps.setString(2, profileId);
+			ps.setString(3, featureId);
+			rs = ps.executeQuery();
+			if (rs.next()) return rs.getBoolean("ENABLED");
+		} catch (SQLException e) {
+			classLogger.error("Failed to check feature enabled", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return false;
+	}
+
+	static String getUserId(User user) {
+		if (user == null) return null;
+		AccessToken token = user.getAccessToken(user.getPrimaryLogin());
+		return token != null ? token.getId() : null;
+	}
+}

--- a/src/prerna/auth/utils/PlatformProfileUtils.java
+++ b/src/prerna/auth/utils/PlatformProfileUtils.java
@@ -333,6 +333,31 @@ public class PlatformProfileUtils {
 		return getProfileFeatures(profileId);
 	}
 
+	public static List<Map<String, Object>> getPlatformProfileUsers(String profileId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		List<Map<String, Object>> users = new ArrayList<>();
+		String sql = "SELECT USER_ID, ASSIGNED_BY, ASSIGNED_AT FROM PLATFORM_USER_PROFILE WHERE PROFILE_ID=?";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, profileId);
+			rs = ps.executeQuery();
+			while (rs.next()) {
+				Map<String, Object> row = new HashMap<>();
+				row.put("userId", rs.getString("USER_ID"));
+				row.put("assignedBy", rs.getString("ASSIGNED_BY"));
+				row.put("assignedAt", rs.getTimestamp("ASSIGNED_AT"));
+				users.add(row);
+			}
+		} catch (SQLException e) {
+			classLogger.error("Failed to get platform profile users", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return users;
+	}
+
 	// ─── Private helpers ─────────────────────────────────────────────────────
 
 	private static int getAssignedUserCount(IRDBMSEngine securityDb, String profileId) {

--- a/src/prerna/auth/utils/PlatformProfileUtils.java
+++ b/src/prerna/auth/utils/PlatformProfileUtils.java
@@ -1,0 +1,371 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.auth.utils;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.User;
+import prerna.engine.api.IRDBMSEngine;
+import prerna.util.ConnectionUtils;
+import prerna.util.SystemEngineRegistry;
+import prerna.util.Utility;
+
+public class PlatformProfileUtils {
+
+	private static final Logger classLogger = LogManager.getLogger(PlatformProfileUtils.class);
+
+	public static final Set<String> PREDEFINED_FEATURE_KEYS = Collections.unmodifiableSet(
+			new HashSet<>(Arrays.asList(
+					"nav.app-catalog",
+					"nav.build",
+					"nav.skills",
+					"nav.settings",
+					"nav.engine")));
+
+	private PlatformProfileUtils() {
+	}
+
+	// ─── Permission check ────────────────────────────────────────────────────
+
+	public static boolean canManage(User user) {
+		return SecurityAdminUtils.userIsAdmin(user);
+	}
+
+	// ─── Profile CRUD ────────────────────────────────────────────────────────
+
+	public static Map<String, Object> createProfile(String name, String description, User user) {
+		if (name == null || name.trim().isEmpty()) {
+			throw new IllegalArgumentException("Profile name cannot be blank.");
+		}
+		String profileId = UUID.randomUUID().toString();
+		String actorId = AppProfileUtils.getUserId(user);
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"INSERT INTO PLATFORM_PROFILE (PROFILE_ID, PROFILE_NAME, DESCRIPTION, CREATED_BY, CREATED_AT) VALUES (?,?,?,?,?)");
+			int i = 1;
+			ps.setString(i++, profileId);
+			ps.setString(i++, name.trim());
+			ps.setString(i++, description);
+			ps.setString(i++, actorId);
+			ps.setTimestamp(i++, Utility.getCurrentSqlTimestampUTC());
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to create platform profile", e);
+			throw new IllegalArgumentException("An error occurred creating the platform profile.");
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		Map<String, Object> result = new HashMap<>();
+		result.put("profileId", profileId);
+		result.put("profileName", name.trim());
+		result.put("description", description);
+		return result;
+	}
+
+	public static void updateProfile(String profileId, String name, String description, User user) {
+		if (name != null && name.trim().isEmpty()) {
+			throw new IllegalArgumentException("Profile name cannot be blank.");
+		}
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		StringBuilder sb = new StringBuilder("UPDATE PLATFORM_PROFILE SET");
+		List<String> params = new ArrayList<>();
+		if (name != null) { sb.append(" PROFILE_NAME=?,"); params.add(name.trim()); }
+		if (description != null) { sb.append(" DESCRIPTION=?,"); params.add(description); }
+		if (params.isEmpty()) return;
+		sb.setLength(sb.length() - 1);
+		sb.append(" WHERE PROFILE_ID=?");
+		params.add(profileId);
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(sb.toString());
+			for (int i = 0; i < params.size(); i++) {
+				ps.setString(i + 1, params.get(i));
+			}
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to update platform profile", e);
+			throw new IllegalArgumentException("An error occurred updating the platform profile.");
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static void deleteProfile(String profileId, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		int count = getAssignedUserCount(securityDb, profileId);
+		if (count > 0) {
+			throw new IllegalArgumentException(
+					"Cannot delete: " + count + " user(s) are assigned to this profile. Reassign them first.");
+		}
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement("DELETE FROM PLATFORM_PROFILE WHERE PROFILE_ID=?");
+			ps.setString(1, profileId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to delete platform profile", e);
+			throw new IllegalArgumentException("An error occurred deleting the platform profile.");
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		ps = null;
+		try {
+			ps = securityDb.getPreparedStatement("DELETE FROM PLATFORM_PROFILE_FEATURE WHERE PROFILE_ID=?");
+			ps.setString(1, profileId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to cascade delete platform profile features", e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static List<Map<String, Object>> getProfiles(User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		List<Map<String, Object>> profiles = new ArrayList<>();
+		String sql = "SELECT PROFILE_ID, PROFILE_NAME, DESCRIPTION, CREATED_BY, CREATED_AT "
+				+ "FROM PLATFORM_PROFILE ORDER BY PROFILE_NAME";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			rs = ps.executeQuery();
+			while (rs.next()) {
+				Map<String, Object> profile = new HashMap<>();
+				String pid = rs.getString("PROFILE_ID");
+				profile.put("profileId", pid);
+				profile.put("profileName", rs.getString("PROFILE_NAME"));
+				profile.put("description", rs.getString("DESCRIPTION"));
+				profile.put("createdBy", rs.getString("CREATED_BY"));
+				profile.put("createdAt", rs.getTimestamp("CREATED_AT"));
+				profile.put("userCount", getAssignedUserCount(securityDb, pid));
+				profiles.add(profile);
+			}
+		} catch (SQLException e) {
+			classLogger.error("Failed to get platform profiles", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return profiles;
+	}
+
+	// ─── Profile-Feature Assignment ──────────────────────────────────────────
+
+	public static void setProfileFeature(String profileId, String featureKey, boolean enabled, User user) {
+		if (!PREDEFINED_FEATURE_KEYS.contains(featureKey)) {
+			throw new IllegalArgumentException(
+					"Unknown platform feature key: " + featureKey
+							+ ". Valid keys: " + PREDEFINED_FEATURE_KEYS);
+		}
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"DELETE FROM PLATFORM_PROFILE_FEATURE WHERE PROFILE_ID=? AND FEATURE_KEY=?");
+			ps.setString(1, profileId);
+			ps.setString(2, featureKey);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to delete existing platform feature row", e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"INSERT INTO PLATFORM_PROFILE_FEATURE (PROFILE_ID, FEATURE_KEY, ENABLED) VALUES (?,?,?)");
+			ps.setString(1, profileId);
+			ps.setString(2, featureKey);
+			ps.setBoolean(3, enabled);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to insert platform feature", e);
+			throw new IllegalArgumentException("An error occurred setting the platform feature.");
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static Map<String, Boolean> getProfileFeatures(String profileId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		// Start with all keys disabled
+		Map<String, Boolean> result = new LinkedHashMap<>();
+		for (String key : PREDEFINED_FEATURE_KEYS) {
+			result.put(key, Boolean.FALSE);
+		}
+		String sql = "SELECT FEATURE_KEY, ENABLED FROM PLATFORM_PROFILE_FEATURE WHERE PROFILE_ID=?";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, profileId);
+			rs = ps.executeQuery();
+			while (rs.next()) {
+				String key = rs.getString("FEATURE_KEY");
+				if (PREDEFINED_FEATURE_KEYS.contains(key)) {
+					result.put(key, rs.getBoolean("ENABLED"));
+				}
+			}
+		} catch (SQLException e) {
+			classLogger.error("Failed to get platform profile features", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return result;
+	}
+
+	// ─── User-Profile Assignment ─────────────────────────────────────────────
+
+	public static void assignUserProfile(String userId, String profileId, User actor) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		String actorId = AppProfileUtils.getUserId(actor);
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement("DELETE FROM PLATFORM_USER_PROFILE WHERE USER_ID=?");
+			ps.setString(1, userId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to remove existing platform user profile", e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"INSERT INTO PLATFORM_USER_PROFILE (USER_ID, PROFILE_ID, ASSIGNED_BY, ASSIGNED_AT) VALUES (?,?,?,?)");
+			ps.setString(1, userId);
+			ps.setString(2, profileId);
+			ps.setString(3, actorId);
+			ps.setTimestamp(4, Utility.getCurrentSqlTimestampUTC());
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to assign platform user profile", e);
+			throw new IllegalArgumentException("An error occurred assigning the platform profile.");
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static void removeUserProfile(String userId, User actor) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement("DELETE FROM PLATFORM_USER_PROFILE WHERE USER_ID=?");
+			ps.setString(1, userId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) ps.getConnection().commit();
+		} catch (SQLException e) {
+			classLogger.error("Failed to remove platform user profile", e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	// ─── Feature evaluation ──────────────────────────────────────────────────
+
+	/**
+	 * Returns all predefined platform feature keys with their enabled status for the
+	 * calling user. If the user has no platform profile assigned, all keys are true
+	 * (fail-open — user is already authenticated and admin-provisioned).
+	 */
+	public static Map<String, Boolean> getUserFeatures(User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		String userId = AppProfileUtils.getUserId(user);
+		String profileId = getAssignedProfileId(securityDb, userId);
+		if (profileId == null) {
+			// No profile assigned → all nav visible
+			Map<String, Boolean> all = new LinkedHashMap<>();
+			for (String key : PREDEFINED_FEATURE_KEYS) {
+				all.put(key, Boolean.TRUE);
+			}
+			return all;
+		}
+		return getProfileFeatures(profileId);
+	}
+
+	// ─── Private helpers ─────────────────────────────────────────────────────
+
+	private static int getAssignedUserCount(IRDBMSEngine securityDb, String profileId) {
+		String sql = "SELECT COUNT(*) FROM PLATFORM_USER_PROFILE WHERE PROFILE_ID=?";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, profileId);
+			rs = ps.executeQuery();
+			if (rs.next()) return rs.getInt(1);
+		} catch (SQLException e) {
+			classLogger.error("Failed to count platform profile users", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return 0;
+	}
+
+	private static String getAssignedProfileId(IRDBMSEngine securityDb, String userId) {
+		String sql = "SELECT PROFILE_ID FROM PLATFORM_USER_PROFILE WHERE USER_ID=?";
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, userId);
+			rs = ps.executeQuery();
+			if (rs.next()) return rs.getString("PROFILE_ID");
+		} catch (SQLException e) {
+			classLogger.error("Failed to get platform user profile", e);
+		} finally {
+			ConnectionUtils.closeAllConnections(ps, rs);
+		}
+		return null;
+	}
+}

--- a/src/prerna/auth/utils/SecurityProjectUtils.java
+++ b/src/prerna/auth/utils/SecurityProjectUtils.java
@@ -1751,6 +1751,8 @@ public class SecurityProjectUtils extends AbstractSecurityUtils {
 				ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
 			}
 		}
+		// cascade: remove any app profile assignment so no stale rows survive
+		AppProfileUtils.removeUserProfile(projectId, existingUserId);
 	}
 
 	/**
@@ -1777,6 +1779,8 @@ public class SecurityProjectUtils extends AbstractSecurityUtils {
 		} finally {
 			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
 		}
+		// cascade: remove any app profile assignment so no stale rows survive
+		AppProfileUtils.removeUserProfile(projectId, userId);
 	}
 
 	/**
@@ -4895,6 +4899,10 @@ public class SecurityProjectUtils extends AbstractSecurityUtils {
 			classLogger.error("Failed to remove project users", e);
 		} finally {
 			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		// cascade: remove any app profile assignments so no stale rows survive
+		for (String uid : existingUserIds) {
+			AppProfileUtils.removeUserProfile(projectId, uid);
 		}
 	}
 

--- a/src/prerna/reactor/appprofile/AssignUserProfileReactor.java
+++ b/src/prerna/reactor/appprofile/AssignUserProfileReactor.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class AssignUserProfileReactor extends AbstractReactor {
+
+	public AssignUserProfileReactor() {
+		this.keysToGet = new String[] { "app", "userId", "profileId" };
+		this.keyRequired = new int[] { 1, 1, 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String userId = this.keyValue.get("userId");
+		String profileId = this.keyValue.get("profileId");
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		AppProfileUtils.assignUserProfile(appId, userId, profileId, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("User assigned to profile."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Assign a user to a profile for an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/CheckFeatureReactor.java
+++ b/src/prerna/reactor/appprofile/CheckFeatureReactor.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class CheckFeatureReactor extends AbstractReactor {
+
+	public CheckFeatureReactor() {
+		this.keysToGet = new String[] { "app", "featureKey" };
+		this.keyRequired = new int[] { 1, 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String featureKey = this.keyValue.get("featureKey");
+
+		if (!AppProfileUtils.canEvaluateFeatures(user, appId)) {
+			throw new IllegalArgumentException("User does not have access to this app.");
+		}
+		boolean enabled = AppProfileUtils.checkFeature(appId, featureKey, user);
+		return new NounMetadata(enabled, PixelDataType.BOOLEAN);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Check whether a feature is enabled for the calling user in an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/CreateAppFeatureReactor.java
+++ b/src/prerna/reactor/appprofile/CreateAppFeatureReactor.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class CreateAppFeatureReactor extends AbstractReactor {
+
+	public CreateAppFeatureReactor() {
+		this.keysToGet = new String[] { "app", "key", "description" };
+		this.keyRequired = new int[] { 1, 1, 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String featureKey = this.keyValue.get("key");
+		String description = this.keyValue.get("description");
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		Map<String, Object> result = AppProfileUtils.createFeature(appId, featureKey, description, user);
+		NounMetadata noun = new NounMetadata(result, PixelDataType.MAP);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Feature created."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Create a feature key for an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/CreateAppProfileReactor.java
+++ b/src/prerna/reactor/appprofile/CreateAppProfileReactor.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class CreateAppProfileReactor extends AbstractReactor {
+
+	public CreateAppProfileReactor() {
+		this.keysToGet = new String[] { "app", "name", "description", "isDefault" };
+		this.keyRequired = new int[] { 1, 1, 0, 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String name = this.keyValue.get("name");
+		String description = this.keyValue.get("description");
+		boolean isDefault = Boolean.parseBoolean(this.keyValue.get("isDefault"));
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		Map<String, Object> result = AppProfileUtils.createProfile(appId, name, description, isDefault, user);
+		NounMetadata noun = new NounMetadata(result, PixelDataType.MAP);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Profile created."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Create a named profile for an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/DeleteAppFeatureReactor.java
+++ b/src/prerna/reactor/appprofile/DeleteAppFeatureReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class DeleteAppFeatureReactor extends AbstractReactor {
+
+	public DeleteAppFeatureReactor() {
+		this.keysToGet = new String[] { "app", "featureId" };
+		this.keyRequired = new int[] { 1, 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String featureId = this.keyValue.get("featureId");
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		AppProfileUtils.deleteFeature(appId, featureId, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Feature deleted."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Delete a feature key from an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/DeleteAppProfileReactor.java
+++ b/src/prerna/reactor/appprofile/DeleteAppProfileReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class DeleteAppProfileReactor extends AbstractReactor {
+
+	public DeleteAppProfileReactor() {
+		this.keysToGet = new String[] { "app", "profileId" };
+		this.keyRequired = new int[] { 1, 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String profileId = this.keyValue.get("profileId");
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		AppProfileUtils.deleteProfile(appId, profileId, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Profile deleted."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Delete a named profile from an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/GetAppFeaturesReactor.java
+++ b/src/prerna/reactor/appprofile/GetAppFeaturesReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import java.util.List;
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetAppFeaturesReactor extends AbstractReactor {
+
+	public GetAppFeaturesReactor() {
+		this.keysToGet = new String[] { "app" };
+		this.keyRequired = new int[] { 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		List<Map<String, Object>> features = AppProfileUtils.getFeatures(appId);
+		return new NounMetadata(features, PixelDataType.CUSTOM_DATA_STRUCTURE);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Get all feature keys defined for an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/GetAppProfilesReactor.java
+++ b/src/prerna/reactor/appprofile/GetAppProfilesReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import java.util.List;
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetAppProfilesReactor extends AbstractReactor {
+
+	public GetAppProfilesReactor() {
+		this.keysToGet = new String[] { "app" };
+		this.keyRequired = new int[] { 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		List<Map<String, Object>> profiles = AppProfileUtils.getProfiles(appId);
+		return new NounMetadata(profiles, PixelDataType.CUSTOM_DATA_STRUCTURE);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Get all profiles defined for an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/GetProfileFeaturesReactor.java
+++ b/src/prerna/reactor/appprofile/GetProfileFeaturesReactor.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import java.util.List;
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetProfileFeaturesReactor extends AbstractReactor {
+
+	public GetProfileFeaturesReactor() {
+		this.keysToGet = new String[] { "app", "profileId" };
+		this.keyRequired = new int[] { 1, 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String profileId = this.keyValue.get("profileId");
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		List<Map<String, Object>> features = AppProfileUtils.getProfileFeatures(appId, profileId);
+		return new NounMetadata(features, PixelDataType.CUSTOM_DATA_STRUCTURE);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Get all features with their enabled status for a profile.";
+	}
+}

--- a/src/prerna/reactor/appprofile/GetProfileUsersReactor.java
+++ b/src/prerna/reactor/appprofile/GetProfileUsersReactor.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import java.util.List;
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetProfileUsersReactor extends AbstractReactor {
+
+	public GetProfileUsersReactor() {
+		this.keysToGet = new String[] { "app", "profileId" };
+		this.keyRequired = new int[] { 1, 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String profileId = this.keyValue.get("profileId");
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		List<Map<String, Object>> users = AppProfileUtils.getProfileUsers(appId, profileId);
+		return new NounMetadata(users, PixelDataType.CUSTOM_DATA_STRUCTURE);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Get all users assigned to a profile in an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/GetUserFeaturesReactor.java
+++ b/src/prerna/reactor/appprofile/GetUserFeaturesReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetUserFeaturesReactor extends AbstractReactor {
+
+	public GetUserFeaturesReactor() {
+		this.keysToGet = new String[] { "app" };
+		this.keyRequired = new int[] { 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+
+		if (!AppProfileUtils.canEvaluateFeatures(user, appId)) {
+			throw new IllegalArgumentException("User does not have access to this app.");
+		}
+		// Returns only enabled features — callers cannot infer what features exist but are hidden
+		Map<String, Object> features = AppProfileUtils.getUserFeatures(appId, user);
+		return new NounMetadata(features, PixelDataType.MAP);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Get all enabled features for the calling user in an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/GetUserProfileReactor.java
+++ b/src/prerna/reactor/appprofile/GetUserProfileReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetUserProfileReactor extends AbstractReactor {
+
+	public GetUserProfileReactor() {
+		this.keysToGet = new String[] { "app", "userId" };
+		this.keyRequired = new int[] { 1, 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String userId = this.keyValue.get("userId");
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		Map<String, Object> profile = AppProfileUtils.getUserProfile(appId, userId);
+		return new NounMetadata(profile, PixelDataType.MAP);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Get the effective profile for a user in an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/RemoveUserProfileReactor.java
+++ b/src/prerna/reactor/appprofile/RemoveUserProfileReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class RemoveUserProfileReactor extends AbstractReactor {
+
+	public RemoveUserProfileReactor() {
+		this.keysToGet = new String[] { "app", "userId" };
+		this.keyRequired = new int[] { 1, 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String userId = this.keyValue.get("userId");
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		AppProfileUtils.removeUserProfile(appId, userId);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("User removed from profile."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Remove a user's profile assignment for an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/SetProfileFeatureReactor.java
+++ b/src/prerna/reactor/appprofile/SetProfileFeatureReactor.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class SetProfileFeatureReactor extends AbstractReactor {
+
+	public SetProfileFeatureReactor() {
+		this.keysToGet = new String[] { "app", "profileId", "featureId", "enabled" };
+		this.keyRequired = new int[] { 1, 1, 1, 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String profileId = this.keyValue.get("profileId");
+		String featureId = this.keyValue.get("featureId");
+		boolean enabled = Boolean.parseBoolean(this.keyValue.get("enabled"));
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		AppProfileUtils.setProfileFeature(appId, profileId, featureId, enabled, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Profile feature updated."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Enable or disable a feature for a profile.";
+	}
+}

--- a/src/prerna/reactor/appprofile/UpdateAppFeatureReactor.java
+++ b/src/prerna/reactor/appprofile/UpdateAppFeatureReactor.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class UpdateAppFeatureReactor extends AbstractReactor {
+
+	public UpdateAppFeatureReactor() {
+		this.keysToGet = new String[] { "app", "featureId", "key", "description" };
+		this.keyRequired = new int[] { 1, 1, 0, 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String featureId = this.keyValue.get("featureId");
+		String featureKey = this.keyValue.get("key");
+		String description = this.keyValue.get("description");
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		AppProfileUtils.updateFeature(appId, featureId, featureKey, description, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Feature updated."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Update a feature key for an app.";
+	}
+}

--- a/src/prerna/reactor/appprofile/UpdateAppProfileReactor.java
+++ b/src/prerna/reactor/appprofile/UpdateAppProfileReactor.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class UpdateAppProfileReactor extends AbstractReactor {
+
+	public UpdateAppProfileReactor() {
+		this.keysToGet = new String[] { "app", "profileId", "name", "description", "isDefault" };
+		this.keyRequired = new int[] { 1, 1, 0, 0, 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		String appId = this.keyValue.get("app");
+		String profileId = this.keyValue.get("profileId");
+		String name = this.keyValue.get("name");
+		String description = this.keyValue.get("description");
+		String isDefaultStr = this.keyValue.get("isDefault");
+		Boolean isDefault = isDefaultStr != null ? Boolean.parseBoolean(isDefaultStr) : null;
+
+		if (!AppProfileUtils.canManageProfiles(user, appId)) {
+			throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+		}
+		AppProfileUtils.updateProfile(appId, profileId, name, description, isDefault, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Profile updated."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Update a named profile for an app.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/AssignUserPlatformProfileReactor.java
+++ b/src/prerna/reactor/platformprofile/AssignUserPlatformProfileReactor.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class AssignUserPlatformProfileReactor extends AbstractReactor {
+
+	public AssignUserPlatformProfileReactor() {
+		this.keysToGet = new String[] { "userId", "profileId" };
+		this.keyRequired = new int[] { 1, 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		if (!PlatformProfileUtils.canManage(user)) {
+			throw new IllegalArgumentException("User must be an admin to manage platform profiles.");
+		}
+		String userId = this.keyValue.get("userId");
+		String profileId = this.keyValue.get("profileId");
+		PlatformProfileUtils.assignUserProfile(userId, profileId, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("User assigned to platform profile."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Assign a user to a platform profile.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/CreatePlatformProfileReactor.java
+++ b/src/prerna/reactor/platformprofile/CreatePlatformProfileReactor.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class CreatePlatformProfileReactor extends AbstractReactor {
+
+	public CreatePlatformProfileReactor() {
+		this.keysToGet = new String[] { "name", "description" };
+		this.keyRequired = new int[] { 1, 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		if (!PlatformProfileUtils.canManage(user)) {
+			throw new IllegalArgumentException("User must be an admin to manage platform profiles.");
+		}
+		String name = this.keyValue.get("name");
+		String description = this.keyValue.get("description");
+		Map<String, Object> result = PlatformProfileUtils.createProfile(name, description, user);
+		NounMetadata noun = new NounMetadata(result, PixelDataType.MAP);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Platform profile created."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Create a platform profile.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/DeletePlatformProfileReactor.java
+++ b/src/prerna/reactor/platformprofile/DeletePlatformProfileReactor.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class DeletePlatformProfileReactor extends AbstractReactor {
+
+	public DeletePlatformProfileReactor() {
+		this.keysToGet = new String[] { "profileId" };
+		this.keyRequired = new int[] { 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		if (!PlatformProfileUtils.canManage(user)) {
+			throw new IllegalArgumentException("User must be an admin to manage platform profiles.");
+		}
+		String profileId = this.keyValue.get("profileId");
+		PlatformProfileUtils.deleteProfile(profileId, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Platform profile deleted."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Delete a platform profile.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/GetPlatformFeaturesReactor.java
+++ b/src/prerna/reactor/platformprofile/GetPlatformFeaturesReactor.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetPlatformFeaturesReactor extends AbstractReactor {
+
+	public GetPlatformFeaturesReactor() {
+		this.keysToGet = new String[] { "profileId" };
+		this.keyRequired = new int[] { 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		if (!PlatformProfileUtils.canManage(user)) {
+			throw new IllegalArgumentException("User must be an admin to manage platform profiles.");
+		}
+		String profileId = this.keyValue.get("profileId");
+		Map<String, Boolean> features = PlatformProfileUtils.getProfileFeatures(profileId);
+		return new NounMetadata(features, PixelDataType.MAP);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Get all predefined platform nav features with their enabled status for a profile.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/GetPlatformProfileUsersReactor.java
+++ b/src/prerna/reactor/platformprofile/GetPlatformProfileUsersReactor.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import java.util.List;
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetPlatformProfileUsersReactor extends AbstractReactor {
+
+	public GetPlatformProfileUsersReactor() {
+		this.keysToGet = new String[] { "profileId" };
+		this.keyRequired = new int[] { 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		if (!PlatformProfileUtils.canManage(user)) {
+			throw new IllegalArgumentException("User must be an admin to manage platform profiles.");
+		}
+		String profileId = this.keyValue.get("profileId");
+		List<Map<String, Object>> users = PlatformProfileUtils.getPlatformProfileUsers(profileId);
+		return new NounMetadata(users, PixelDataType.CUSTOM_DATA_STRUCTURE);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Get all users assigned to a platform profile.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/GetPlatformProfilesReactor.java
+++ b/src/prerna/reactor/platformprofile/GetPlatformProfilesReactor.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import java.util.List;
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetPlatformProfilesReactor extends AbstractReactor {
+
+	public GetPlatformProfilesReactor() {
+		this.keysToGet = new String[] {};
+		this.keyRequired = new int[] {};
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		if (!PlatformProfileUtils.canManage(user)) {
+			throw new IllegalArgumentException("User must be an admin to manage platform profiles.");
+		}
+		List<Map<String, Object>> profiles = PlatformProfileUtils.getProfiles(user);
+		return new NounMetadata(profiles, PixelDataType.CUSTOM_DATA_STRUCTURE);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Get all platform profiles.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/GetUserPlatformFeaturesReactor.java
+++ b/src/prerna/reactor/platformprofile/GetUserPlatformFeaturesReactor.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetUserPlatformFeaturesReactor extends AbstractReactor {
+
+	public GetUserPlatformFeaturesReactor() {
+		this.keysToGet = new String[] {};
+		this.keyRequired = new int[] {};
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		// Returns all predefined keys → true for unassigned users (fail-open at platform level)
+		Map<String, Boolean> features = PlatformProfileUtils.getUserFeatures(user);
+		return new NounMetadata(features, PixelDataType.MAP);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Get platform nav feature visibility for the calling user. Unassigned users receive all features enabled.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/RemoveUserPlatformProfileReactor.java
+++ b/src/prerna/reactor/platformprofile/RemoveUserPlatformProfileReactor.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class RemoveUserPlatformProfileReactor extends AbstractReactor {
+
+	public RemoveUserPlatformProfileReactor() {
+		this.keysToGet = new String[] { "userId" };
+		this.keyRequired = new int[] { 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		if (!PlatformProfileUtils.canManage(user)) {
+			throw new IllegalArgumentException("User must be an admin to manage platform profiles.");
+		}
+		String userId = this.keyValue.get("userId");
+		PlatformProfileUtils.removeUserProfile(userId, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("User removed from platform profile."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Remove a user's platform profile assignment.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/SetPlatformFeatureReactor.java
+++ b/src/prerna/reactor/platformprofile/SetPlatformFeatureReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class SetPlatformFeatureReactor extends AbstractReactor {
+
+	public SetPlatformFeatureReactor() {
+		this.keysToGet = new String[] { "profileId", "featureKey", "enabled" };
+		this.keyRequired = new int[] { 1, 1, 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		if (!PlatformProfileUtils.canManage(user)) {
+			throw new IllegalArgumentException("User must be an admin to manage platform profiles.");
+		}
+		String profileId = this.keyValue.get("profileId");
+		String featureKey = this.keyValue.get("featureKey");
+		boolean enabled = Boolean.parseBoolean(this.keyValue.get("enabled"));
+		PlatformProfileUtils.setProfileFeature(profileId, featureKey, enabled, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Platform feature updated."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Enable or disable a predefined platform nav feature for a profile.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/UpdatePlatformProfileReactor.java
+++ b/src/prerna/reactor/platformprofile/UpdatePlatformProfileReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class UpdatePlatformProfileReactor extends AbstractReactor {
+
+	public UpdatePlatformProfileReactor() {
+		this.keysToGet = new String[] { "profileId", "name", "description" };
+		this.keyRequired = new int[] { 1, 0, 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		if (!PlatformProfileUtils.canManage(user)) {
+			throw new IllegalArgumentException("User must be an admin to manage platform profiles.");
+		}
+		String profileId = this.keyValue.get("profileId");
+		String name = this.keyValue.get("name");
+		String description = this.keyValue.get("description");
+		PlatformProfileUtils.updateProfile(profileId, name, description, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Platform profile updated."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Update a platform profile.";
+	}
+}


### PR DESCRIPTION
## Description

Implements a two-part Role-Based Feature Visibility system from scratch. The system has two independent parts:

- **Part A — App Profiles** (fail-closed): controls which features are visible inside a specific app for a given user
- **Part B — Platform Profiles** (fail-open): controls which top-level nav pages a user can see after login

"Profile" is intentionally distinct from SEMOSS's existing "role" concept (owner/editor/viewer). Roles control what a user can *do*; profiles control what a user *sees*.

---

## Changes Made

### New Utility Classes
- **`src/prerna/auth/utils/AppProfileUtils.java`** — All DB operations for app-level profiles, features, and user-profile assignments. Cascade delete from `SecurityProjectUtils` ensures `APP_USER_PROFILE` rows are cleaned up whenever a user loses app access.
- **`src/prerna/auth/utils/PlatformProfileUtils.java`** — All DB operations for platform-level profiles and nav feature toggles. Validates feature keys against a predefined set (`nav.app-catalog`, `nav.build`, `nav.skills`, `nav.settings`, `nav.engine`).

### Security DB Schema (AbstractSecurityUtils.java)
7 new tables added to `initialize()` using the existing `createTableIfNotExists` pattern:
- `APP_PROFILE`, `APP_FEATURE`, `APP_PROFILE_FEATURE`, `APP_USER_PROFILE`
- `PLATFORM_PROFILE`, `PLATFORM_PROFILE_FEATURE`, `PLATFORM_USER_PROFILE`

### App Profile Reactors (`src/prerna/reactor/appprofile/`)
16 reactors covering full CRUD for profiles, features, profile-feature assignment, and user-profile assignment:

| Reactor | Keys | Auth |
|---|---|---|
| `CreateAppProfile` | `app`*, `name`*, `description`, `isDefault` | canManageProfiles |
| `UpdateAppProfile` | `app`*, `profileId`*, `name`, `description`, `isDefault` | canManageProfiles |
| `DeleteAppProfile` | `app`*, `profileId`* | canManageProfiles (rejects if users assigned) |
| `GetAppProfiles` | `app`* | canManageProfiles |
| `CreateAppFeature` | `app`*, `key`*, `description` | canManageProfiles |
| `UpdateAppFeature` | `app`*, `featureId`*, `key`, `description` | canManageProfiles |
| `DeleteAppFeature` | `app`*, `featureId`* | canManageProfiles |
| `GetAppFeatures` | `app`* | canManageProfiles |
| `SetProfileFeature` | `app`*, `profileId`*, `featureId`*, `enabled`* | canManageProfiles |
| `GetProfileFeatures` | `app`*, `profileId`* | canManageProfiles |
| `AssignUserProfile` | `app`*, `userId`*, `profileId`* | canManageProfiles |
| `RemoveUserProfile` | `app`*, `userId`* | canManageProfiles |
| `GetUserProfile` | `app`*, `userId`* | canManageProfiles |
| `GetProfileUsers` | `app`*, `profileId`* | canManageProfiles |
| `CheckFeature` | `app`*, `featureKey`* | canEvaluateFeatures (any app user) |
| `GetUserFeatures` | `app`* | canEvaluateFeatures — returns enabled features only |

### Platform Profile Reactors (`src/prerna/reactor/platformprofile/`)
10 reactors (all admin-only):

| Reactor | Keys |
|---|---|
| `CreatePlatformProfile` | `name`*, `description` |
| `UpdatePlatformProfile` | `profileId`*, `name`, `description` |
| `DeletePlatformProfile` | `profileId`* (rejects if users assigned) |
| `GetPlatformProfiles` | *(none)* |
| `SetPlatformFeature` | `profileId`*, `featureKey`*, `enabled`* |
| `GetPlatformFeatures` | `profileId`* |
| `AssignUserPlatformProfile` | `userId`*, `profileId`* |
| `RemoveUserPlatformProfile` | `userId`* |
| `GetUserPlatformFeatures` | *(none — uses session user)* |
| `GetPlatformProfileUsers` | `profileId`* |

### SecurityProjectUtils.java
Added `AppProfileUtils.removeUserProfile(appId, userId)` at every code path that removes a user from a project — ensures no stale `APP_USER_PROFILE` rows after access revocation.

---

## How to Test

### App Profiles — end-to-end
```
# 1. Create profiles (replace "abc" with a real app ID you own)
CreateAppProfile(app="abc", name="beta", isDefault=false);
CreateAppProfile(app="abc", name="standard", isDefault=true);

# 2. Create a feature
CreateAppFeature(app="abc", key="export-csv");

# 3. Enable feature for beta profile only
SetProfileFeature(app="abc", profileId="<beta-id>", featureId="<feature-id>", enabled=true);

# 4. Assign a user to the beta profile
AssignUserProfile(app="abc", userId="<user-id>", profileId="<beta-id>");

# 5. As that user, check the feature (should return true)
CheckFeature(app="abc", featureKey="export-csv");

# 6. GetUserFeatures — should return only enabled features
GetUserFeatures(app="abc");

# 7. Remove user from profile; CheckFeature falls back to standard (default) → false
RemoveUserProfile(app="abc", userId="<user-id>");
CheckFeature(app="abc", featureKey="export-csv");

# 8. Backwards compat — app with no profiles/features
CheckFeature(app="no-profile-app", featureKey="anything");
# → false (no features defined, not an error)
```

### Platform Profiles
```
# Create profile
CreatePlatformProfile(name="catalog-only");

# Enable only app-catalog nav
SetPlatformFeature(profileId="<id>", featureKey="nav.app-catalog", enabled=true);

# Assign user
AssignUserPlatformProfile(userId="<user-id>", profileId="<id>");

# Query features for that user (after they log in)
GetUserPlatformFeatures();
# → {nav.app-catalog: true, nav.build: false, nav.skills: false, ...}

# Unassigned user (no platform profile) gets all nav visible (fail-open)
# → all keys = true
```

### Delete protection
```
# Assign a user to a profile, then try to delete it → error with count
AssignUserProfile(app="abc", userId="<user-id>", profileId="<beta-id>");
DeleteAppProfile(app="abc", profileId="<beta-id>");
# → "Cannot delete: 1 users are assigned to this profile. Reassign them first."
```

### Cascade delete (access revocation)
Remove a user from an app via existing security mechanisms and verify the `APP_USER_PROFILE` row is also gone:
```sql
-- After removing user from app:
SELECT * FROM APP_USER_PROFILE WHERE APP_ID='abc' AND USER_ID='<user-id>';
-- → 0 rows
```

---

## Notes

- **Fail-closed vs fail-open**: App profiles are fail-closed (no profile = no features). Platform profiles are fail-open (no profile = all nav visible). This is intentional — app feature visibility is opt-in; platform nav restriction requires explicit admin setup.
- **Phase 2 deferred**: Platform profile enforcement at the server/auth layer is not implemented. Users who directly navigate to a gated URL can still access it. UI-only gating per spec.
- **No migration needed**: No existing data or tables are modified. New tables are created only if they don't exist.
- **Feature key format**: App feature keys validate against `^[a-zA-Z0-9\-]+$`, max 100 chars, server-side. Platform feature keys are a closed predefined set.
- **No shared feature key library**: App feature keys are per-app. `export-csv` in App A and App B are separate rows with separate UUIDs.