### PR TITLE
Platform Skills

### DIFF
--- a/docs/agents/skills/skills_doc.md
+++ b/docs/agents/skills/skills_doc.md
@@ -3,7 +3,9 @@
 Two reactors surface the skills available on the platform. They answer different questions:
 
 - **`ListSkills`** reads the **physical skill files on disk** for a room, project, or the current insight. It does **not** read the database, so any skill files that were copied or added manually are picked up and returned.
-- **`GetSkills`** does a **database read** of the skills that are **registered as projects** on the platform.
+- **`GetSkills`** does a **database read** of the skills **registered as projects** on the platform, and also includes the **platform skills** (disk-backed built-ins).
+
+Once you have a skill's identifier, attach it to a workspace with **`AttachSkillToWorkspace`** / **`DetachSkillFromWorkspace`**, or set a workspace's whole skill set with **`EditWorkspace`** - see [Managing skills on a workspace](#managing-skills-on-a-workspace).
 
 ---
 
@@ -98,13 +100,18 @@ With `includeAll=true`, each skill additionally carries a `files` array. Every f
 
 ## GetSkills
 
-Does a database read to return the skills **registered as projects** on the platform. Supports a `filter` to scope the results. This reactor does **not** return skill file contents - use `ListSkills` for that.
+Returns the skills available to you: the **registry skills** (registered as Projects) you can view, **plus** all **platform skills** (disk-backed built-ins). Supports a `filter` to scope the results. This reactor does **not** return skill file contents - use `ListSkills` for that.
 
 ### Parameters
 
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
-| `filter` | string | `accessible` | One of `mine` (skills you created), `platform` (platform-origin skills), or `accessible` (every skill-project you can view). |
+| `filter` | string | `accessible` | One of `mine` (registry skills you created), `platform` (platform skills only), or `accessible` (default - every registry skill you can view **plus** all platform skills). |
+
+**Notes**
+
+- A registry skill has a `skill_id` and an `origin` of `USER`, `IMPORTED`, or `GENERATED`. A platform skill has `origin = PLATFORM` and a `slug` but **no `skill_id`** - that is how you tell them apart in the merged `accessible` result.
+- `mine` returns registry skills only; `platform` returns platform skills only.
 
 ### Examples
 
@@ -140,6 +147,166 @@ GetSkills(filter="accessible");
     "skill_id": "019eb7d5-4998-76b4-8620-5e9a516816db",
     "created_by": "rweiler",
     "slug": "pptx"
+  },
+  {
+    "origin": "PLATFORM",
+    "name": "database",
+    "description": "Use when writing code that queries a relational or graph database on the platform...",
+    "slug": "database"
   }
 ]
 ```
+
+The last entry is a **platform skill**: note `origin` is `PLATFORM`, it carries a `slug`, and it has **no `skill_id`**. Registry skills always carry a `skill_id`.
+
+---
+
+## Managing skills on a workspace
+
+There are two ways to change which skills a workspace uses:
+
+- **Incremental** - `AttachSkillToWorkspace` / `DetachSkillFromWorkspace` add or remove **one** skill at a time.
+- **Bulk** - `EditWorkspace` sets the **whole** configuration (name, MCPs, registry skills, and - when you pass `platformSkills` - platform skills) at once.
+
+A skill is identified one of two ways, and the reactors branch on which you pass:
+
+| | Registry skill | Platform skill |
+| --- | --- | --- |
+| Identifier | `skillId` (UUID) | `slug` (folder name) |
+| Stored in `CONFIG_JSON` as | `skills[]` (`{"skill_id": "..."}`) | `platform_skills[]` (`["slug", ...]`) |
+| `WORKSPACE_RESOURCE__` row | yes | no |
+
+All of these reactors require **edit** permission on the workspace.
+
+---
+
+## AttachSkillToWorkspace
+
+Attaches a single skill to a workspace and keeps `WORKSPACE.CONFIG_JSON` in sync. Pass **`skillId`** for a registry skill **or** **`slug`** for a platform skill - exactly one. Idempotent (re-attaching the same skill is a no-op).
+
+### Parameters
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `workspaceId` | string | - | Target workspace. **Required.** |
+| `skillId` | string | - | Registry skill to attach. Required **unless** `slug` is given. |
+| `slug` | string | - | Platform skill to attach. Required **unless** `skillId` is given. |
+
+### Examples
+
+```
+# registry skill (by id)
+AttachSkillToWorkspace(workspaceId=["0146f913-2ae3-4f6b-8b04-0e7a53a36145"], skillId=["019e4687-e52c-718a-8460-27cb795896ac"]);
+
+# platform skill (by slug)
+AttachSkillToWorkspace(workspaceId=["0146f913-2ae3-4f6b-8b04-0e7a53a36145"], slug=["database"]);
+```
+
+**Notes**
+
+- Registry path: writes a `WORKSPACE_RESOURCE__` row (`RESOURCE_TYPE='SKILL'`) and mirrors into `CONFIG_JSON.skills[]` as `{"skill_id": "..."}`.
+- Platform path: adds the slug to `CONFIG_JSON.platform_skills[]` (a plain array of slug strings); no `WORKSPACE_RESOURCE__` row.
+- Attaching a `slug` with no folder under `<BASE_FOLDER>/skills/` is an error. Passing both `skillId` and `slug`, or neither, is also an error.
+
+### Response
+
+```json
+{ "workspace_id": "0146f913-...", "skill_id": "019e4687-...", "created": true }
+```
+
+For a platform skill:
+
+```json
+{ "workspace_id": "0146f913-...", "slug": "database", "type": "PLATFORM_SKILL" }
+```
+
+---
+
+## DetachSkillFromWorkspace
+
+Removes a single skill from a workspace. Same `skillId`-or-`slug` rule as `AttachSkillToWorkspace`. No-op when the skill is not attached. Does **not** delete the skill itself (use `DeleteSkill` for a registry skill; platform skills are read-only and are never deleted through reactors).
+
+### Parameters
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `workspaceId` | string | - | Target workspace. **Required.** |
+| `skillId` | string | - | Registry skill to detach. Required **unless** `slug` is given. |
+| `slug` | string | - | Platform skill to detach. Required **unless** `skillId` is given. |
+
+### Examples
+
+```
+# registry skill (by id)
+DetachSkillFromWorkspace(workspaceId=["0146f913-2ae3-4f6b-8b04-0e7a53a36145"], skillId=["019e4687-e52c-718a-8460-27cb795896ac"]);
+
+# platform skill (by slug)
+DetachSkillFromWorkspace(workspaceId=["0146f913-2ae3-4f6b-8b04-0e7a53a36145"], slug=["database"]);
+```
+
+---
+
+## EditWorkspace
+
+Sets a workspace's configuration in **bulk** - name, description, system prompt, active state, the full MCP list, and the full **registry**-skill list. Use it to declare the complete state rather than nudge one item.
+
+### Parameters
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `workspaceId` | string | - | Target workspace. **Required.** |
+| `name` | string | - | Display name. **Required.** |
+| `description` | string | - | Workspace description. |
+| `systemPrompt` | string | - | Workspace system prompt (mirrored into `CONFIG_JSON.system_prompt`). |
+| `isActive` | boolean | `true` | Active/inactive state (owner only to change). |
+| `mcp` | list of maps | - | Full MCP set. Each entry is `{id, name, type}`; `type` is the catalog type (`PROJECT` for project/MCP tools, or an engine type such as `MODEL`). |
+| `skills` | list of strings | - | Full **registry**-skill set, as a flat list of `skill_id`s. |
+| `platformSkills` | list of strings | - | Platform skills, as a flat list of **slugs**. Opt-in: omit it to leave existing platform skills untouched; pass it (even empty) to full-replace `CONFIG_JSON.platform_skills[]`. |
+
+### Examples
+
+```
+EditWorkspace(
+  workspaceId=["0146f913-2ae3-4f6b-8b04-0e7a53a36145"],
+  name=["Ryan's Agent47"],
+  description=["Builds React/TypeScript apps"],
+  systemPrompt=["You are Agent 47..."],
+  isActive=[true],
+  mcp=[
+    {"id":"ce722163-2a8c-4667-b504-ce8732d77123","name":"NodeBuilderMCP","type":"PROJECT"},
+    {"id":"394404bf-02e5-44b2-bc7c-e93d9b698f58","name":"Database Maker","type":"PROJECT"}
+  ],
+  skills=["019e4687-e52c-718a-8460-27cb795896ac"],
+  platformSkills=["database","model"]
+);
+```
+
+**Notes**
+
+- `skills` and `mcp` are **full replaces** - the resulting set is exactly what you pass. `skills=[]` removes every registry skill.
+- `platformSkills` is **opt-in**: omit the key and any existing `CONFIG_JSON.platform_skills[]` is left untouched (so callers that don't send it never wipe platform skills); pass it and it is a **full replace**, where `platformSkills=[]` clears them all. Each slug is validated against the on-disk catalog - an unknown slug fails the call.
+
+### Which to use
+
+| Need | Use |
+| --- | --- |
+| Add/remove one registry skill | `AttachSkillToWorkspace` / `DetachSkillFromWorkspace` with `skillId` |
+| Add/remove one platform skill | `AttachSkillToWorkspace` / `DetachSkillFromWorkspace` with `slug` |
+| Replace the entire registry-skill + MCP set | `EditWorkspace` |
+| Add/remove one platform skill | `Attach`/`Detach` with `slug` |
+| Replace the entire platform-skill set | `EditWorkspace` with `platformSkills=[...]` |
+
+---
+
+## Reading back what is attached: GetWorkspace
+
+`GetWorkspace(workspaceId=["..."])` returns the workspace, including a `skills[]` array that contains **both** registry and platform skills, distinguished by `type` (`SKILL` vs `PLATFORM_SKILL`):
+
+```json
+"skills": [
+  { "id": "019e4687-...", "type": "SKILL", "name": "csv-cleaner", "slug": "csv-cleaner", "description": "..." },
+  { "id": "database", "type": "PLATFORM_SKILL", "name": "database", "slug": "database", "description": "..." }
+]
+```
+
+For a platform skill the `id` is the slug (platform skills have no project id). The full `config_json` is returned alongside, so you can read `skills[]` and `platform_skills[]` directly if you prefer the raw form.

--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -2516,6 +2516,88 @@ public class ModelInferenceLogsUtils {
 	}
 
 	/**
+	 * Adds a platform-skill slug to {@code WORKSPACE.CONFIG_JSON.platform_skills[]}.
+	 * Platform skills are disk-backed folders (see
+	 * {@code prerna.reactor.agent.skill.PlatformSkills}) - they are not Projects,
+	 * have no ids, and carry no {@code WORKSPACE_RESOURCE} row, so CONFIG_JSON is
+	 * the sole store. The array holds plain slug strings. Idempotent: a slug
+	 * already present is left untouched and no write is issued.
+	 *
+	 * @param workspaceId workspace identifier
+	 * @param slug        platform skill slug (folder name) to add
+	 * @throws SQLException if the CONFIG_JSON write fails
+	 */
+	public static void addPlatformSkillToWorkspaceConfigJson(String workspaceId, String slug) throws SQLException {
+		if (workspaceId == null || workspaceId.isEmpty()) {
+			throw new IllegalArgumentException("workspaceId is required");
+		}
+		if (slug == null || slug.isEmpty()) {
+			throw new IllegalArgumentException("slug is required");
+		}
+		JSONObject cfg = getWorkspaceConfigJson(workspaceId);
+		if (cfg == null) {
+			cfg = new JSONObject();
+			cfg.put("schema_version", 1);
+		}
+		JSONArray platformSkills = cfg.optJSONArray("platform_skills");
+		if (platformSkills == null) {
+			platformSkills = new JSONArray();
+		}
+		for (int i = 0; i < platformSkills.length(); i++) {
+			if (slug.equals(platformSkills.optString(i, null))) {
+				return;
+			}
+		}
+		platformSkills.put(slug);
+		cfg.put("platform_skills", platformSkills);
+		updateWorkspaceConfigJson(workspaceId, cfg);
+	}
+
+	/**
+	 * Removes a platform-skill slug from
+	 * {@code WORKSPACE.CONFIG_JSON.platform_skills[]}. No-op (no write) when the
+	 * workspace has no CONFIG_JSON, no {@code platform_skills} array, or the slug
+	 * is not present.
+	 *
+	 * @param workspaceId workspace identifier
+	 * @param slug        platform skill slug to remove
+	 * @throws SQLException if the CONFIG_JSON write fails
+	 */
+	public static void removePlatformSkillFromWorkspaceConfigJson(String workspaceId, String slug) throws SQLException {
+		if (workspaceId == null || workspaceId.isEmpty()) {
+			throw new IllegalArgumentException("workspaceId is required");
+		}
+		if (slug == null || slug.isEmpty()) {
+			throw new IllegalArgumentException("slug is required");
+		}
+		JSONObject cfg = getWorkspaceConfigJson(workspaceId);
+		if (cfg == null) {
+			return;
+		}
+		JSONArray platformSkills = cfg.optJSONArray("platform_skills");
+		if (platformSkills == null || platformSkills.length() == 0) {
+			return;
+		}
+		JSONArray kept = new JSONArray();
+		boolean removed = false;
+		for (int i = 0; i < platformSkills.length(); i++) {
+			String existing = platformSkills.optString(i, null);
+			if (slug.equals(existing)) {
+				removed = true;
+				continue;
+			}
+			if (existing != null) {
+				kept.put(existing);
+			}
+		}
+		if (!removed) {
+			return;
+		}
+		cfg.put("platform_skills", kept);
+		updateWorkspaceConfigJson(workspaceId, cfg);
+	}
+
+	/**
 	 * Returns paginated room entries for a workspace visible to the requesting
 	 * user.
 	 *
@@ -3604,17 +3686,39 @@ public class ModelInferenceLogsUtils {
 	}
 
 	/**
-	 * Removes the SKILL__ row and any WORKSPACE_RESOURCE__ rows pointing at this
-	 * skill. Does NOT delete the underlying Project - callers (typically the
-	 * project-delete path) own that.
+	 * Removes the SKILL__ row, any WORKSPACE_RESOURCE__ rows pointing at this skill,
+	 * and the matching {@code CONFIG_JSON.skills[]} mirror entry in every workspace
+	 * that referenced it. Does NOT delete the underlying Project - callers (typically
+	 * the project-delete path) own that.
+	 *
+	 * <p>Attach writes the WORKSPACE_RESOURCE row AND the CONFIG_JSON.skills[] mirror
+	 * (see {@code AttachSkillToWorkspaceReactor}); delete must clear BOTH. Skipping the
+	 * mirror leaves a dangling skill id that {@code AgentConfigLoader.resolveSkills}
+	 * still returns, so the run-time {@code SkillStager} fails it every run with
+	 * "not found in SKILL__". The referencing workspaces are captured before the row
+	 * deletes so the mirror can be scrubbed afterward.
 	 *
 	 * @param skillId skill identifier
 	 */
 	public static void deleteSkillEntry(String skillId) {
 		IRDBMSEngine modelInferenceLogsDb = SystemEngineRegistry.getModelInferenceLogsDb();
 		Connection con = null;
+		List<String> affectedWorkspaceIds = new ArrayList<>();
 		try {
 			con = modelInferenceLogsDb.getConnection();
+			try (PreparedStatement sel = con.prepareStatement(
+					"SELECT DISTINCT WORKSPACE_ID FROM WORKSPACE_RESOURCE WHERE RESOURCE_TYPE = ? AND RESOURCE_ID = ?")) {
+				sel.setString(1, "SKILL");
+				sel.setString(2, skillId);
+				try (ResultSet rs = sel.executeQuery()) {
+					while (rs.next()) {
+						String wsId = rs.getString(1);
+						if (wsId != null && !wsId.trim().isEmpty()) {
+							affectedWorkspaceIds.add(wsId);
+						}
+					}
+				}
+			}
 			try (PreparedStatement ps1 = con
 					.prepareStatement("DELETE FROM WORKSPACE_RESOURCE WHERE RESOURCE_TYPE = ? AND RESOURCE_ID = ?");
 					PreparedStatement ps2 = con.prepareStatement("DELETE FROM SKILL WHERE SKILL_ID = ?")) {
@@ -3632,6 +3736,16 @@ public class ModelInferenceLogsUtils {
 			throw new IllegalArgumentException("Error deleting skill: " + e.getMessage(), e);
 		} finally {
 			ConnectionUtils.closeAllConnectionsIfPooling(modelInferenceLogsDb, con, null, null);
+		}
+
+		for (String workspaceId : affectedWorkspaceIds) {
+			try {
+				removeSkillFromWorkspaceConfigJson(workspaceId, skillId);
+			} catch (Exception e) {
+				classLogger.warn(
+						"Deleted skill '{}' but failed to scrub it from CONFIG_JSON.skills[] for workspace '{}': {}",
+						skillId, workspaceId, e.getMessage());
+			}
 		}
 	}
 

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/AbstractWorkspaceReactor.java
@@ -63,6 +63,8 @@ public abstract class AbstractWorkspaceReactor extends AbstractReactor {
 	static final String PROMPTS = "prompts";
 	/** Request key for skill collection input. */
 	static final String SKILLS = "skills";
+	/** Request key for platform-skill (slug) collection input. */
+	static final String PLATFORM_SKILLS = "platformSkills";
 	/** Request key for active/inactive workspace state. */
 	static final String IS_ACTIVE = "isActive";
 

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/EditWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/EditWorkspaceReactor.java
@@ -30,6 +30,7 @@ package prerna.engine.impl.model.inferencetracking.reactors.workspaces;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,6 +47,7 @@ import prerna.auth.utils.SecurityProjectUtils;
 import prerna.engine.api.IEngine.CATALOG_TYPE;
 import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.prompt.PromptUtils;
+import prerna.reactor.agent.skill.PlatformSkills;
 import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.ReactorKeysEnum;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
@@ -57,8 +59,8 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 
 	public EditWorkspaceReactor() {
 		this.keysToGet = new String[] { ReactorKeysEnum.WORKSPACE_ID.getKey(), NAME, DESCRIPTION, SYSTEM_PROMPT,
-				IS_ACTIVE, ReactorKeysEnum.MCP.getKey(), PROMPTS, SKILLS };
-		this.keyRequired = new int[] { 1, 1, 0, 0, 0, 0, 0, 0 };
+				IS_ACTIVE, ReactorKeysEnum.MCP.getKey(), PROMPTS, SKILLS, PLATFORM_SKILLS };
+		this.keyRequired = new int[] { 1, 1, 0, 0, 0, 0, 0, 0, 0 };
 	}
 
 	@Override
@@ -183,6 +185,24 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 			}
 		}
 
+		Set<String> platformSkills = null;
+		if (getGenRowStruct(PLATFORM_SKILLS) != null) {
+			platformSkills = new LinkedHashSet<>();
+			for (String slug : getNounAsStringList(PLATFORM_SKILLS)) {
+				if (slug == null) {
+					continue;
+				}
+				String trimmed = slug.trim();
+				if (trimmed.isEmpty()) {
+					continue;
+				}
+				if (!PlatformSkills.exists(trimmed)) {
+					return getError("Platform skill not found: " + trimmed);
+				}
+				platformSkills.add(trimmed);
+			}
+		}
+
 		try {
 			ModelInferenceLogsUtils.updateWorkspaceEntry(workspaceId, workspaceName, workspaceDescription,
 					workspaceSystemPrompt, isActive, workspaceResources);
@@ -198,7 +218,8 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 		// WORKSPACE_RESOURCE rows already landed and AgentConfigLoader still resolves
 		// correctly from those.
 		try {
-			mirrorCoreFieldsIntoConfigJson(workspaceId, workspaceSystemPrompt, engines, projectDependencies, skillIds);
+			mirrorCoreFieldsIntoConfigJson(workspaceId, workspaceSystemPrompt, engines, projectDependencies, skillIds,
+					platformSkills);
 		} catch (Exception e) {
 			classLogger.warn(
 					"Failed to mirror system_prompt/mcps/skills into CONFIG_JSON for workspaceId '{}' (legacy writes already succeeded)",
@@ -229,9 +250,16 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 	 * {@code AgentConfigLoader.resolveSkills} and
 	 * {@code ModelInferenceLogsUtils.addSkillToWorkspaceConfigJson} read/write. No
 	 * {@code pinned_version} is emitted because the edit input carries only ids.
+	 *
+	 * <p>
+	 * {@code platformSkills} differs from {@code skills}/{@code mcps}: a {@code null}
+	 * value leaves any existing {@code platform_skills} array untouched (callers that
+	 * omit the input never clobber it), while a non-null value is a full replace (an
+	 * empty set clears it). Entries are plain slug strings, matching
+	 * {@code CONFIG_JSON.platform_skills[]}.
 	 */
 	private static void mirrorCoreFieldsIntoConfigJson(String workspaceId, String systemPrompt, Set<String> engines,
-			Set<String> projects, Set<String> skills) throws Exception {
+			Set<String> projects, Set<String> skills, Set<String> platformSkills) throws Exception {
 		JSONObject cfg = ModelInferenceLogsUtils.getWorkspaceConfigJson(workspaceId);
 		if (cfg == null) {
 			cfg = new JSONObject();
@@ -265,6 +293,14 @@ public class EditWorkspaceReactor extends AbstractWorkspaceReactor {
 			skillsJson.put(entry);
 		}
 		cfg.put("skills", skillsJson);
+
+		if (platformSkills != null) {
+			JSONArray platformSkillsJson = new JSONArray();
+			for (String slug : platformSkills) {
+				platformSkillsJson.put(slug);
+			}
+			cfg.put("platform_skills", platformSkillsJson);
+		}
 
 		ModelInferenceLogsUtils.updateWorkspaceConfigJson(workspaceId, cfg);
 	}

--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/GetWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/GetWorkspaceReactor.java
@@ -34,6 +34,8 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.json.JSONArray;
+import org.json.JSONObject;
 
 import prerna.auth.User;
 import prerna.auth.utils.AbstractSecurityUtils;
@@ -45,6 +47,7 @@ import prerna.project.api.IProject;
 import prerna.project.impl.ProjectHelper;
 import prerna.prompt.PromptUtils;
 import prerna.reactor.AbstractReactor;
+import prerna.reactor.agent.skill.PlatformSkills;
 import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.ReactorKeysEnum;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
@@ -130,9 +133,7 @@ public class GetWorkspaceReactor extends AbstractReactor {
 				}
 				prompts.add(promptMap);
 			} else if (AbstractWorkspaceReactor.SKILL_RESOURCE_TYPE.equalsIgnoreCase(rType)) {
-				// Skills are projects (PROJECT_TYPE.SKILL) but they are not engines and
-				// not regular projects either - they have their own bucket in the response
-				// so the UI can surface them distinctly from MCPs.
+
 				Map<String, String> skillMap = new HashMap<>();
 				skillMap.put("id", resourceId);
 				skillMap.put("type", rType);
@@ -164,6 +165,8 @@ public class GetWorkspaceReactor extends AbstractReactor {
 				mcps.add(mcpMap);
 			}
 		}
+		mergePlatformSkills(workspaceId, skills);
+
 		current.put("mcp", mcps);
 		current.put("prompts", prompts);
 		current.put("skills", skills);
@@ -171,6 +174,52 @@ public class GetWorkspaceReactor extends AbstractReactor {
 		current.put("number_collaborators", userCount);
 
 		return new NounMetadata(current, PixelDataType.MAP);
+	}
+
+	/**
+	 * Appends the workspace's platform skills (disk-backed built-ins referenced by
+	 * slug in {@code CONFIG_JSON.platform_skills[]}) to {@code skills}. Each entry
+	 * carries {@code id} (= slug), {@code slug}, {@code type=PLATFORM_SKILL}, and
+	 * {@code name}/{@code description} resolved from the on-disk catalog - falling
+	 * back to the slug for name when a slug is no longer present on disk so it stays
+	 * visible (and detachable) in the UI.
+	 */
+	private void mergePlatformSkills(String workspaceId, List<Map<String, String>> skills) {
+		try {
+			JSONObject cfg = ModelInferenceLogsUtils.getWorkspaceConfigJson(workspaceId);
+			JSONArray platformSlugs = cfg != null ? cfg.optJSONArray("platform_skills") : null;
+			if (platformSlugs == null || platformSlugs.length() == 0) {
+				return;
+			}
+			Map<String, Map<String, Object>> catalog = new HashMap<>();
+			for (Map<String, Object> ps : PlatformSkills.list()) {
+				Object slug = ps.get("slug");
+				if (slug != null) {
+					catalog.put(slug.toString(), ps);
+				}
+			}
+			for (int i = 0; i < platformSlugs.length(); i++) {
+				String slug = platformSlugs.optString(i, null);
+				if (slug == null || slug.trim().isEmpty()) {
+					continue;
+				}
+				slug = slug.trim();
+				Map<String, Object> meta = catalog.get(slug);
+				Map<String, String> skillMap = new HashMap<>();
+				skillMap.put("id", slug);
+				skillMap.put("slug", slug);
+				skillMap.put("type", PlatformSkills.PLATFORM_SKILL_TYPE);
+				Object name = meta != null ? meta.get("name") : null;
+				skillMap.put("name", name != null ? name.toString() : slug);
+				Object description = meta != null ? meta.get("description") : null;
+				if (description != null) {
+					skillMap.put("description", description.toString());
+				}
+				skills.add(skillMap);
+			}
+		} catch (Exception e) {
+			classLogger.warn("Failed to merge platform skills for workspace '{}': {}", workspaceId, e.getMessage());
+		}
 	}
 
 	/**

--- a/src/prerna/reactor/agent/AgentRunner.java
+++ b/src/prerna/reactor/agent/AgentRunner.java
@@ -211,7 +211,11 @@ public final class AgentRunner {
 			AgentConfig agentConfig = AgentConfigLoader.load(room, filePath, modelId, params, agentParams, maxTurns,
 					maxReflections, explicitWorkspaceId);
 
-			// Best-effort skill staging for harnesses that discover local skills from disk.
+			try {
+				SkillStager.stagePlatform(filePath, agentConfig.getPlatformSkills());
+			} catch (Exception e) {
+				logger.warn("AgentRunner: platform skill staging failed for room='{}': {}", roomId, e.getMessage(), e);
+			}
 			try {
 				SkillStager.stage(filePath, agentConfig.getSkills());
 			} catch (Exception e) {

--- a/src/prerna/reactor/agent/config/AgentConfig.java
+++ b/src/prerna/reactor/agent/config/AgentConfig.java
@@ -74,6 +74,10 @@ public final class AgentConfig {
     // Skill refs (union of WORKSPACE_RESOURCE['SKILL'] + CONFIG_JSON.skills[] + room.options.skills[])
     private final List<Map<String, String>> skills;
 
+    // Platform skill slugs (union of CONFIG_JSON.platform_skills[] + room.options.platform_skills[]);
+    // disk-backed built-in skills referenced by folder name, staged from <BASE_FOLDER>/skills/.
+    private final List<String> platformSkills;
+
     // Budgets (nested)
     private final Budgets budgets;
 
@@ -110,6 +114,9 @@ public final class AgentConfig {
                 : Collections.emptyList();
         this.skills          = b.skills != null
                 ? Collections.unmodifiableList(new ArrayList<>(b.skills))
+                : Collections.emptyList();
+        this.platformSkills  = b.platformSkills != null
+                ? Collections.unmodifiableList(new ArrayList<>(b.platformSkills))
                 : Collections.emptyList();
         this.budgets         = b.budgets != null ? b.budgets : Budgets.defaults();
         this.spawnPolicy     = b.spawnPolicy != null ? b.spawnPolicy : SubAgentSpawnPolicy.defaults();
@@ -248,6 +255,18 @@ public final class AgentConfig {
         return skills;
     }
 
+    // Platform skills
+    /**
+     * Resolved platform-skill slugs for this run.
+     *
+     * <p>Disk-backed built-in skills referenced by folder name (no ids).
+     * {@link prerna.reactor.agent.skill.SkillStager#stagePlatform} materializes
+     * each into {@code .claude/skills/<slug>/} from {@code <BASE_FOLDER>/skills/}.
+     */
+    public List<String> getPlatformSkills() {
+        return platformSkills;
+    }
+
     // Budgets
     /** Run-time budgets (turn cap, reflection cap, wall-clock). Never {@code null}. */
     public Budgets getBudgets() {
@@ -299,6 +318,7 @@ public final class AgentConfig {
         private String workingDir;
         private List<Map<String, String>> mcps;
         private List<Map<String, String>> skills;
+        private List<String>        platformSkills;
         private Budgets             budgets;
         private SubAgentSpawnPolicy spawnPolicy;
         private List<IAgentRunHook> runHooks;
@@ -317,6 +337,7 @@ public final class AgentConfig {
         public Builder workingDir(String v)          { this.workingDir = v;          return this; }
         public Builder mcps(List<Map<String, String>> v) { this.mcps = v;            return this; }
         public Builder skills(List<Map<String, String>> v) { this.skills = v;        return this; }
+        public Builder platformSkills(List<String> v)      { this.platformSkills = v; return this; }
         public Builder budgets(Budgets v)                       { this.budgets = v;             return this; }
         public Builder spawnPolicy(SubAgentSpawnPolicy v)       { this.spawnPolicy = v;         return this; }
         public Builder runHooks(List<IAgentRunHook> v)          { this.runHooks = v;            return this; }

--- a/src/prerna/reactor/agent/config/AgentConfigLoader.java
+++ b/src/prerna/reactor/agent/config/AgentConfigLoader.java
@@ -170,6 +170,9 @@ public final class AgentConfigLoader {
         // Skills follow the same layered merge and are staged later by AgentRunner.
         b.skills(resolveSkills(workspaceId, room, cfgJson));
 
+        // Platform skills: disk-backed built-ins referenced by slug, staged from <BASE_FOLDER>/skills/.
+        b.platformSkills(resolvePlatformSkills(room, cfgJson));
+
         // Hooks and subagents currently come from CONFIG_JSON only. resolveHooks classifies
         // each entry by interface so a hook can land on the run-hook list, tool-hook list,
         // or both.
@@ -180,9 +183,9 @@ public final class AgentConfigLoader {
 
         AgentConfig cfg = b.build();
         logger.info(
-                "AgentConfigLoader: resolved room={} workspaceId={} name={} modelId={} workingDir={} mcps={} skills={} runHooks={} toolHooks={} subagents={} budgets(turns={},refl={},secs={}) authoredChars={} workdirAgentsMdChars={} cfgJson={}",
+                "AgentConfigLoader: resolved room={} workspaceId={} name={} modelId={} workingDir={} mcps={} skills={} platformSkills={} runHooks={} toolHooks={} subagents={} budgets(turns={},refl={},secs={}) authoredChars={} workdirAgentsMdChars={} cfgJson={}",
                 room.getId(), cfg.getWorkspaceId(), cfg.getName(), cfg.getModelId(), cfg.getWorkingDir(),
-                cfg.getMcps().size(), cfg.getSkills().size(), cfg.getRunHooks().size(), cfg.getToolHooks().size(), cfg.getSubagents().size(),
+                cfg.getMcps().size(), cfg.getSkills().size(), cfg.getPlatformSkills().size(), cfg.getRunHooks().size(), cfg.getToolHooks().size(), cfg.getSubagents().size(),
                 cfg.getBudgets().getMaxTurns(), cfg.getBudgets().getMaxReflections(), cfg.getBudgets().getMaxSeconds(),
                 lengthOrZero(cfg.getAuthoredPrompt()), lengthOrZero(cfg.getWorkdirAgentsMd()),
                 cfgJson == null ? "absent" : "present");
@@ -368,6 +371,67 @@ public final class AgentConfigLoader {
             entry.put("pinned_version", pinnedVersion);
         }
         return entry;
+    }
+
+    /**
+     * Builds the platform-skill slug list from CONFIG_JSON and room options,
+     * deduped by slug (insertion order preserved). Platform skills are disk-backed
+     * folders under {@code <BASE_FOLDER>/skills/}; they have no ids and are
+     * referenced by folder name. Staged from disk by
+     * {@link prerna.reactor.agent.skill.SkillStager#stagePlatform}.
+     */
+    private static List<String> resolvePlatformSkills(Room room, JSONObject cfgJson) {
+        Set<String> out = new LinkedHashSet<>();
+
+        // CONFIG_JSON.platform_skills[] - array of slug strings.
+        if (cfgJson != null && cfgJson.has("platform_skills")) {
+            JSONArray arr = cfgJson.optJSONArray("platform_skills");
+            if (arr != null) {
+                for (int i = 0; i < arr.length(); i++) {
+                    String slug = StringUtils.trimToNull(arr.optString(i, null));
+                    if (slug != null) {
+                        out.add(slug);
+                    }
+                }
+            }
+        }
+
+        // room.options.platform_skills[] - array of slug strings.
+        for (String slug : extractRoomPlatformSkills(room)) {
+            if (slug != null && !slug.isEmpty()) {
+                out.add(slug);
+            }
+        }
+
+        return new ArrayList<>(out);
+    }
+
+    /** Parse {@code room.options.platform_skills[]} into a list of slug strings. */
+    private static List<String> extractRoomPlatformSkills(Room room) {
+        List<String> result = new ArrayList<>();
+        String opts = room.getOptions();
+        if (opts == null || opts.trim().isEmpty()) {
+            return result;
+        }
+        try {
+            JsonObject obj = JsonParser.parseString(opts).getAsJsonObject();
+            JsonElement el = obj.get("platform_skills");
+            if (el == null || !el.isJsonArray()) {
+                return result;
+            }
+            for (JsonElement e : el.getAsJsonArray()) {
+                if (!e.isJsonPrimitive()) {
+                    continue;
+                }
+                String slug = StringUtils.trimToNull(e.getAsString());
+                if (slug != null) {
+                    result.add(slug);
+                }
+            }
+        } catch (Exception ignore) {
+            // best-effort parse; bad options blob -> no room platform skills
+        }
+        return result;
     }
 
     /** Parse {@code room.options.mcp[]} into a list of {@code {id, name}} maps. */

--- a/src/prerna/reactor/agent/skill/AttachSkillToWorkspaceReactor.java
+++ b/src/prerna/reactor/agent/skill/AttachSkillToWorkspaceReactor.java
@@ -47,18 +47,30 @@ import prerna.sablecc2.om.nounmeta.NounMetadata;
 import prerna.util.Constants;
 
 /**
- * Attaches a skill from the registry to a workspace by inserting a
- * {@code WORKSPACE_RESOURCE__} row with {@code RESOURCE_TYPE='SKILL'}.
+ * Attaches a skill to a workspace. Handles both skill kinds through one entry
+ * point, keyed by which identifier you pass:
  *
- * <p>Since a skill is itself a Project (type=SKILL), authorization piggybacks on
- * project permissions: the user must be able to edit the workspace project and
- * view the skill project. Idempotent - a second call with the same
- * {@code (workspaceId, skillId)} no-ops.
+ * <ul>
+ *   <li>{@code skillId} - a registry skill (a Project of type {@code SKILL}).
+ *       Inserts a {@code WORKSPACE_RESOURCE__} row with
+ *       {@code RESOURCE_TYPE='SKILL'} and mirrors it into
+ *       {@code CONFIG_JSON.skills[]}. Authorization piggybacks on project
+ *       permissions: edit on the workspace, view on the skill.</li>
+ *   <li>{@code slug} - a platform skill (a disk-backed built-in under
+ *       {@code <BASE_FOLDER>/skills/}; see {@link PlatformSkills}). Adds the slug
+ *       to {@code CONFIG_JSON.platform_skills[]}. Platform skills are not Projects
+ *       and carry no permissions, so only workspace-edit rights are required.</li>
+ * </ul>
+ *
+ * <p>Exactly one of {@code skillId} / {@code slug} must be supplied - a
+ * {@code slug} (no id) is the signal that you mean a platform skill. Idempotent
+ * in both modes.
  *
  * <p>Inputs:
  * <ul>
  *   <li>{@code workspaceId} - target workspace (required)</li>
- *   <li>{@code skillId}     - skill to attach (required)</li>
+ *   <li>{@code skillId}     - registry skill to attach (required unless {@code slug} given)</li>
+ *   <li>{@code slug}        - platform skill to attach (required unless {@code skillId} given)</li>
  * </ul>
  */
 public class AttachSkillToWorkspaceReactor extends AbstractReactor {
@@ -66,10 +78,11 @@ public class AttachSkillToWorkspaceReactor extends AbstractReactor {
 	private static final Logger classLogger = LogManager.getLogger(AttachSkillToWorkspaceReactor.class);
 
 	private static final String SKILL_ID = "skillId";
+	private static final String SLUG     = "slug";
 
 	public AttachSkillToWorkspaceReactor() {
-		this.keysToGet = new String[] { ReactorKeysEnum.WORKSPACE_ID.getKey(), SKILL_ID };
-		this.keyRequired = new int[] { 1, 1 };
+		this.keysToGet = new String[] { ReactorKeysEnum.WORKSPACE_ID.getKey(), SKILL_ID, SLUG };
+		this.keyRequired = new int[] { 1, 0, 0 };
 	}
 
 	@Override
@@ -77,22 +90,53 @@ public class AttachSkillToWorkspaceReactor extends AbstractReactor {
 		organizeKeys();
 
 		String workspaceId = this.keyValue.get(ReactorKeysEnum.WORKSPACE_ID.getKey());
-		String skillId     = this.keyValue.get(SKILL_ID);
+		String skillId     = nullIfBlank(this.keyValue.get(SKILL_ID));
+		String slug        = nullIfBlank(this.keyValue.get(SLUG));
 
 		if (workspaceId == null || workspaceId.isEmpty()) {
 			throw new IllegalArgumentException("workspaceId is required");
 		}
-		if (skillId == null || skillId.isEmpty()) {
-			throw new IllegalArgumentException("skillId is required");
+		if (skillId == null && slug == null) {
+			throw new IllegalArgumentException("either skillId or slug is required");
+		}
+		if (skillId != null && slug != null) {
+			throw new IllegalArgumentException("provide exactly one of skillId or slug (slug => platform skill)");
 		}
 
 		User user = this.insight.getUser();
-
 		if (!SecurityProjectUtils.userCanEditProject(user, workspaceId)) {
 			throw new IllegalArgumentException(
 					"Workspace " + workspaceId + " does not exist or user does not have permission to edit it");
 		}
 
+		// A slug (and no id) means a disk-backed platform skill.
+		if (slug != null) {
+			return attachPlatformSkill(workspaceId, slug);
+		}
+		return attachRegistrySkill(user, workspaceId, skillId);
+	}
+
+	/** Platform skill: add the slug to CONFIG_JSON.platform_skills[]. */
+	private NounMetadata attachPlatformSkill(String workspaceId, String slug) {
+		if (!PlatformSkills.exists(slug)) {
+			throw new IllegalArgumentException("Platform skill not found: " + slug);
+		}
+		try {
+			ModelInferenceLogsUtils.addPlatformSkillToWorkspaceConfigJson(workspaceId, slug);
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to attach platform skill to workspace: " + e.getMessage(), e);
+		}
+
+		Map<String, Object> response = new HashMap<>();
+		response.put("workspace_id", workspaceId);
+		response.put("slug", slug);
+		response.put("type", PlatformSkills.PLATFORM_SKILL_TYPE);
+		return new NounMetadata(response, PixelDataType.MAP, PixelOperationType.OPERATION);
+	}
+
+	/** Registry skill: insert the WORKSPACE_RESOURCE__ row and mirror into CONFIG_JSON.skills[]. */
+	private NounMetadata attachRegistrySkill(User user, String workspaceId, String skillId) {
 		Map<String, Object> skillRow = ModelInferenceLogsUtils.getSkillEntry(skillId);
 		if (skillRow == null) {
 			throw new IllegalArgumentException("Skill not found: " + skillId);
@@ -137,9 +181,18 @@ public class AttachSkillToWorkspaceReactor extends AbstractReactor {
 		}
 	}
 
+	private static String nullIfBlank(String s) {
+		if (s == null) {
+			return null;
+		}
+		String t = s.trim();
+		return t.isEmpty() ? null : t;
+	}
+
 	@Override
 	public String getReactorDescription() {
-		return "Attaches a skill from the registry to a workspace (WORKSPACE_RESOURCE__ with RESOURCE_TYPE='SKILL'). Idempotent.";
+		return "Attaches a skill to a workspace. Pass skillId for a registry skill (WORKSPACE_RESOURCE__ + "
+				+ "CONFIG_JSON.skills[]) or slug for a platform skill (CONFIG_JSON.platform_skills[]). Idempotent.";
 	}
 
 	@Override
@@ -148,7 +201,10 @@ public class AttachSkillToWorkspaceReactor extends AbstractReactor {
 			return "Target workspace identifier";
 		}
 		if (SKILL_ID.equals(key)) {
-			return "Identifier of the skill to attach";
+			return "Identifier of the registry skill to attach (omit when attaching a platform skill by slug)";
+		}
+		if (SLUG.equals(key)) {
+			return "Folder name (slug) of the platform skill to attach (omit when attaching a registry skill by id)";
 		}
 		return super.getDescriptionForKey(key);
 	}

--- a/src/prerna/reactor/agent/skill/CreateSkillReactor.java
+++ b/src/prerna/reactor/agent/skill/CreateSkillReactor.java
@@ -41,7 +41,6 @@ import com.github.f4b6a3.uuid.alt.GUID;
 
 import prerna.auth.AuthProvider;
 import prerna.auth.User;
-import prerna.auth.utils.SecurityAdminUtils;
 import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.project.impl.ProjectHelper;
 import prerna.reactor.AbstractReactor;
@@ -70,8 +69,9 @@ import prerna.util.Constants;
  *   <li>{@code name}         - display name. Required <i>only</i> when the frontmatter omits one. When
  *                              both are supplied, frontmatter wins.</li>
  *   <li>{@code description}  - same rule as {@code name}: required only when frontmatter omits it.</li>
- *   <li>{@code origin}       - provenance, default {@link Skill#ORIGIN_USER}. Setting this to
- *                              {@link Skill#ORIGIN_PLATFORM} requires platform admin (optional)</li>
+ *   <li>{@code origin}       - provenance, default {@link Skill#ORIGIN_USER}. Accepts USER,
+ *                              IMPORTED, or GENERATED; {@link Skill#ORIGIN_PLATFORM} is rejected
+ *                              (platform skills ship as folders, not Projects). (optional)</li>
  * </ul>
  *
  * <p>When the supplied {@code skillContent} already starts with a {@code ---} frontmatter
@@ -133,9 +133,10 @@ public class CreateSkillReactor extends AbstractReactor {
 
 		User user = this.insight.getUser();
 		String createdBy = resolveUserId(user);
-		boolean isPlatform = Skill.ORIGIN_PLATFORM.equals(origin);
-		if (isPlatform && !Boolean.TRUE.equals(SecurityAdminUtils.userIsAdmin(user))) {
-			throw new IllegalArgumentException("Only platform admins can create platform skills");
+		if (Skill.ORIGIN_PLATFORM.equals(origin)) {
+			throw new IllegalArgumentException(
+					"origin=PLATFORM is not supported here - platform skills ship as folders under "
+							+ "<BASE_FOLDER>/skills/. Use origin USER, IMPORTED, or GENERATED.");
 		}
 
 		String skillId = GUID.v7().toString();
@@ -145,7 +146,7 @@ public class CreateSkillReactor extends AbstractReactor {
 				: Skill.buildFrontmatter(name, description) + skillContent;
 
 		try {
-			ProjectHelper.createSkillProject(skillId, name, /* global */ isPlatform,
+			ProjectHelper.createSkillProject(skillId, name, /* global */ false,
 					/* gitProvider */ null, /* gitCloneUrl */ null, user, classLogger);
 
 			String assetsFolder = AssetUtility.getProjectAssetsFolder(skillId);
@@ -214,8 +215,8 @@ public class CreateSkillReactor extends AbstractReactor {
 					+ "Frontmatter wins when both are supplied";
 		}
 		if (ORIGIN.equals(key)) {
-			return "Provenance: USER | PLATFORM | IMPORTED | GENERATED. Default USER. "
-					+ "Setting to PLATFORM requires platform admin.";
+			return "Provenance: USER | IMPORTED | GENERATED. Default USER. "
+					+ "PLATFORM is rejected - platform skills ship as folders under <BASE_FOLDER>/skills/.";
 		}
 		return super.getDescriptionForKey(key);
 	}

--- a/src/prerna/reactor/agent/skill/DeleteSkillReactor.java
+++ b/src/prerna/reactor/agent/skill/DeleteSkillReactor.java
@@ -48,8 +48,9 @@ import prerna.util.Utility;
 
 /**
  * Deletes a skill: removes the {@code SKILL__} row, any {@code WORKSPACE_RESOURCE__}
- * rows that attach it to a workspace, and the underlying skill-project (security
- * rows, DIHelper entry, on-disk folder).
+ * rows that attach it to a workspace, the matching {@code CONFIG_JSON.skills[]} mirror
+ * entries, and the underlying skill-project (security rows, DIHelper entry, on-disk
+ * folder).
  *
  * <p>Mirrors {@code DeleteWorkspaceReactor}. The generic {@code DeleteProjectReactor}
  * also handles skill cleanup via its {@code PROJECT_TYPE.SKILL} branch, so callers

--- a/src/prerna/reactor/agent/skill/DetachSkillFromWorkspaceReactor.java
+++ b/src/prerna/reactor/agent/skill/DetachSkillFromWorkspaceReactor.java
@@ -42,31 +42,45 @@ import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.PixelOperationType;
 import prerna.sablecc2.om.ReactorKeysEnum;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.util.Constants;
 
 /**
- * Removes the {@code WORKSPACE_RESOURCE__} row that links a skill to a workspace.
- * No-op when no such attachment exists. Does not delete the skill itself; use
- * {@code DeleteSkillReactor} for that.
+ * Detaches a skill from a workspace. Mirrors {@link AttachSkillToWorkspaceReactor}
+ * and handles both skill kinds, keyed by which identifier you pass:
  *
- * <p>Inputs:
  * <ul>
- *   <li>{@code workspaceId} - workspace identifier (required)</li>
- *   <li>{@code skillId}     - skill identifier to detach (required)</li>
+ *   <li>{@code skillId} - a registry skill: removes the {@code WORKSPACE_RESOURCE__}
+ *       row and the matching {@code CONFIG_JSON.skills[]} entry.</li>
+ *   <li>{@code slug} - a platform skill: removes the slug from
+ *       {@code CONFIG_JSON.platform_skills[]} (see {@link PlatformSkills}).</li>
  * </ul>
+ *
+ * <p>Exactly one of {@code skillId} / {@code slug} must be supplied. No-op when
+ * the attachment does not exist. Does not delete the skill itself; use
+ * {@code DeleteSkillReactor} for registry skills (platform skills are read-only
+ * built-ins and are never deleted through reactors).
  *
  * <p>Authorization: user must have edit access to the workspace
  * ({@link SecurityProjectUtils#userCanEditProject}). No skill-side check -
  * detaching is always allowed for someone who can edit the workspace.
+ *
+ * <p>Inputs:
+ * <ul>
+ *   <li>{@code workspaceId} - workspace identifier (required)</li>
+ *   <li>{@code skillId}     - registry skill to detach (required unless {@code slug} given)</li>
+ *   <li>{@code slug}        - platform skill to detach (required unless {@code skillId} given)</li>
+ * </ul>
  */
 public class DetachSkillFromWorkspaceReactor extends AbstractReactor {
 
 	private static final Logger classLogger = LogManager.getLogger(DetachSkillFromWorkspaceReactor.class);
 
 	private static final String SKILL_ID = "skillId";
+	private static final String SLUG     = "slug";
 
 	public DetachSkillFromWorkspaceReactor() {
-		this.keysToGet = new String[] { ReactorKeysEnum.WORKSPACE_ID.getKey(), SKILL_ID };
-		this.keyRequired = new int[] { 1, 1 };
+		this.keysToGet = new String[] { ReactorKeysEnum.WORKSPACE_ID.getKey(), SKILL_ID, SLUG };
+		this.keyRequired = new int[] { 1, 0, 0 };
 	}
 
 	@Override
@@ -74,13 +88,17 @@ public class DetachSkillFromWorkspaceReactor extends AbstractReactor {
 		organizeKeys();
 
 		String workspaceId = this.keyValue.get(ReactorKeysEnum.WORKSPACE_ID.getKey());
-		String skillId     = this.keyValue.get(SKILL_ID);
+		String skillId     = nullIfBlank(this.keyValue.get(SKILL_ID));
+		String slug        = nullIfBlank(this.keyValue.get(SLUG));
 
 		if (workspaceId == null || workspaceId.isEmpty()) {
 			throw new IllegalArgumentException("workspaceId is required");
 		}
-		if (skillId == null || skillId.isEmpty()) {
-			throw new IllegalArgumentException("skillId is required");
+		if (skillId == null && slug == null) {
+			throw new IllegalArgumentException("either skillId or slug is required");
+		}
+		if (skillId != null && slug != null) {
+			throw new IllegalArgumentException("provide exactly one of skillId or slug (slug => platform skill)");
 		}
 
 		User user = this.insight.getUser();
@@ -89,14 +107,29 @@ public class DetachSkillFromWorkspaceReactor extends AbstractReactor {
 					"Workspace " + workspaceId + " does not exist or user does not have permission to edit it");
 		}
 
-		int deleted = ModelInferenceLogsUtils.deleteWorkspaceResource(workspaceId, skillId,
-				AbstractWorkspaceReactor.SKILL_RESOURCE_TYPE);
-
 		Map<String, Object> response = new HashMap<>();
 		response.put("workspace_id", workspaceId);
+
+		// A slug (and no id) means a disk-backed platform skill.
+		if (slug != null) {
+			try {
+				ModelInferenceLogsUtils.removePlatformSkillFromWorkspaceConfigJson(workspaceId, slug);
+			} catch (Exception e) {
+				classLogger.error(Constants.STACKTRACE, e);
+				throw new IllegalArgumentException(
+						"Failed to detach platform skill from workspace: " + e.getMessage(), e);
+			}
+			response.put("slug", slug);
+			response.put("type", PlatformSkills.PLATFORM_SKILL_TYPE);
+			response.put("removed", true);
+			return new NounMetadata(response, PixelDataType.MAP, PixelOperationType.OPERATION);
+		}
+
+		// Registry skill path.
+		int deleted = ModelInferenceLogsUtils.deleteWorkspaceResource(workspaceId, skillId,
+				AbstractWorkspaceReactor.SKILL_RESOURCE_TYPE);
 		response.put("skill_id", skillId);
 		response.put("removed", deleted > 0);
-
 
 		try {
 			ModelInferenceLogsUtils.removeSkillFromWorkspaceConfigJson(workspaceId, skillId);
@@ -109,9 +142,18 @@ public class DetachSkillFromWorkspaceReactor extends AbstractReactor {
 		return new NounMetadata(response, PixelDataType.MAP, PixelOperationType.OPERATION);
 	}
 
+	private static String nullIfBlank(String s) {
+		if (s == null) {
+			return null;
+		}
+		String t = s.trim();
+		return t.isEmpty() ? null : t;
+	}
+
 	@Override
 	public String getReactorDescription() {
-		return "Detaches a skill from a workspace by removing the WORKSPACE_RESOURCE__ row";
+		return "Detaches a skill from a workspace. Pass skillId for a registry skill (removes WORKSPACE_RESOURCE__ + "
+				+ "CONFIG_JSON.skills[]) or slug for a platform skill (removes from CONFIG_JSON.platform_skills[]).";
 	}
 
 	@Override
@@ -120,7 +162,10 @@ public class DetachSkillFromWorkspaceReactor extends AbstractReactor {
 			return "Workspace identifier";
 		}
 		if (SKILL_ID.equals(key)) {
-			return "Identifier of the skill to detach";
+			return "Identifier of the registry skill to detach (omit when detaching a platform skill by slug)";
+		}
+		if (SLUG.equals(key)) {
+			return "Folder name (slug) of the platform skill to detach (omit when detaching a registry skill by id)";
 		}
 		return super.getDescriptionForKey(key);
 	}

--- a/src/prerna/reactor/agent/skill/GetSkillsReactor.java
+++ b/src/prerna/reactor/agent/skill/GetSkillsReactor.java
@@ -57,8 +57,10 @@ import prerna.sablecc2.om.nounmeta.NounMetadata;
  *       Default {@code accessible}.
  *     <ul>
  *       <li>{@code mine}       - skills where {@code CREATED_BY = me}</li>
- *       <li>{@code platform}   - skills with {@code ORIGIN = 'PLATFORM'}</li>
- *       <li>{@code accessible} - every skill-project the user can view</li>
+ *       <li>{@code platform}   - built-in platform skills (disk-backed folders under
+ *           {@code <BASE_FOLDER>/skills/}; keyed by slug, no {@code skill_id})</li>
+ *       <li>{@code accessible} - every skill-project the user can view, plus all
+ *           platform skills (this is the default when no {@code filter} is given)</li>
  *     </ul>
  *   </li>
  * </ul>
@@ -101,7 +103,9 @@ public class GetSkillsReactor extends AbstractReactor {
 				rows = ModelInferenceLogsUtils.listSkills(null, userId);
 				break;
 			case FILTER_PLATFORM:
-				rows = ModelInferenceLogsUtils.listSkills(Skill.ORIGIN_PLATFORM, null);
+				// Platform skills are disk-backed folders under <BASE_FOLDER>/skills/,
+				// not SKILL__ rows - enumerate them from disk (no skill_id; keyed by slug).
+				rows = PlatformSkills.list();
 				break;
 			case FILTER_ACCESSIBLE:
 				Set<String> visibleProjectIds = getVisibleSkillProjectIds(user);
@@ -113,6 +117,9 @@ public class GetSkillsReactor extends AbstractReactor {
 						rows.add(row);
 					}
 				}
+				// Platform skills are global, read-only built-ins available to everyone,
+				// so they are always part of the accessible set (origin=PLATFORM, keyed by slug).
+				rows.addAll(PlatformSkills.list());
 				break;
 			default:
 				throw new IllegalArgumentException(
@@ -163,7 +170,7 @@ public class GetSkillsReactor extends AbstractReactor {
 	protected String getDescriptionForKey(String key) {
 		if (FILTER.equals(key)) {
 			return "Scope filter: 'mine' (skills I created), 'platform' (platform skills), "
-					+ "or 'accessible' (default - every skill-project I can view)";
+					+ "or 'accessible' (default - every skill-project I can view, plus all platform skills)";
 		}
 		return super.getDescriptionForKey(key);
 	}

--- a/src/prerna/reactor/agent/skill/PlatformSkills.java
+++ b/src/prerna/reactor/agent/skill/PlatformSkills.java
@@ -1,0 +1,174 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.agent.skill;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.util.DIHelper;
+import prerna.util.Utility;
+
+/**
+ * Disk-backed catalog of platform skills.
+ *
+ * <p>Platform skills ship with the product as plain folders under
+ * {@code <BASE_FOLDER>/skills/<slug>/}, each holding a {@code SKILL.md}. Unlike
+ * user skills they are NOT Projects: they have no ids, no permissions, are
+ * read-only, and cannot be edited or deleted by users. They are referenced by
+ * folder name (slug) from {@code WORKSPACE.CONFIG_JSON.platform_skills[]} and
+ * {@code room.options.platform_skills[]}, and materialized into a run's
+ * {@code .claude/skills/} by {@link SkillStager#stagePlatform}.
+ *
+ * <p>The directory is the {@code PLATFORM_SKILLS_DIR} property when set,
+ * otherwise {@code <BASE_FOLDER>/skills} - the same tree the legacy
+ * {@code PlatformSkillBootstrap} scanned.
+ */
+public final class PlatformSkills {
+
+	private static final Logger logger = LogManager.getLogger(PlatformSkills.class);
+
+	/** Optional RDF_Map / DIHelper override for the platform skills directory. */
+	public static final String PLATFORM_SKILLS_DIR_PROP = "PLATFORM_SKILLS_DIR";
+
+	/** Default subfolder under BASE_FOLDER that holds the platform skill folders. */
+	public static final String DEFAULT_SKILLS_SUBDIR = "skills";
+
+	/**
+	 * Discriminator written into the {@code type} field of a platform skill entry
+	 * in workspace payloads (e.g. {@code GetWorkspaceReactor}), so the UI can tell a
+	 * disk-backed platform skill apart from a project-backed {@code SKILL} resource.
+	 */
+	public static final String PLATFORM_SKILL_TYPE = "PLATFORM_SKILL";
+
+	private PlatformSkills() {}
+
+	/**
+	 * Root directory holding the platform skill folders: the
+	 * {@code PLATFORM_SKILLS_DIR} property when set (and non-blank), otherwise
+	 * {@code <BASE_FOLDER>/skills}. The returned path may not exist yet; callers
+	 * tolerate that.
+	 */
+	public static Path baseDir() {
+		String override = DIHelper.getInstance().getProperty(PLATFORM_SKILLS_DIR_PROP);
+		if (override != null && !override.trim().isEmpty()) {
+			return Paths.get(override.trim());
+		}
+		return Paths.get(Utility.getBaseFolder(), DEFAULT_SKILLS_SUBDIR);
+	}
+
+	/**
+	 * Resolves the folder for a single platform skill, or {@code null} when the
+	 * slug is blank, attempts path traversal, or has no {@code SKILL.md}.
+	 */
+	public static Path resolveDir(String slug) {
+		if (slug == null || slug.trim().isEmpty()) {
+			return null;
+		}
+		String clean = slug.trim();
+		// Platform slugs are simple folder names - reject anything that could escape baseDir.
+		if (clean.contains("/") || clean.contains("\\") || clean.contains("..")) {
+			logger.warn("PlatformSkills: rejecting unsafe slug '{}'", slug);
+			return null;
+		}
+		Path dir = baseDir().resolve(clean);
+		if (!Files.isDirectory(dir)) {
+			return null;
+		}
+		if (!Files.isRegularFile(dir.resolve(Skill.SKILL_FILE))) {
+			return null;
+		}
+		return dir;
+	}
+
+	/** True when {@code slug} resolves to a platform skill folder containing a {@code SKILL.md}. */
+	public static boolean exists(String slug) {
+		return resolveDir(slug) != null;
+	}
+
+	/**
+	 * Lists every platform skill: one entry per immediate subdirectory of
+	 * {@link #baseDir()} that contains a {@code SKILL.md}. Each entry carries
+	 * {@code slug}, {@code name}, {@code description} (parsed from the frontmatter,
+	 * falling back to the slug for name), and {@code origin = PLATFORM}. There is
+	 * no {@code skill_id} - platform skills are referenced by slug. Returns an
+	 * empty list when the directory is absent or unreadable.
+	 */
+	public static List<Map<String, Object>> list() {
+		List<Map<String, Object>> out = new ArrayList<>();
+		Path base = baseDir();
+		if (!Files.isDirectory(base)) {
+			logger.info("PlatformSkills: skills dir '{}' does not exist; returning empty catalog", base);
+			return out;
+		}
+		File[] children = base.toFile().listFiles(File::isDirectory);
+		if (children == null) {
+			return out;
+		}
+		Arrays.sort(children, (a, b) -> a.getName().compareToIgnoreCase(b.getName()));
+		for (File child : children) {
+			Path skillMd = child.toPath().resolve(Skill.SKILL_FILE);
+			if (!Files.isRegularFile(skillMd)) {
+				continue;
+			}
+			String slug = child.getName();
+			String name = slug;
+			String description = null;
+			try {
+				String content = new String(Files.readAllBytes(skillMd), StandardCharsets.UTF_8);
+				Skill.Frontmatter fm = Skill.parseFrontmatter(content);
+				if (fm.name != null && !fm.name.isEmpty()) {
+					name = fm.name;
+				}
+				if (fm.description != null && !fm.description.isEmpty()) {
+					description = fm.description;
+				}
+			} catch (IOException e) {
+				logger.warn("PlatformSkills: failed reading '{}': {}", skillMd, e.getMessage());
+			}
+			Map<String, Object> entry = new LinkedHashMap<>();
+			entry.put("slug", slug);
+			entry.put("name", name);
+			entry.put("description", description);
+			entry.put("origin", Skill.ORIGIN_PLATFORM);
+			out.add(entry);
+		}
+		return out;
+	}
+}

--- a/src/prerna/reactor/agent/skill/SkillStager.java
+++ b/src/prerna/reactor/agent/skill/SkillStager.java
@@ -165,21 +165,94 @@ public final class SkillStager {
 			return StageOutcome.FAILED;
 		}
 
+		return stageFromSource(skillsRoot, slug, sourceDir, skillId);
+	}
+
+	/**
+	 * Stage every platform skill named in {@code slugs} under
+	 * {@code <workingDir>/.claude/skills/}. Platform skills are disk-backed folders
+	 * (see {@link PlatformSkills}); each slug resolves to
+	 * {@code <BASE_FOLDER>/skills/<slug>/}. Skipped silently when {@code workingDir}
+	 * is blank or {@code slugs} is empty.
+	 *
+	 * <p>Call this BEFORE {@link #stage} so that a user's own registry skill of the
+	 * same slug, staged last, shadows the built-in one.
+	 *
+	 * @param workingDir agent's working directory
+	 * @param slugs      platform skill folder names to stage
+	 */
+	public static void stagePlatform(String workingDir, List<String> slugs) {
+		if (workingDir == null || workingDir.trim().isEmpty()) {
+			return;
+		}
+		if (slugs == null || slugs.isEmpty()) {
+			return;
+		}
+
+		Path skillsRoot = Paths.get(workingDir, CLAUDE_DIR, SKILLS_DIR);
+		try {
+			Files.createDirectories(skillsRoot);
+		} catch (IOException e) {
+			logger.warn("SkillStager: failed to create skills root '{}': {}", skillsRoot, e.getMessage());
+			return;
+		}
+
+		int staged = 0;
+		int skipped = 0;
+		int failed = 0;
+		for (String slug : slugs) {
+			if (slug == null || slug.trim().isEmpty()) {
+				failed++;
+				continue;
+			}
+			try {
+				StageOutcome outcome = stagePlatformOne(skillsRoot, slug.trim());
+				if (outcome == StageOutcome.STAGED) staged++;
+				else if (outcome == StageOutcome.CACHED) skipped++;
+				else failed++;
+			} catch (Exception e) {
+				logger.warn("SkillStager: failed to stage platform skill '{}': {}", slug, e.getMessage(), e);
+				failed++;
+			}
+		}
+		logger.info("SkillStager: [platform] workingDir='{}' total={} staged={} cached={} failed={}",
+				workingDir, slugs.size(), staged, skipped, failed);
+	}
+
+	private static StageOutcome stagePlatformOne(Path skillsRoot, String slug) throws Exception {
+		Path sourceDir = PlatformSkills.resolveDir(slug);
+		if (sourceDir == null) {
+			logger.warn("SkillStager: platform skill '{}' not found under '{}'; skipping", slug,
+					PlatformSkills.baseDir());
+			return StageOutcome.FAILED;
+		}
+		return stageFromSource(skillsRoot, slug, sourceDir, "platform:" + slug);
+	}
+
+	/**
+	 * Shared staging core: fingerprint the source, short-circuit on an unchanged
+	 * cache, otherwise wipe-and-copy and refresh the {@code .skill-meta} sidecar.
+	 * The {@code identity} is the cache key written into (and matched against) the
+	 * sidecar - the project id for registry skills, {@code "platform:<slug>"} for
+	 * platform skills - so the two source kinds never alias on a shared slug.
+	 */
+	private static StageOutcome stageFromSource(Path skillsRoot, String slug, Path sourceDir, String identity)
+			throws IOException {
 		long sourceFingerprint = computeFingerprint(sourceDir);
 		Path targetDir = skillsRoot.resolve(slug);
-		if (cacheHit(targetDir, slug, sourceFingerprint)) {
+		if (cacheHit(targetDir, identity, sourceFingerprint)) {
 			return StageOutcome.CACHED;
 		}
 
 		if (Files.exists(targetDir)) {
 			deleteTree(targetDir);
-			logger.info("SkillStager: re-staging skill '{}' (slug='{}') - wiped existing dir", skillId, slug);
+			logger.info("SkillStager: re-staging skill '{}' (slug='{}') - wiped existing dir", identity, slug);
 		}
 		Files.createDirectories(targetDir);
 
 		copyTree(sourceDir, targetDir);
-		writeMetaSidecar(targetDir, skillId, sourceFingerprint);
-		logger.info("SkillStager: staged skill '{}' from '{}' into '{}'", skillId, sourceDir, targetDir);
+		writeMetaSidecar(targetDir, identity, sourceFingerprint);
+		logger.info("SkillStager: staged skill '{}' from '{}' into '{}'", identity, sourceDir, targetDir);
 		return StageOutcome.STAGED;
 	}
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

# Agent Skills

Two reactors surface the skills available on the platform. They answer different questions:

- **`ListSkills`** reads the **physical skill files on disk** for a room, project, or the current insight. It does **not** read the database, so any skill files that were copied or added manually are picked up and returned.
- **`GetSkills`** does a **database read** of the skills **registered as projects** on the platform, and also includes the **platform skills** (disk-backed built-ins).

Once you have a skill's identifier, attach it to a workspace with **`AttachSkillToWorkspace`** / **`DetachSkillFromWorkspace`**, or set a workspace's whole skill set with **`EditWorkspace`** - see [Managing skills on a workspace](#managing-skills-on-a-workspace).

---

## ListSkills

Lists the physical skill files discovered on disk under the conventional skill-host directories (`.skills/`, `.agents/skills/`, `.claude/skills/`, and the `client/`, `java/`, `py/` variants), deduplicated by name. Because it reads the filesystem rather than the database, manually copied or added skill files are included.

The directory it scans is chosen by the inputs below; if neither `project` nor `roomId` is given it falls back to the current insight's working directory.

### Parameters

| Key | Type | Default | Description |
| --- | --- | --- | --- |
| `project` | string | - | Project id whose assets folder to scan. Requires view access to the project. |
| `roomId` | string | - | Room id whose folder to scan. Must be a room you own. |
| `includeContent` | boolean | `false` | Adds a `content` key to each skill holding the `SKILL.md` body (everything after the frontmatter). |
| `includeAll` | boolean | `false` | Crawls each skill folder and adds a `files` array of every other file. Forces `includeContent` to `true`. |

**Notes**

- `project` and `roomId` are mutually exclusive - passing both is an error.
- When neither `project` nor `roomId` is given, the current insight is scanned.
- Setting `includeAll=true` always turns on `includeContent`, even if `includeContent=false` is passed.
- In the `files` array, the skill's own top-level `SKILL.md` is omitted (it is already in `content`), and genuinely empty directories are not represented.

### Examples

```
# project
ListSkills(project="b7787bb4-f543-44fa-bc4e-a2e5edf25171");

# room
ListSkills(roomId="a9059a32-c6ed-4495-9f09-3303022a35be");

# current insight
ListSkills();

# include the content after the frontmatter for each skill
ListSkills(project="b7787bb4-f543-44fa-bc4e-a2e5edf25171", includeContent=true);

# include every file and folder inside each skill folder (implies includeContent)
ListSkills(roomId="a9059a32-c6ed-4495-9f09-3303022a35be", includeAll=true);
```

### Response

Every skill is a map with `name`, `path`, `directory`, and `description`. `path` and `directory` are relative to the scanned working directory.

With `includeContent=true`, each skill also carries a `content` key:

```json
[
  {
    "name": "database",
    "path": ".claude/skills/database/SKILL.md",
    "directory": ".claude/skills/database",
    "description": "Use when writing code in an app that queries a relational or graph database on the platform, running SELECTs, inserts, updates, deletes, or fetching schema/table structure...",
    "content": "# Database Engine\nQuery a database on the..."
  },
  {
    "name": "file-uploads",
    "path": ".claude/skills/file-uploads/skill.md",
    "directory": ".claude/skills/file-uploads",
    "description": "Implementing two-step image upload + LLM pixel call (SEMOSS pattern)",
    "content": "Overview\nWhen a user attaches a file..."
  }
]
```

With `includeAll=true`, each skill additionally carries a `files` array. Every file has its own `path` and `directory` (the same shape as the skill itself), so the folder structure can be recreated. Note that `content` is also present, because `includeAll` implies `includeContent`:

```json
[
  {
    "name": "pptx",
    "path": ".claude/skills/pptx/SKILL.md",
    "directory": ".claude/skills/pptx",
    "description": "Use this skill any time a .pptx file...",
    "content": "# PPTX\n...",
    "files": [
      {
        "path": ".claude/skills/pptx/editing.md",
        "directory": ".claude/skills/pptx",
        "content": "# Editing Presentations..."
      }
    ]
  }
]
```

---

## GetSkills

Returns the skills available to you: the **registry skills** (registered as Projects) you can view, **plus** all **platform skills** (disk-backed built-ins). Supports a `filter` to scope the results. This reactor does **not** return skill file contents - use `ListSkills` for that.

### Parameters

| Key | Type | Default | Description |
| --- | --- | --- | --- |
| `filter` | string | `accessible` | One of `mine` (registry skills you created), `platform` (platform skills only), or `accessible` (default - every registry skill you can view **plus** all platform skills). |

**Notes**

- A registry skill has a `skill_id` and an `origin` of `USER`, `IMPORTED`, or `GENERATED`. A platform skill has `origin = PLATFORM` and a `slug` but **no `skill_id`** - that is how you tell them apart in the merged `accessible` result.
- `mine` returns registry skills only; `platform` returns platform skills only.

### Examples

```
# defaults to accessible
GetSkills();

GetSkills(filter="mine");
GetSkills(filter="platform");
GetSkills(filter="accessible");
```

### Response

```json
[
  {
    "date_updated": "2026-06-15T14:30:10Z",
    "date_created": "2026-06-15T14:30:10Z",
    "origin": "USER",
    "name": "ppt-master",
    "description": "AI-driven multi-format SVG content generation system. Converts source documents (PDF/DOCX/URL/Markdown) into high-quality SVG pages and exports to PPTX through multi-role collaboration...",
    "skill_id": "019ecbb0-9d26-7302-bcad-c6691bfdfc00",
    "created_by": "rweiler",
    "slug": "ppt-master"
  },
  {
    "date_updated": "2026-06-11T17:57:49Z",
    "date_created": "2026-06-11T17:57:49Z",
    "origin": "USER",
    "name": "pptx",
    "description": "Use this skill any time a .pptx file is involved in any way - as input, output, or both...",
    "skill_id": "019eb7d5-4998-76b4-8620-5e9a516816db",
    "created_by": "rweiler",
    "slug": "pptx"
  },
  {
    "origin": "PLATFORM",
    "name": "database",
    "description": "Use when writing code that queries a relational or graph database on the platform...",
    "slug": "database"
  }
]
```

The last entry is a **platform skill**: note `origin` is `PLATFORM`, it carries a `slug`, and it has **no `skill_id`**. Registry skills always carry a `skill_id`.

---

## Managing skills on a workspace

There are two ways to change which skills a workspace uses:

- **Incremental** - `AttachSkillToWorkspace` / `DetachSkillFromWorkspace` add or remove **one** skill at a time.
- **Bulk** - `EditWorkspace` sets the **whole** configuration (name, MCPs, registry skills, and - when you pass `platformSkills` - platform skills) at once.

A skill is identified one of two ways, and the reactors branch on which you pass:

| | Registry skill | Platform skill |
| --- | --- | --- |
| Identifier | `skillId` (UUID) | `slug` (folder name) |
| Stored in `CONFIG_JSON` as | `skills[]` (`{"skill_id": "..."}`) | `platform_skills[]` (`["slug", ...]`) |
| `WORKSPACE_RESOURCE__` row | yes | no |

All of these reactors require **edit** permission on the workspace.

---

## AttachSkillToWorkspace

Attaches a single skill to a workspace and keeps `WORKSPACE.CONFIG_JSON` in sync. Pass **`skillId`** for a registry skill **or** **`slug`** for a platform skill - exactly one. Idempotent (re-attaching the same skill is a no-op).

### Parameters

| Key | Type | Default | Description |
| --- | --- | --- | --- |
| `workspaceId` | string | - | Target workspace. **Required.** |
| `skillId` | string | - | Registry skill to attach. Required **unless** `slug` is given. |
| `slug` | string | - | Platform skill to attach. Required **unless** `skillId` is given. |

### Examples

```
# registry skill (by id)
AttachSkillToWorkspace(workspaceId=["0146f913-2ae3-4f6b-8b04-0e7a53a36145"], skillId=["019e4687-e52c-718a-8460-27cb795896ac"]);

# platform skill (by slug)
AttachSkillToWorkspace(workspaceId=["0146f913-2ae3-4f6b-8b04-0e7a53a36145"], slug=["database"]);
```

**Notes**

- Registry path: writes a `WORKSPACE_RESOURCE__` row (`RESOURCE_TYPE='SKILL'`) and mirrors into `CONFIG_JSON.skills[]` as `{"skill_id": "..."}`.
- Platform path: adds the slug to `CONFIG_JSON.platform_skills[]` (a plain array of slug strings); no `WORKSPACE_RESOURCE__` row.
- Attaching a `slug` with no folder under `<BASE_FOLDER>/skills/` is an error. Passing both `skillId` and `slug`, or neither, is also an error.

### Response

```json
{ "workspace_id": "0146f913-...", "skill_id": "019e4687-...", "created": true }
```

For a platform skill:

```json
{ "workspace_id": "0146f913-...", "slug": "database", "type": "PLATFORM_SKILL" }
```

---

## DetachSkillFromWorkspace

Removes a single skill from a workspace. Same `skillId`-or-`slug` rule as `AttachSkillToWorkspace`. No-op when the skill is not attached. Does **not** delete the skill itself (use `DeleteSkill` for a registry skill; platform skills are read-only and are never deleted through reactors).

### Parameters

| Key | Type | Default | Description |
| --- | --- | --- | --- |
| `workspaceId` | string | - | Target workspace. **Required.** |
| `skillId` | string | - | Registry skill to detach. Required **unless** `slug` is given. |
| `slug` | string | - | Platform skill to detach. Required **unless** `skillId` is given. |

### Examples

```
# registry skill (by id)
DetachSkillFromWorkspace(workspaceId=["0146f913-2ae3-4f6b-8b04-0e7a53a36145"], skillId=["019e4687-e52c-718a-8460-27cb795896ac"]);

# platform skill (by slug)
DetachSkillFromWorkspace(workspaceId=["0146f913-2ae3-4f6b-8b04-0e7a53a36145"], slug=["database"]);
```

---

## EditWorkspace

Sets a workspace's configuration in **bulk** - name, description, system prompt, active state, the full MCP list, and the full **registry**-skill list. Use it to declare the complete state rather than nudge one item.

### Parameters

| Key | Type | Default | Description |
| --- | --- | --- | --- |
| `workspaceId` | string | - | Target workspace. **Required.** |
| `name` | string | - | Display name. **Required.** |
| `description` | string | - | Workspace description. |
| `systemPrompt` | string | - | Workspace system prompt (mirrored into `CONFIG_JSON.system_prompt`). |
| `isActive` | boolean | `true` | Active/inactive state (owner only to change). |
| `mcp` | list of maps | - | Full MCP set. Each entry is `{id, name, type}`; `type` is the catalog type (`PROJECT` for project/MCP tools, or an engine type such as `MODEL`). |
| `skills` | list of strings | - | Full **registry**-skill set, as a flat list of `skill_id`s. |
| `platformSkills` | list of strings | - | Platform skills, as a flat list of **slugs**. Opt-in: omit it to leave existing platform skills untouched; pass it (even empty) to full-replace `CONFIG_JSON.platform_skills[]`. |

### Examples

```
EditWorkspace(
  workspaceId=["0146f913-2ae3-4f6b-8b04-0e7a53a36145"],
  name=["Ryan's Agent47"],
  description=["Builds React/TypeScript apps"],
  systemPrompt=["You are Agent 47..."],
  isActive=[true],
  mcp=[
    {"id":"ce722163-2a8c-4667-b504-ce8732d77123","name":"NodeBuilderMCP","type":"PROJECT"},
    {"id":"394404bf-02e5-44b2-bc7c-e93d9b698f58","name":"Database Maker","type":"PROJECT"}
  ],
  skills=["019e4687-e52c-718a-8460-27cb795896ac"],
  platformSkills=["database","model"]
);
```

**Notes**

- `skills` and `mcp` are **full replaces** - the resulting set is exactly what you pass. `skills=[]` removes every registry skill.
- `platformSkills` is **opt-in**: omit the key and any existing `CONFIG_JSON.platform_skills[]` is left untouched (so callers that don't send it never wipe platform skills); pass it and it is a **full replace**, where `platformSkills=[]` clears them all. Each slug is validated against the on-disk catalog - an unknown slug fails the call.

### Which to use

| Need | Use |
| --- | --- |
| Add/remove one registry skill | `AttachSkillToWorkspace` / `DetachSkillFromWorkspace` with `skillId` |
| Add/remove one platform skill | `AttachSkillToWorkspace` / `DetachSkillFromWorkspace` with `slug` |
| Replace the entire registry-skill + MCP set | `EditWorkspace` |
| Add/remove one platform skill | `Attach`/`Detach` with `slug` |
| Replace the entire platform-skill set | `EditWorkspace` with `platformSkills=[...]` |

---

## Reading back what is attached: GetWorkspace

`GetWorkspace(workspaceId=["..."])` returns the workspace, including a `skills[]` array that contains **both** registry and platform skills, distinguished by `type` (`SKILL` vs `PLATFORM_SKILL`):

```json
"skills": [
  { "id": "019e4687-...", "type": "SKILL", "name": "csv-cleaner", "slug": "csv-cleaner", "description": "..." },
  { "id": "database", "type": "PLATFORM_SKILL", "name": "database", "slug": "database", "description": "..." }
]
```

For a platform skill the `id` is the slug (platform skills have no project id). The full `config_json` is returned alongside, so you can read `skills[]` and `platform_skills[]` directly if you prefer the raw form.


## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->