### PR TITLE
feat: role-based feature visibility system (App Profiles + Platform Profiles)

### DIFF
--- a/src/prerna/auth/utils/AbstractSecurityUtils.java
+++ b/src/prerna/auth/utils/AbstractSecurityUtils.java
@@ -2414,6 +2414,195 @@ public abstract class AbstractSecurityUtils {
 				}
 			}
 
+			// APP_PROFILE
+			colNames = new String[] { "PROFILE_ID", "APP_ID", "PROFILE_NAME", "DESCRIPTION", "IS_DEFAULT", "CREATED_BY", "CREATED_AT" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(2000)", BOOLEAN_DATATYPE_NAME, "VARCHAR(255)", TIMESTAMP_DATATYPE_NAME };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExists("APP_PROFILE", colNames, types);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "APP_PROFILE", database, schema)) {
+					String sql = queryUtil.createTable("APP_PROFILE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "APP_PROFILE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("APP_PROFILE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
+			// APP_FEATURE
+			colNames = new String[] { "FEATURE_ID", "APP_ID", "FEATURE_KEY", "DESCRIPTION", "CREATED_BY", "CREATED_AT" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(2000)", "VARCHAR(255)", TIMESTAMP_DATATYPE_NAME };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExists("APP_FEATURE", colNames, types);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "APP_FEATURE", database, schema)) {
+					String sql = queryUtil.createTable("APP_FEATURE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "APP_FEATURE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("APP_FEATURE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
+			// APP_PROFILE_FEATURE
+			colNames = new String[] { "APP_ID", "PROFILE_ID", "FEATURE_ID", "ENABLED" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(255)", BOOLEAN_DATATYPE_NAME };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExists("APP_PROFILE_FEATURE", colNames, types);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "APP_PROFILE_FEATURE", database, schema)) {
+					String sql = queryUtil.createTable("APP_PROFILE_FEATURE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "APP_PROFILE_FEATURE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("APP_PROFILE_FEATURE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
+			// APP_USER_PROFILE
+			colNames = new String[] { "APP_ID", "USER_ID", "PROFILE_ID", "ASSIGNED_BY", "ASSIGNED_AT" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(255)", TIMESTAMP_DATATYPE_NAME };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExists("APP_USER_PROFILE", colNames, types);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "APP_USER_PROFILE", database, schema)) {
+					String sql = queryUtil.createTable("APP_USER_PROFILE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "APP_USER_PROFILE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("APP_USER_PROFILE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
+			// PLATFORM_PROFILE
+			colNames = new String[] { "PROFILE_ID", "PROFILE_NAME", "DESCRIPTION", "CREATED_BY", "CREATED_AT" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(2000)", "VARCHAR(255)", TIMESTAMP_DATATYPE_NAME };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExists("PLATFORM_PROFILE", colNames, types);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "PLATFORM_PROFILE", database, schema)) {
+					String sql = queryUtil.createTable("PLATFORM_PROFILE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "PLATFORM_PROFILE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("PLATFORM_PROFILE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
+			// PLATFORM_PROFILE_FEATURE
+			colNames = new String[] { "PROFILE_ID", "FEATURE_KEY", "ENABLED" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(100)", BOOLEAN_DATATYPE_NAME };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExists("PLATFORM_PROFILE_FEATURE", colNames, types);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "PLATFORM_PROFILE_FEATURE", database, schema)) {
+					String sql = queryUtil.createTable("PLATFORM_PROFILE_FEATURE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "PLATFORM_PROFILE_FEATURE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("PLATFORM_PROFILE_FEATURE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
+			// PLATFORM_USER_PROFILE
+			colNames = new String[] { "USER_ID", "PROFILE_ID", "ASSIGNED_BY", "ASSIGNED_AT" };
+			types = new String[] { "VARCHAR(255)", "VARCHAR(255)", "VARCHAR(255)", TIMESTAMP_DATATYPE_NAME };
+			if (allowIfExistsTable) {
+				String sql = queryUtil.createTableIfNotExists("PLATFORM_USER_PROFILE", colNames, types);
+				classLogger.info("Running sql {}", sql);
+				securityDb.insertData(sql);
+			} else {
+				if (!queryUtil.tableExists(conn, "PLATFORM_USER_PROFILE", database, schema)) {
+					String sql = queryUtil.createTable("PLATFORM_USER_PROFILE", colNames, types);
+					classLogger.info("Running sql {}", sql);
+					securityDb.insertData(sql);
+				}
+			}
+			{
+				List<String> allCols = queryUtil.getTableColumns(conn, "PLATFORM_USER_PROFILE", database, schema);
+				for (int i = 0; i < colNames.length; i++) {
+					String col = colNames[i];
+					if (!allCols.contains(col) && !allCols.contains(col.toLowerCase())) {
+						classLogger.info("Column '{}' is not present in current list of columns: {}", col, allCols);
+						String addColumnSql = queryUtil.alterTableAddColumn("PLATFORM_USER_PROFILE", col, types[i]);
+						classLogger.info("Running sql {}", addColumnSql);
+						securityDb.insertData(addColumnSql);
+					}
+				}
+			}
+
 			if (!conn.getAutoCommit()) {
 				conn.commit();
 			}

--- a/src/prerna/auth/utils/AppProfileUtils.java
+++ b/src/prerna/auth/utils/AppProfileUtils.java
@@ -1,0 +1,896 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.auth.utils;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.User;
+import prerna.engine.api.IRDBMSEngine;
+import prerna.engine.api.IRawSelectWrapper;
+import prerna.query.querystruct.SelectQueryStruct;
+import prerna.query.querystruct.filters.SimpleQueryFilter;
+import prerna.query.querystruct.selectors.QueryColumnSelector;
+import prerna.query.querystruct.selectors.QueryFunctionHelper;
+import prerna.query.querystruct.selectors.QueryFunctionSelector;
+import prerna.rdf.engine.wrappers.WrapperManager;
+import prerna.util.ConnectionUtils;
+import prerna.util.Constants;
+import prerna.util.SystemEngineRegistry;
+
+public class AppProfileUtils extends AbstractSecurityUtils {
+
+	private static final Logger classLogger = LogManager.getLogger(AppProfileUtils.class);
+
+	private static final String FEATURE_KEY_PATTERN = "^[a-zA-Z0-9\\-]+$";
+
+	private AppProfileUtils() {
+	}
+
+	// -----------------------------------------------------------------------
+	// Permission checks
+	// -----------------------------------------------------------------------
+
+	public static boolean canManageProfiles(User user, String appId) {
+		if (SecurityAdminUtils.userIsAdmin(user)) {
+			return true;
+		}
+		verifyAppExists(appId);
+		return SecurityProjectUtils.userIsOwner(user, appId)
+				|| SecurityProjectUtils.userCanEditProject(user, appId);
+	}
+
+	public static boolean canEvaluateFeatures(User user, String appId) {
+		return SecurityProjectUtils.userCanViewProject(user, appId);
+	}
+
+	private static void verifyAppExists(String appId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("PROJECTPERMISSION__PROJECTID"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"PROJECTPERMISSION__PROJECTID", "==", appId));
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			if (!wrapper.hasNext()) {
+				throw new IllegalArgumentException("App not found: " + appId);
+			}
+		} catch (IllegalArgumentException e) {
+			throw e;
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Error verifying app existence: " + appId);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Profile CRUD
+	// -----------------------------------------------------------------------
+
+	public static Map<String, Object> createProfile(String appId, String name,
+			String description, boolean isDefault, User user) {
+		if (name == null || name.trim().isEmpty()) {
+			throw new IllegalArgumentException("Profile name is required.");
+		}
+		if (name.trim().length() > 100) {
+			throw new IllegalArgumentException("Profile name must be 100 characters or fewer.");
+		}
+		name = name.trim();
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+
+		if (isDefault) {
+			clearDefaultProfile(securityDb, appId);
+		}
+
+		String profileId = UUID.randomUUID().toString();
+		String actorId = getUserId(user);
+		Timestamp now = nowUtc();
+
+		String query = "INSERT INTO APP_PROFILE (PROFILE_ID, APP_ID, PROFILE_NAME, DESCRIPTION, IS_DEFAULT, CREATED_BY, CREATED_AT) VALUES (?, ?, ?, ?, ?, ?, ?)";
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(query);
+			int i = 1;
+			ps.setString(i++, profileId);
+			ps.setString(i++, appId);
+			ps.setString(i++, name);
+			ps.setString(i++, description != null ? description : "");
+			ps.setBoolean(i++, isDefault);
+			ps.setString(i++, actorId);
+			ps.setTimestamp(i++, now);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to create profile: " + e.getMessage());
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+
+		Map<String, Object> result = new HashMap<>();
+		result.put("profileId", profileId);
+		result.put("profileName", name);
+		result.put("description", description != null ? description : "");
+		result.put("isDefault", isDefault);
+		return result;
+	}
+
+	public static void updateProfile(String appId, String profileId, String name,
+			String description, Boolean isDefault, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+
+		if (isDefault != null && isDefault) {
+			clearDefaultProfile(securityDb, appId);
+		}
+
+		StringBuilder sb = new StringBuilder("UPDATE APP_PROFILE SET");
+		List<Object> params = new ArrayList<>();
+
+		if (name != null && !name.trim().isEmpty()) {
+			sb.append(" PROFILE_NAME=?,");
+			params.add(name.trim());
+		}
+		if (description != null) {
+			sb.append(" DESCRIPTION=?,");
+			params.add(description);
+		}
+		if (isDefault != null) {
+			sb.append(" IS_DEFAULT=?,");
+			params.add(isDefault);
+		}
+
+		if (params.isEmpty()) {
+			return;
+		}
+
+		String sql = sb.substring(0, sb.length() - 1)
+				+ " WHERE PROFILE_ID=? AND APP_ID=?";
+		params.add(profileId);
+		params.add(appId);
+
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			for (int i = 0; i < params.size(); i++) {
+				Object val = params.get(i);
+				if (val instanceof String) {
+					ps.setString(i + 1, (String) val);
+				} else if (val instanceof Boolean) {
+					ps.setBoolean(i + 1, (Boolean) val);
+				}
+			}
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to update profile: " + e.getMessage());
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static void deleteProfile(String appId, String profileId, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+
+		// Count assigned users
+		SelectQueryStruct countQs = new SelectQueryStruct();
+		QueryFunctionSelector countSel = new QueryFunctionSelector();
+		countSel.setFunction(QueryFunctionHelper.COUNT);
+		countSel.addInnerSelector(new QueryColumnSelector("APP_USER_PROFILE__USER_ID"));
+		countSel.setAlias("user_count");
+		countQs.addSelector(countSel);
+		countQs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_USER_PROFILE__APP_ID", "==", appId));
+		countQs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_USER_PROFILE__PROFILE_ID", "==", profileId));
+
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, countQs)) {
+			if (wrapper.hasNext()) {
+				Object[] row = wrapper.next().getValues();
+				long count = row[0] != null ? ((Number) row[0]).longValue() : 0;
+				if (count > 0) {
+					throw new IllegalArgumentException(
+							"Cannot delete: " + count + " user(s) are assigned to this profile. Reassign them first.");
+				}
+			}
+		} catch (IllegalArgumentException e) {
+			throw e;
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Error checking profile assignment count.");
+		}
+
+		String[] deletes = {
+			"DELETE FROM APP_PROFILE WHERE PROFILE_ID=? AND APP_ID=?",
+			"DELETE FROM APP_PROFILE_FEATURE WHERE PROFILE_ID=? AND APP_ID=?"
+		};
+		for (String deleteQuery : deletes) {
+			PreparedStatement ps = null;
+			try {
+				ps = securityDb.getPreparedStatement(deleteQuery);
+				ps.setString(1, profileId);
+				ps.setString(2, appId);
+				ps.execute();
+				if (!ps.getConnection().getAutoCommit()) {
+					ps.getConnection().commit();
+				}
+			} catch (SQLException e) {
+				classLogger.error(Constants.STACKTRACE, e);
+				throw new IllegalArgumentException("Failed to delete profile: " + e.getMessage());
+			} finally {
+				ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+			}
+		}
+	}
+
+	public static List<Map<String, Object>> getProfiles(String appId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		List<Map<String, Object>> profiles = new ArrayList<>();
+
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__PROFILE_ID"));
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__PROFILE_NAME"));
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__DESCRIPTION"));
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__IS_DEFAULT"));
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__CREATED_BY"));
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__CREATED_AT"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_PROFILE__APP_ID", "==", appId));
+		qs.addOrderBy("APP_PROFILE__PROFILE_NAME", "ASC");
+
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			while (wrapper.hasNext()) {
+				Object[] row = wrapper.next().getValues();
+				String profileId = (String) row[0];
+				Map<String, Object> profile = new HashMap<>();
+				profile.put("profileId", profileId);
+				profile.put("profileName", row[1]);
+				profile.put("description", row[2]);
+				profile.put("isDefault", row[3]);
+				profile.put("createdBy", row[4]);
+				profile.put("createdAt", row[5] != null ? row[5].toString() : null);
+				profile.put("userCount", getProfileUserCount(securityDb, appId, profileId));
+				profiles.add(profile);
+			}
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to retrieve profiles: " + e.getMessage());
+		}
+		return profiles;
+	}
+
+	// -----------------------------------------------------------------------
+	// Feature CRUD
+	// -----------------------------------------------------------------------
+
+	public static Map<String, Object> createFeature(String appId, String featureKey,
+			String description, User user) {
+		validateFeatureKey(featureKey);
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		String featureId = UUID.randomUUID().toString();
+		String actorId = getUserId(user);
+		Timestamp now = nowUtc();
+
+		String query = "INSERT INTO APP_FEATURE (FEATURE_ID, APP_ID, FEATURE_KEY, DESCRIPTION, CREATED_BY, CREATED_AT) VALUES (?, ?, ?, ?, ?, ?)";
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(query);
+			int i = 1;
+			ps.setString(i++, featureId);
+			ps.setString(i++, appId);
+			ps.setString(i++, featureKey);
+			ps.setString(i++, description != null ? description : "");
+			ps.setString(i++, actorId);
+			ps.setTimestamp(i++, now);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to create feature: " + e.getMessage());
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+
+		Map<String, Object> result = new HashMap<>();
+		result.put("featureId", featureId);
+		result.put("featureKey", featureKey);
+		result.put("description", description != null ? description : "");
+		return result;
+	}
+
+	public static void updateFeature(String appId, String featureId, String featureKey,
+			String description, User user) {
+		if (featureKey != null) {
+			validateFeatureKey(featureKey);
+		}
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		StringBuilder sb = new StringBuilder("UPDATE APP_FEATURE SET");
+		List<Object> params = new ArrayList<>();
+
+		if (featureKey != null) {
+			sb.append(" FEATURE_KEY=?,");
+			params.add(featureKey);
+		}
+		if (description != null) {
+			sb.append(" DESCRIPTION=?,");
+			params.add(description);
+		}
+		if (params.isEmpty()) {
+			return;
+		}
+		String sql = sb.substring(0, sb.length() - 1)
+				+ " WHERE FEATURE_ID=? AND APP_ID=?";
+		params.add(featureId);
+		params.add(appId);
+
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			for (int i = 0; i < params.size(); i++) {
+				ps.setString(i + 1, (String) params.get(i));
+			}
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to update feature: " + e.getMessage());
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static void deleteFeature(String appId, String featureId, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		String[] deletes = {
+			"DELETE FROM APP_FEATURE WHERE FEATURE_ID=? AND APP_ID=?",
+			"DELETE FROM APP_PROFILE_FEATURE WHERE FEATURE_ID=? AND APP_ID=?"
+		};
+		for (String deleteQuery : deletes) {
+			PreparedStatement ps = null;
+			try {
+				ps = securityDb.getPreparedStatement(deleteQuery);
+				ps.setString(1, featureId);
+				ps.setString(2, appId);
+				ps.execute();
+				if (!ps.getConnection().getAutoCommit()) {
+					ps.getConnection().commit();
+				}
+			} catch (SQLException e) {
+				classLogger.error(Constants.STACKTRACE, e);
+				throw new IllegalArgumentException("Failed to delete feature: " + e.getMessage());
+			} finally {
+				ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+			}
+		}
+	}
+
+	public static List<Map<String, Object>> getFeatures(String appId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		List<Map<String, Object>> features = new ArrayList<>();
+
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("APP_FEATURE__FEATURE_ID"));
+		qs.addSelector(new QueryColumnSelector("APP_FEATURE__FEATURE_KEY"));
+		qs.addSelector(new QueryColumnSelector("APP_FEATURE__DESCRIPTION"));
+		qs.addSelector(new QueryColumnSelector("APP_FEATURE__CREATED_BY"));
+		qs.addSelector(new QueryColumnSelector("APP_FEATURE__CREATED_AT"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_FEATURE__APP_ID", "==", appId));
+		qs.addOrderBy("APP_FEATURE__FEATURE_KEY", "ASC");
+
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			while (wrapper.hasNext()) {
+				Object[] row = wrapper.next().getValues();
+				Map<String, Object> feature = new HashMap<>();
+				feature.put("featureId", row[0]);
+				feature.put("featureKey", row[1]);
+				feature.put("description", row[2]);
+				feature.put("createdBy", row[3]);
+				feature.put("createdAt", row[4] != null ? row[4].toString() : null);
+				features.add(feature);
+			}
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to retrieve features: " + e.getMessage());
+		}
+		return features;
+	}
+
+	// -----------------------------------------------------------------------
+	// Profile-Feature Assignment
+	// -----------------------------------------------------------------------
+
+	public static void setProfileFeature(String appId, String profileId,
+			String featureId, boolean enabled, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+
+		PreparedStatement del = null;
+		try {
+			del = securityDb.getPreparedStatement(
+					"DELETE FROM APP_PROFILE_FEATURE WHERE APP_ID=? AND PROFILE_ID=? AND FEATURE_ID=?");
+			del.setString(1, appId);
+			del.setString(2, profileId);
+			del.setString(3, featureId);
+			del.execute();
+			if (!del.getConnection().getAutoCommit()) {
+				del.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, del);
+		}
+
+		PreparedStatement ins = null;
+		try {
+			ins = securityDb.getPreparedStatement(
+					"INSERT INTO APP_PROFILE_FEATURE (APP_ID, PROFILE_ID, FEATURE_ID, ENABLED) VALUES (?, ?, ?, ?)");
+			ins.setString(1, appId);
+			ins.setString(2, profileId);
+			ins.setString(3, featureId);
+			ins.setBoolean(4, enabled);
+			ins.execute();
+			if (!ins.getConnection().getAutoCommit()) {
+				ins.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to set profile feature: " + e.getMessage());
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ins);
+		}
+	}
+
+	public static List<Map<String, Object>> getProfileFeatures(String appId, String profileId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		List<Map<String, Object>> result = new ArrayList<>();
+
+		// Get all features for the app with their enabled state for this profile
+		String sql = "SELECT f.FEATURE_ID, f.FEATURE_KEY, f.DESCRIPTION, pf.ENABLED "
+				+ "FROM APP_FEATURE f "
+				+ "LEFT JOIN APP_PROFILE_FEATURE pf "
+				+ "ON f.FEATURE_ID = pf.FEATURE_ID AND pf.APP_ID=? AND pf.PROFILE_ID=? "
+				+ "WHERE f.APP_ID=? "
+				+ "ORDER BY f.FEATURE_KEY";
+
+		PreparedStatement ps = null;
+		java.sql.ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, appId);
+			ps.setString(2, profileId);
+			ps.setString(3, appId);
+			rs = ps.executeQuery();
+			while (rs.next()) {
+				Map<String, Object> row = new HashMap<>();
+				row.put("featureId", rs.getString(1));
+				row.put("featureKey", rs.getString(2));
+				row.put("description", rs.getString(3));
+				Boolean enabled = rs.getObject(4) != null ? rs.getBoolean(4) : false;
+				row.put("enabled", enabled);
+				result.add(row);
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to retrieve profile features: " + e.getMessage());
+		} finally {
+			if (rs != null) { try { rs.close(); } catch (Exception ignore) {} }
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		return result;
+	}
+
+	// -----------------------------------------------------------------------
+	// User-Profile Assignment
+	// -----------------------------------------------------------------------
+
+	public static void assignUserProfile(String appId, String userId,
+			String profileId, User actor) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		String actorId = getUserId(actor);
+		Timestamp now = nowUtc();
+
+		PreparedStatement del = null;
+		try {
+			del = securityDb.getPreparedStatement(
+					"DELETE FROM APP_USER_PROFILE WHERE APP_ID=? AND USER_ID=?");
+			del.setString(1, appId);
+			del.setString(2, userId);
+			del.execute();
+			if (!del.getConnection().getAutoCommit()) {
+				del.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, del);
+		}
+
+		PreparedStatement ins = null;
+		try {
+			ins = securityDb.getPreparedStatement(
+					"INSERT INTO APP_USER_PROFILE (APP_ID, USER_ID, PROFILE_ID, ASSIGNED_BY, ASSIGNED_AT) VALUES (?, ?, ?, ?, ?)");
+			ins.setString(1, appId);
+			ins.setString(2, userId);
+			ins.setString(3, profileId);
+			ins.setString(4, actorId);
+			ins.setTimestamp(5, now);
+			ins.execute();
+			if (!ins.getConnection().getAutoCommit()) {
+				ins.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to assign user profile: " + e.getMessage());
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ins);
+		}
+	}
+
+	public static void removeUserProfile(String appId, String userId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"DELETE FROM APP_USER_PROFILE WHERE APP_ID=? AND USER_ID=?");
+			ps.setString(1, appId);
+			ps.setString(2, userId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static void removeAllUserProfilesForApp(String appId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"DELETE FROM APP_USER_PROFILE WHERE APP_ID=?");
+			ps.setString(1, appId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static void removeUserProfiles(String appId, List<String> userIds) {
+		if (userIds == null || userIds.isEmpty()) {
+			return;
+		}
+		for (String userId : userIds) {
+			removeUserProfile(appId, userId);
+		}
+	}
+
+	public static Map<String, Object> getUserProfile(String appId, String userId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+
+		// Explicit assignment
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("APP_USER_PROFILE__PROFILE_ID"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_USER_PROFILE__APP_ID", "==", appId));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_USER_PROFILE__USER_ID", "==", userId));
+
+		String profileId = null;
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			if (wrapper.hasNext()) {
+				profileId = (String) wrapper.next().getValues()[0];
+			}
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		}
+
+		boolean explicit = profileId != null;
+		if (profileId == null) {
+			// Fall back to default profile
+			profileId = getDefaultProfileId(securityDb, appId);
+		}
+		if (profileId == null) {
+			return null;
+		}
+
+		// Get profile name
+		SelectQueryStruct nameQs = new SelectQueryStruct();
+		nameQs.addSelector(new QueryColumnSelector("APP_PROFILE__PROFILE_NAME"));
+		nameQs.addSelector(new QueryColumnSelector("APP_PROFILE__IS_DEFAULT"));
+		nameQs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_PROFILE__PROFILE_ID", "==", profileId));
+		nameQs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_PROFILE__APP_ID", "==", appId));
+
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, nameQs)) {
+			if (wrapper.hasNext()) {
+				Object[] row = wrapper.next().getValues();
+				Map<String, Object> result = new HashMap<>();
+				result.put("profileId", profileId);
+				result.put("profileName", row[0]);
+				result.put("isDefaultProfile", row[1]);
+				result.put("isExplicitAssignment", explicit);
+				return result;
+			}
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		}
+		return null;
+	}
+
+	public static List<Map<String, Object>> getProfileUsers(String appId, String profileId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		List<Map<String, Object>> users = new ArrayList<>();
+
+		String sql = "SELECT up.USER_ID, u.NAME, u.EMAIL, up.ASSIGNED_BY, up.ASSIGNED_AT "
+				+ "FROM APP_USER_PROFILE up "
+				+ "INNER JOIN SMSS_USER u ON up.USER_ID = u.ID "
+				+ "INNER JOIN PROJECTPERMISSION pp ON up.USER_ID = pp.USERID AND up.APP_ID = pp.PROJECTID "
+				+ "WHERE up.APP_ID=? AND up.PROFILE_ID=?";
+
+		PreparedStatement ps = null;
+		java.sql.ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, appId);
+			ps.setString(2, profileId);
+			rs = ps.executeQuery();
+			while (rs.next()) {
+				Map<String, Object> row = new HashMap<>();
+				row.put("userId", rs.getString(1));
+				row.put("displayName", rs.getString(2));
+				row.put("email", rs.getString(3));
+				row.put("assignedBy", rs.getString(4));
+				row.put("assignedAt", rs.getTimestamp(5) != null ? rs.getTimestamp(5).toString() : null);
+				users.add(row);
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to retrieve profile users: " + e.getMessage());
+		} finally {
+			if (rs != null) { try { rs.close(); } catch (Exception ignore) {} }
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		return users;
+	}
+
+	// -----------------------------------------------------------------------
+	// Evaluation
+	// -----------------------------------------------------------------------
+
+	public static boolean checkFeature(String appId, String featureKey, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+
+		String featureId = resolveFeatureId(securityDb, appId, featureKey);
+		if (featureId == null) {
+			return false;
+		}
+
+		String userId = getUserId(user);
+		Map<String, Object> profile = getUserProfile(appId, userId);
+		if (profile == null) {
+			return false;
+		}
+		String profileId = (String) profile.get("profileId");
+
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE_FEATURE__ENABLED"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_PROFILE_FEATURE__APP_ID", "==", appId));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_PROFILE_FEATURE__PROFILE_ID", "==", profileId));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_PROFILE_FEATURE__FEATURE_ID", "==", featureId));
+
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			if (wrapper.hasNext()) {
+				Object val = wrapper.next().getValues()[0];
+				return val != null && (Boolean) val;
+			}
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		}
+		return false;
+	}
+
+	public static Map<String, Object> getUserFeatures(String appId, User user) {
+		Map<String, Object> result = new HashMap<>();
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+
+		String userId = getUserId(user);
+		Map<String, Object> profile = getUserProfile(appId, userId);
+		if (profile == null) {
+			return result;
+		}
+		String profileId = (String) profile.get("profileId");
+		String profileName = (String) profile.get("profileName");
+		boolean isDefaultProfile = Boolean.TRUE.equals(profile.get("isDefaultProfile"));
+
+		String sql = "SELECT f.FEATURE_KEY, pf.FEATURE_ID "
+				+ "FROM APP_PROFILE_FEATURE pf "
+				+ "INNER JOIN APP_FEATURE f ON pf.FEATURE_ID = f.FEATURE_ID AND f.APP_ID=pf.APP_ID "
+				+ "WHERE pf.APP_ID=? AND pf.PROFILE_ID=? AND pf.ENABLED=?";
+
+		PreparedStatement ps = null;
+		java.sql.ResultSet rs = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			ps.setString(1, appId);
+			ps.setString(2, profileId);
+			ps.setBoolean(3, true);
+			rs = ps.executeQuery();
+			while (rs.next()) {
+				String featureKey = rs.getString(1);
+				String featureId = rs.getString(2);
+				Map<String, Object> featureInfo = new HashMap<>();
+				featureInfo.put("featureId", featureId);
+				featureInfo.put("profileName", profileName);
+				featureInfo.put("isDefaultProfile", isDefaultProfile);
+				result.put(featureKey, featureInfo);
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to retrieve user features: " + e.getMessage());
+		} finally {
+			if (rs != null) { try { rs.close(); } catch (Exception ignore) {} }
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+		return result;
+	}
+
+	// -----------------------------------------------------------------------
+	// Internal helpers
+	// -----------------------------------------------------------------------
+
+	private static void clearDefaultProfile(IRDBMSEngine securityDb, String appId) {
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"UPDATE APP_PROFILE SET IS_DEFAULT=? WHERE APP_ID=?");
+			ps.setBoolean(1, false);
+			ps.setString(2, appId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	private static String getDefaultProfileId(IRDBMSEngine securityDb, String appId) {
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("APP_PROFILE__PROFILE_ID"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_PROFILE__APP_ID", "==", appId));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_PROFILE__IS_DEFAULT", "==", true));
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			if (wrapper.hasNext()) {
+				return (String) wrapper.next().getValues()[0];
+			}
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		}
+		return null;
+	}
+
+	private static String resolveFeatureId(IRDBMSEngine securityDb, String appId, String featureKey) {
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("APP_FEATURE__FEATURE_ID"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_FEATURE__APP_ID", "==", appId));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_FEATURE__FEATURE_KEY", "==", featureKey));
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			if (wrapper.hasNext()) {
+				return (String) wrapper.next().getValues()[0];
+			}
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		}
+		return null;
+	}
+
+	private static long getProfileUserCount(IRDBMSEngine securityDb, String appId, String profileId) {
+		SelectQueryStruct qs = new SelectQueryStruct();
+		QueryFunctionSelector countSel = new QueryFunctionSelector();
+		countSel.setFunction(QueryFunctionHelper.COUNT);
+		countSel.addInnerSelector(new QueryColumnSelector("APP_USER_PROFILE__USER_ID"));
+		countSel.setAlias("cnt");
+		qs.addSelector(countSel);
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_USER_PROFILE__APP_ID", "==", appId));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"APP_USER_PROFILE__PROFILE_ID", "==", profileId));
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			if (wrapper.hasNext()) {
+				Object val = wrapper.next().getValues()[0];
+				return val != null ? ((Number) val).longValue() : 0;
+			}
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		}
+		return 0;
+	}
+
+	private static void validateFeatureKey(String featureKey) {
+		if (featureKey == null || featureKey.isEmpty()) {
+			throw new IllegalArgumentException("Feature key is required.");
+		}
+		if (featureKey.length() > 100) {
+			throw new IllegalArgumentException("Feature key must be 100 characters or fewer.");
+		}
+		if (!featureKey.matches(FEATURE_KEY_PATTERN)) {
+			throw new IllegalArgumentException(
+					"Feature key may only contain letters, numbers, and hyphens.");
+		}
+	}
+
+	private static String getUserId(User user) {
+		if (user == null) {
+			throw new IllegalArgumentException("User is required.");
+		}
+		return user.getPrimaryLoginToken().getId();
+	}
+
+	private static Timestamp nowUtc() {
+		ZonedDateTime zdt = LocalDateTime.now().atZone(ZoneId.of("UTC"));
+		return new Timestamp(zdt.toInstant().toEpochMilli());
+	}
+}

--- a/src/prerna/auth/utils/PlatformProfileUtils.java
+++ b/src/prerna/auth/utils/PlatformProfileUtils.java
@@ -1,0 +1,450 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.auth.utils;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.User;
+import prerna.engine.api.IRDBMSEngine;
+import prerna.engine.api.IRawSelectWrapper;
+import prerna.query.querystruct.SelectQueryStruct;
+import prerna.query.querystruct.filters.SimpleQueryFilter;
+import prerna.query.querystruct.selectors.QueryColumnSelector;
+import prerna.query.querystruct.selectors.QueryFunctionHelper;
+import prerna.query.querystruct.selectors.QueryFunctionSelector;
+import prerna.rdf.engine.wrappers.WrapperManager;
+import prerna.util.ConnectionUtils;
+import prerna.util.Constants;
+import prerna.util.SystemEngineRegistry;
+
+public class PlatformProfileUtils extends AbstractSecurityUtils {
+
+	private static final Logger classLogger = LogManager.getLogger(PlatformProfileUtils.class);
+
+	public static final Set<String> PREDEFINED_FEATURE_KEYS = Collections.unmodifiableSet(
+			new HashSet<>(Arrays.asList(
+					"nav.app-catalog",
+					"nav.build",
+					"nav.skills",
+					"nav.settings",
+					"nav.engine")));
+
+	private PlatformProfileUtils() {
+	}
+
+	public static boolean canManage(User user) {
+		return SecurityAdminUtils.userIsAdmin(user);
+	}
+
+	// -----------------------------------------------------------------------
+	// Profile CRUD
+	// -----------------------------------------------------------------------
+
+	public static Map<String, Object> createProfile(String name, String description, User user) {
+		if (name == null || name.trim().isEmpty()) {
+			throw new IllegalArgumentException("Profile name is required.");
+		}
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		String profileId = UUID.randomUUID().toString();
+		String actorId = getUserId(user);
+		Timestamp now = nowUtc();
+
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"INSERT INTO PLATFORM_PROFILE (PROFILE_ID, PROFILE_NAME, DESCRIPTION, CREATED_BY, CREATED_AT) VALUES (?, ?, ?, ?, ?)");
+			ps.setString(1, profileId);
+			ps.setString(2, name.trim());
+			ps.setString(3, description != null ? description : "");
+			ps.setString(4, actorId);
+			ps.setTimestamp(5, now);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to create platform profile: " + e.getMessage());
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+
+		Map<String, Object> result = new HashMap<>();
+		result.put("profileId", profileId);
+		result.put("profileName", name.trim());
+		result.put("description", description != null ? description : "");
+		return result;
+	}
+
+	public static void updateProfile(String profileId, String name, String description, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		StringBuilder sb = new StringBuilder("UPDATE PLATFORM_PROFILE SET");
+		List<Object> params = new ArrayList<>();
+
+		if (name != null && !name.trim().isEmpty()) {
+			sb.append(" PROFILE_NAME=?,");
+			params.add(name.trim());
+		}
+		if (description != null) {
+			sb.append(" DESCRIPTION=?,");
+			params.add(description);
+		}
+		if (params.isEmpty()) {
+			return;
+		}
+		String sql = sb.substring(0, sb.length() - 1) + " WHERE PROFILE_ID=?";
+		params.add(profileId);
+
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(sql);
+			for (int i = 0; i < params.size(); i++) {
+				ps.setString(i + 1, (String) params.get(i));
+			}
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to update platform profile: " + e.getMessage());
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	public static void deleteProfile(String profileId, User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+
+		SelectQueryStruct countQs = new SelectQueryStruct();
+		QueryFunctionSelector countSel = new QueryFunctionSelector();
+		countSel.setFunction(QueryFunctionHelper.COUNT);
+		countSel.addInnerSelector(new QueryColumnSelector("PLATFORM_USER_PROFILE__USER_ID"));
+		countSel.setAlias("cnt");
+		countQs.addSelector(countSel);
+		countQs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"PLATFORM_USER_PROFILE__PROFILE_ID", "==", profileId));
+
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, countQs)) {
+			if (wrapper.hasNext()) {
+				Object val = wrapper.next().getValues()[0];
+				long count = val != null ? ((Number) val).longValue() : 0;
+				if (count > 0) {
+					throw new IllegalArgumentException(
+							"Cannot delete: " + count + " user(s) are assigned to this profile. Reassign them first.");
+				}
+			}
+		} catch (IllegalArgumentException e) {
+			throw e;
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		}
+
+		String[] deletes = {
+			"DELETE FROM PLATFORM_PROFILE WHERE PROFILE_ID=?",
+			"DELETE FROM PLATFORM_PROFILE_FEATURE WHERE PROFILE_ID=?"
+		};
+		for (String deleteQuery : deletes) {
+			PreparedStatement ps = null;
+			try {
+				ps = securityDb.getPreparedStatement(deleteQuery);
+				ps.setString(1, profileId);
+				ps.execute();
+				if (!ps.getConnection().getAutoCommit()) {
+					ps.getConnection().commit();
+				}
+			} catch (SQLException e) {
+				classLogger.error(Constants.STACKTRACE, e);
+				throw new IllegalArgumentException("Failed to delete platform profile: " + e.getMessage());
+			} finally {
+				ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+			}
+		}
+	}
+
+	public static List<Map<String, Object>> getProfiles(User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		List<Map<String, Object>> profiles = new ArrayList<>();
+
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("PLATFORM_PROFILE__PROFILE_ID"));
+		qs.addSelector(new QueryColumnSelector("PLATFORM_PROFILE__PROFILE_NAME"));
+		qs.addSelector(new QueryColumnSelector("PLATFORM_PROFILE__DESCRIPTION"));
+		qs.addSelector(new QueryColumnSelector("PLATFORM_PROFILE__CREATED_BY"));
+		qs.addSelector(new QueryColumnSelector("PLATFORM_PROFILE__CREATED_AT"));
+		qs.addOrderBy("PLATFORM_PROFILE__PROFILE_NAME", "ASC");
+
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			while (wrapper.hasNext()) {
+				Object[] row = wrapper.next().getValues();
+				String pid = (String) row[0];
+				Map<String, Object> profile = new HashMap<>();
+				profile.put("profileId", pid);
+				profile.put("profileName", row[1]);
+				profile.put("description", row[2]);
+				profile.put("createdBy", row[3]);
+				profile.put("createdAt", row[4] != null ? row[4].toString() : null);
+				profile.put("userCount", getPlatformProfileUserCount(securityDb, pid));
+				profiles.add(profile);
+			}
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to retrieve platform profiles: " + e.getMessage());
+		}
+		return profiles;
+	}
+
+	// -----------------------------------------------------------------------
+	// Platform Feature Toggles
+	// -----------------------------------------------------------------------
+
+	public static void setProfileFeature(String profileId, String featureKey,
+			boolean enabled, User user) {
+		if (!PREDEFINED_FEATURE_KEYS.contains(featureKey)) {
+			throw new IllegalArgumentException(
+					"Unknown platform feature key: " + featureKey
+					+ ". Valid keys: " + PREDEFINED_FEATURE_KEYS);
+		}
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+
+		PreparedStatement del = null;
+		try {
+			del = securityDb.getPreparedStatement(
+					"DELETE FROM PLATFORM_PROFILE_FEATURE WHERE PROFILE_ID=? AND FEATURE_KEY=?");
+			del.setString(1, profileId);
+			del.setString(2, featureKey);
+			del.execute();
+			if (!del.getConnection().getAutoCommit()) {
+				del.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, del);
+		}
+
+		PreparedStatement ins = null;
+		try {
+			ins = securityDb.getPreparedStatement(
+					"INSERT INTO PLATFORM_PROFILE_FEATURE (PROFILE_ID, FEATURE_KEY, ENABLED) VALUES (?, ?, ?)");
+			ins.setString(1, profileId);
+			ins.setString(2, featureKey);
+			ins.setBoolean(3, enabled);
+			ins.execute();
+			if (!ins.getConnection().getAutoCommit()) {
+				ins.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to set platform feature: " + e.getMessage());
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ins);
+		}
+	}
+
+	public static Map<String, Boolean> getProfileFeatures(String profileId) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		Map<String, Boolean> result = new HashMap<>();
+
+		// Default all predefined keys to false
+		for (String key : PREDEFINED_FEATURE_KEYS) {
+			result.put(key, false);
+		}
+
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("PLATFORM_PROFILE_FEATURE__FEATURE_KEY"));
+		qs.addSelector(new QueryColumnSelector("PLATFORM_PROFILE_FEATURE__ENABLED"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"PLATFORM_PROFILE_FEATURE__PROFILE_ID", "==", profileId));
+
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			while (wrapper.hasNext()) {
+				Object[] row = wrapper.next().getValues();
+				String key = (String) row[0];
+				Boolean enabled = row[1] != null ? (Boolean) row[1] : false;
+				if (PREDEFINED_FEATURE_KEYS.contains(key)) {
+					result.put(key, enabled);
+				}
+			}
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to retrieve platform profile features: " + e.getMessage());
+		}
+		return result;
+	}
+
+	// -----------------------------------------------------------------------
+	// User-Profile Assignment
+	// -----------------------------------------------------------------------
+
+	public static void assignUserProfile(String userId, String profileId, User actor) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		String actorId = getUserId(actor);
+		Timestamp now = nowUtc();
+
+		PreparedStatement del = null;
+		try {
+			del = securityDb.getPreparedStatement(
+					"DELETE FROM PLATFORM_USER_PROFILE WHERE USER_ID=?");
+			del.setString(1, userId);
+			del.execute();
+			if (!del.getConnection().getAutoCommit()) {
+				del.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, del);
+		}
+
+		PreparedStatement ins = null;
+		try {
+			ins = securityDb.getPreparedStatement(
+					"INSERT INTO PLATFORM_USER_PROFILE (USER_ID, PROFILE_ID, ASSIGNED_BY, ASSIGNED_AT) VALUES (?, ?, ?, ?)");
+			ins.setString(1, userId);
+			ins.setString(2, profileId);
+			ins.setString(3, actorId);
+			ins.setTimestamp(4, now);
+			ins.execute();
+			if (!ins.getConnection().getAutoCommit()) {
+				ins.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to assign platform profile: " + e.getMessage());
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ins);
+		}
+	}
+
+	public static void removeUserProfile(String userId, User actor) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		PreparedStatement ps = null;
+		try {
+			ps = securityDb.getPreparedStatement(
+					"DELETE FROM PLATFORM_USER_PROFILE WHERE USER_ID=?");
+			ps.setString(1, userId);
+			ps.execute();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+		} catch (SQLException e) {
+			classLogger.error(Constants.STACKTRACE, e);
+			throw new IllegalArgumentException("Failed to remove platform profile: " + e.getMessage());
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Evaluation
+	// -----------------------------------------------------------------------
+
+	public static Map<String, Boolean> getUserFeatures(User user) {
+		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
+		String userId = getUserId(user);
+
+		SelectQueryStruct qs = new SelectQueryStruct();
+		qs.addSelector(new QueryColumnSelector("PLATFORM_USER_PROFILE__PROFILE_ID"));
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"PLATFORM_USER_PROFILE__USER_ID", "==", userId));
+
+		String profileId = null;
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			if (wrapper.hasNext()) {
+				profileId = (String) wrapper.next().getValues()[0];
+			}
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		}
+
+		if (profileId == null) {
+			// No profile assigned — fail open (all nav visible)
+			Map<String, Boolean> allOpen = new HashMap<>();
+			for (String key : PREDEFINED_FEATURE_KEYS) {
+				allOpen.put(key, true);
+			}
+			return allOpen;
+		}
+
+		return getProfileFeatures(profileId);
+	}
+
+	// -----------------------------------------------------------------------
+	// Internal helpers
+	// -----------------------------------------------------------------------
+
+	private static long getPlatformProfileUserCount(IRDBMSEngine securityDb, String profileId) {
+		SelectQueryStruct qs = new SelectQueryStruct();
+		QueryFunctionSelector countSel = new QueryFunctionSelector();
+		countSel.setFunction(QueryFunctionHelper.COUNT);
+		countSel.addInnerSelector(new QueryColumnSelector("PLATFORM_USER_PROFILE__USER_ID"));
+		countSel.setAlias("cnt");
+		qs.addSelector(countSel);
+		qs.addExplicitFilter(SimpleQueryFilter.makeColToValFilter(
+				"PLATFORM_USER_PROFILE__PROFILE_ID", "==", profileId));
+		try (IRawSelectWrapper wrapper = WrapperManager.getInstance().getRawWrapper(securityDb, qs)) {
+			if (wrapper.hasNext()) {
+				Object val = wrapper.next().getValues()[0];
+				return val != null ? ((Number) val).longValue() : 0;
+			}
+		} catch (Exception e) {
+			classLogger.error(Constants.STACKTRACE, e);
+		}
+		return 0;
+	}
+
+	private static String getUserId(User user) {
+		if (user == null) {
+			throw new IllegalArgumentException("User is required.");
+		}
+		return user.getPrimaryLoginToken().getId();
+	}
+
+	private static Timestamp nowUtc() {
+		ZonedDateTime zdt = LocalDateTime.now().atZone(ZoneId.of("UTC"));
+		return new Timestamp(zdt.toInstant().toEpochMilli());
+	}
+}

--- a/src/prerna/auth/utils/SecurityProjectUtils.java
+++ b/src/prerna/auth/utils/SecurityProjectUtils.java
@@ -1692,6 +1692,7 @@ public class SecurityProjectUtils extends AbstractSecurityUtils {
 				ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
 			}
 		}
+		AppProfileUtils.removeAllUserProfilesForApp(projectId);
 	}
 
 	/**
@@ -1751,10 +1752,11 @@ public class SecurityProjectUtils extends AbstractSecurityUtils {
 				ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
 			}
 		}
+		AppProfileUtils.removeUserProfile(projectId, existingUserId);
 	}
 
 	/**
-	 * 
+	 *
 	 * @param userId
 	 * @param projectId
 	 * @return
@@ -1777,6 +1779,7 @@ public class SecurityProjectUtils extends AbstractSecurityUtils {
 		} finally {
 			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
 		}
+		AppProfileUtils.removeUserProfile(projectId, userId);
 	}
 
 	/**
@@ -3126,6 +3129,9 @@ public class SecurityProjectUtils extends AbstractSecurityUtils {
 			classLogger.error("Failed to copy project permissions to the target project", e);
 			throw e;
 		}
+
+		// cascade: remove all app user profile assignments for the target project
+		AppProfileUtils.removeAllUserProfilesForApp(targetProjectId);
 
 		// first delete the current project permissions
 		PreparedStatement ps = null;
@@ -4609,6 +4615,10 @@ public class SecurityProjectUtils extends AbstractSecurityUtils {
 		} finally {
 			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, deletePs);
 		}
+		// cascade: remove app profile assignments for all affected users
+		for (Map<String, String> req : requests) {
+			AppProfileUtils.removeUserProfile(projectId, req.get("userid"));
+		}
 		// insert new user permissions in bulk
 		String insertQ = "INSERT INTO PROJECTPERMISSION (USERID, PROJECTID, PERMISSION, VISIBILITY, PERMISSIONGRANTEDBY, PERMISSIONGRANTEDBYTYPE, DATEADDED, ENDDATE) VALUES(?,?,?,?,?,?,?,?)";
 		PreparedStatement insertPs = null;
@@ -4896,6 +4906,8 @@ public class SecurityProjectUtils extends AbstractSecurityUtils {
 		} finally {
 			ConnectionUtils.closeAllConnectionsIfPooling(securityDb, ps);
 		}
+		// cascade: remove app profile assignments for all removed users
+		AppProfileUtils.removeUserProfiles(projectId, existingUserIds);
 	}
 
 	/**

--- a/src/prerna/reactor/appprofile/AssignUserProfileReactor.java
+++ b/src/prerna/reactor/appprofile/AssignUserProfileReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class AssignUserProfileReactor extends AbstractReactor {
+
+    public AssignUserProfileReactor() {
+        this.keysToGet = new String[]{"app", "userId", "profileId"};
+        this.keyRequired = new int[]{1, 1, 1};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+        String userId = this.keyValue.get("userId");
+        String profileId = this.keyValue.get("profileId");
+        AppProfileUtils.assignUserProfile(appId, userId, profileId, user);
+        NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+        noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("User profile assigned."));
+        return noun;
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Assigns a profile to a user within a specific app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/CheckFeatureReactor.java
+++ b/src/prerna/reactor/appprofile/CheckFeatureReactor.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class CheckFeatureReactor extends AbstractReactor {
+
+    public CheckFeatureReactor() {
+        this.keysToGet = new String[]{"app", "featureKey"};
+        this.keyRequired = new int[]{1, 1};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        if (!AppProfileUtils.canEvaluateFeatures(user, appId)) {
+            throw new IllegalArgumentException("User does not have access to this app.");
+        }
+        String featureKey = this.keyValue.get("featureKey");
+        boolean result = AppProfileUtils.checkFeature(appId, featureKey, user);
+        return new NounMetadata(result, PixelDataType.BOOLEAN);
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Checks whether a specific feature is enabled for the current user in an app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/CreateAppFeatureReactor.java
+++ b/src/prerna/reactor/appprofile/CreateAppFeatureReactor.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import java.util.Map;
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class CreateAppFeatureReactor extends AbstractReactor {
+
+    public CreateAppFeatureReactor() {
+        this.keysToGet = new String[]{"app", "key", "description"};
+        this.keyRequired = new int[]{1, 1, 0};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        String key = this.keyValue.get("key");
+        String description = this.keyValue.get("description");
+
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+
+        Map<String, Object> result = AppProfileUtils.createFeature(appId, key, description, user);
+        NounMetadata noun = new NounMetadata(result, PixelDataType.MAP);
+        noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Feature created successfully."));
+        return noun;
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Creates a new feature for the specified app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/CreateAppProfileReactor.java
+++ b/src/prerna/reactor/appprofile/CreateAppProfileReactor.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import java.util.Map;
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class CreateAppProfileReactor extends AbstractReactor {
+
+    public CreateAppProfileReactor() {
+        this.keysToGet = new String[]{"app", "name", "description", "isDefault"};
+        this.keyRequired = new int[]{1, 1, 0, 0};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        String name = this.keyValue.get("name");
+        String description = this.keyValue.get("description");
+        String isDefaultStr = this.keyValue.get("isDefault");
+        boolean isDefault = isDefaultStr != null && Boolean.parseBoolean(isDefaultStr);
+
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+
+        Map<String, Object> result = AppProfileUtils.createProfile(appId, name, description, isDefault, user);
+        NounMetadata noun = new NounMetadata(result, PixelDataType.MAP);
+        noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Profile created successfully."));
+        return noun;
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Creates a new profile for the specified app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/DeleteAppFeatureReactor.java
+++ b/src/prerna/reactor/appprofile/DeleteAppFeatureReactor.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class DeleteAppFeatureReactor extends AbstractReactor {
+
+    public DeleteAppFeatureReactor() {
+        this.keysToGet = new String[]{"app", "featureId"};
+        this.keyRequired = new int[]{1, 1};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        String featureId = this.keyValue.get("featureId");
+
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+
+        AppProfileUtils.deleteFeature(appId, featureId, user);
+        NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+        noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Feature deleted successfully."));
+        return noun;
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Deletes a feature from the specified app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/DeleteAppProfileReactor.java
+++ b/src/prerna/reactor/appprofile/DeleteAppProfileReactor.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class DeleteAppProfileReactor extends AbstractReactor {
+
+    public DeleteAppProfileReactor() {
+        this.keysToGet = new String[]{"app", "profileId"};
+        this.keyRequired = new int[]{1, 1};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        String profileId = this.keyValue.get("profileId");
+
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+
+        AppProfileUtils.deleteProfile(appId, profileId, user);
+        NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+        noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Profile deleted successfully."));
+        return noun;
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Deletes a profile from the specified app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/GetAppFeaturesReactor.java
+++ b/src/prerna/reactor/appprofile/GetAppFeaturesReactor.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import java.util.List;
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetAppFeaturesReactor extends AbstractReactor {
+
+    public GetAppFeaturesReactor() {
+        this.keysToGet = new String[]{"app"};
+        this.keyRequired = new int[]{1};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+
+        List<?> result = AppProfileUtils.getFeatures(appId);
+        return new NounMetadata(result, PixelDataType.MAP);
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Retrieves all features for the specified app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/GetAppProfilesReactor.java
+++ b/src/prerna/reactor/appprofile/GetAppProfilesReactor.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import java.util.List;
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetAppProfilesReactor extends AbstractReactor {
+
+    public GetAppProfilesReactor() {
+        this.keysToGet = new String[]{"app"};
+        this.keyRequired = new int[]{1};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+
+        List<?> result = AppProfileUtils.getProfiles(appId);
+        return new NounMetadata(result, PixelDataType.MAP);
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Retrieves all profiles for the specified app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/GetProfileFeaturesReactor.java
+++ b/src/prerna/reactor/appprofile/GetProfileFeaturesReactor.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetProfileFeaturesReactor extends AbstractReactor {
+
+    public GetProfileFeaturesReactor() {
+        this.keysToGet = new String[]{"app", "profileId"};
+        this.keyRequired = new int[]{1, 1};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+        String profileId = this.keyValue.get("profileId");
+        java.util.List result = AppProfileUtils.getProfileFeatures(appId, profileId);
+        return new NounMetadata(result, PixelDataType.MAP);
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Returns the list of features and their enabled/disabled state for a given profile in an app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/GetProfileUsersReactor.java
+++ b/src/prerna/reactor/appprofile/GetProfileUsersReactor.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetProfileUsersReactor extends AbstractReactor {
+
+    public GetProfileUsersReactor() {
+        this.keysToGet = new String[]{"app", "profileId"};
+        this.keyRequired = new int[]{1, 1};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+        String profileId = this.keyValue.get("profileId");
+        java.util.List result = AppProfileUtils.getProfileUsers(appId, profileId);
+        return new NounMetadata(result, PixelDataType.MAP);
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Returns the list of users assigned to a specific profile within an app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/GetUserFeaturesReactor.java
+++ b/src/prerna/reactor/appprofile/GetUserFeaturesReactor.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetUserFeaturesReactor extends AbstractReactor {
+
+    public GetUserFeaturesReactor() {
+        this.keysToGet = new String[]{"app"};
+        this.keyRequired = new int[]{1};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        if (!AppProfileUtils.canEvaluateFeatures(user, appId)) {
+            throw new IllegalArgumentException("User does not have access to this app.");
+        }
+        java.util.Map result = AppProfileUtils.getUserFeatures(appId, user);
+        return new NounMetadata(result, PixelDataType.MAP);
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Returns the full map of feature keys to enabled/disabled state for the current user in an app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/GetUserProfileReactor.java
+++ b/src/prerna/reactor/appprofile/GetUserProfileReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetUserProfileReactor extends AbstractReactor {
+
+    public GetUserProfileReactor() {
+        this.keysToGet = new String[]{"app", "userId"};
+        this.keyRequired = new int[]{1, 1};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+        String userId = this.keyValue.get("userId");
+        java.util.Map result = AppProfileUtils.getUserProfile(appId, userId);
+        if (result == null) {
+            result = new java.util.HashMap();
+        }
+        return new NounMetadata(result, PixelDataType.MAP);
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Returns the profile assigned to a specific user within an app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/RemoveUserProfileReactor.java
+++ b/src/prerna/reactor/appprofile/RemoveUserProfileReactor.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class RemoveUserProfileReactor extends AbstractReactor {
+
+    public RemoveUserProfileReactor() {
+        this.keysToGet = new String[]{"app", "userId"};
+        this.keyRequired = new int[]{1, 1};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+        String userId = this.keyValue.get("userId");
+        AppProfileUtils.removeUserProfile(appId, userId);
+        NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+        noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("User profile removed."));
+        return noun;
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Removes the profile assignment for a user within a specific app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/SetProfileFeatureReactor.java
+++ b/src/prerna/reactor/appprofile/SetProfileFeatureReactor.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class SetProfileFeatureReactor extends AbstractReactor {
+
+    public SetProfileFeatureReactor() {
+        this.keysToGet = new String[]{"app", "profileId", "featureId", "enabled"};
+        this.keyRequired = new int[]{1, 1, 1, 1};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+        String profileId = this.keyValue.get("profileId");
+        String featureId = this.keyValue.get("featureId");
+        boolean enabled = Boolean.parseBoolean(this.keyValue.get("enabled"));
+        AppProfileUtils.setProfileFeature(appId, profileId, featureId, enabled, user);
+        NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+        noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Profile feature updated."));
+        return noun;
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Sets whether a specific feature is enabled or disabled for a given profile in an app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/UpdateAppFeatureReactor.java
+++ b/src/prerna/reactor/appprofile/UpdateAppFeatureReactor.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class UpdateAppFeatureReactor extends AbstractReactor {
+
+    public UpdateAppFeatureReactor() {
+        this.keysToGet = new String[]{"app", "featureId", "key", "description"};
+        this.keyRequired = new int[]{1, 1, 0, 0};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        String featureId = this.keyValue.get("featureId");
+        String key = this.keyValue.get("key");
+        String description = this.keyValue.get("description");
+
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+
+        AppProfileUtils.updateFeature(appId, featureId, key, description, user);
+        NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+        noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Feature updated successfully."));
+        return noun;
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Updates an existing feature for the specified app.";
+    }
+}

--- a/src/prerna/reactor/appprofile/UpdateAppProfileReactor.java
+++ b/src/prerna/reactor/appprofile/UpdateAppProfileReactor.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.appprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.AppProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class UpdateAppProfileReactor extends AbstractReactor {
+
+    public UpdateAppProfileReactor() {
+        this.keysToGet = new String[]{"app", "profileId", "name", "description", "isDefault"};
+        this.keyRequired = new int[]{1, 1, 0, 0, 0};
+    }
+
+    @Override
+    public NounMetadata execute() {
+        organizeKeys();
+        User user = this.insight.getUser();
+        String appId = this.keyValue.get("app");
+        String profileId = this.keyValue.get("profileId");
+        String name = this.keyValue.get("name");
+        String description = this.keyValue.get("description");
+        String isDefaultStr = this.keyValue.get("isDefault");
+        Boolean isDefault = isDefaultStr != null ? Boolean.parseBoolean(isDefaultStr) : null;
+
+        if (!AppProfileUtils.canManageProfiles(user, appId)) {
+            throw new IllegalArgumentException("User does not have permission to manage profiles for this app.");
+        }
+
+        AppProfileUtils.updateProfile(appId, profileId, name, description, isDefault, user);
+        NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+        noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Profile updated successfully."));
+        return noun;
+    }
+
+    @Override
+    public String getReactorDescription() {
+        return "Updates an existing profile for the specified app.";
+    }
+}

--- a/src/prerna/reactor/platformprofile/AssignUserPlatformProfileReactor.java
+++ b/src/prerna/reactor/platformprofile/AssignUserPlatformProfileReactor.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.auth.utils.SecurityAdminUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class AssignUserPlatformProfileReactor extends AbstractReactor {
+
+	public AssignUserPlatformProfileReactor() {
+		this.keysToGet = new String[]{"userId", "profileId"};
+		this.keyRequired = new int[]{1, 1};
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		SecurityAdminUtils adminUtils = SecurityAdminUtils.getInstance(user);
+		if (adminUtils == null) {
+			throw new IllegalArgumentException("User must be an admin to perform this function.");
+		}
+		String userId = this.keyValue.get("userId");
+		String profileId = this.keyValue.get("profileId");
+		PlatformProfileUtils.assignUserProfile(userId, profileId, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Platform profile assigned to user."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Assigns a platform profile to a user.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/CreatePlatformProfileReactor.java
+++ b/src/prerna/reactor/platformprofile/CreatePlatformProfileReactor.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.auth.utils.SecurityAdminUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class CreatePlatformProfileReactor extends AbstractReactor {
+
+	public CreatePlatformProfileReactor() {
+		this.keysToGet = new String[]{"name", "description"};
+		this.keyRequired = new int[]{1, 0};
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		SecurityAdminUtils adminUtils = SecurityAdminUtils.getInstance(user);
+		if (adminUtils == null) {
+			throw new IllegalArgumentException("User must be an admin to perform this function.");
+		}
+		String name = this.keyValue.get("name");
+		String desc = this.keyValue.get("description");
+		Map result = PlatformProfileUtils.createProfile(name, desc, user);
+		NounMetadata noun = new NounMetadata(result, PixelDataType.MAP);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Platform profile created."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Creates a new platform profile with the given name and optional description.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/DeletePlatformProfileReactor.java
+++ b/src/prerna/reactor/platformprofile/DeletePlatformProfileReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.auth.utils.SecurityAdminUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class DeletePlatformProfileReactor extends AbstractReactor {
+
+	public DeletePlatformProfileReactor() {
+		this.keysToGet = new String[]{"profileId"};
+		this.keyRequired = new int[]{1};
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		SecurityAdminUtils adminUtils = SecurityAdminUtils.getInstance(user);
+		if (adminUtils == null) {
+			throw new IllegalArgumentException("User must be an admin to perform this function.");
+		}
+		String profileId = this.keyValue.get("profileId");
+		PlatformProfileUtils.deleteProfile(profileId, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Platform profile deleted."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Deletes an existing platform profile by its ID.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/GetPlatformFeaturesReactor.java
+++ b/src/prerna/reactor/platformprofile/GetPlatformFeaturesReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.auth.utils.SecurityAdminUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetPlatformFeaturesReactor extends AbstractReactor {
+
+	public GetPlatformFeaturesReactor() {
+		this.keysToGet = new String[]{"profileId"};
+		this.keyRequired = new int[]{1};
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		SecurityAdminUtils adminUtils = SecurityAdminUtils.getInstance(user);
+		if (adminUtils == null) {
+			throw new IllegalArgumentException("User must be an admin to perform this function.");
+		}
+		String profileId = this.keyValue.get("profileId");
+		Map result = PlatformProfileUtils.getProfileFeatures(profileId);
+		return new NounMetadata(result, PixelDataType.MAP);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Returns all features and their enabled states for a given platform profile.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/GetPlatformProfilesReactor.java
+++ b/src/prerna/reactor/platformprofile/GetPlatformProfilesReactor.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import java.util.List;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.auth.utils.SecurityAdminUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetPlatformProfilesReactor extends AbstractReactor {
+
+	public GetPlatformProfilesReactor() {
+		this.keysToGet = new String[]{};
+		this.keyRequired = new int[]{};
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		SecurityAdminUtils adminUtils = SecurityAdminUtils.getInstance(user);
+		if (adminUtils == null) {
+			throw new IllegalArgumentException("User must be an admin to perform this function.");
+		}
+		List result = PlatformProfileUtils.getProfiles(user);
+		return new NounMetadata(result, PixelDataType.MAP);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Returns all platform profiles.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/GetUserPlatformFeaturesReactor.java
+++ b/src/prerna/reactor/platformprofile/GetUserPlatformFeaturesReactor.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import java.util.Map;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class GetUserPlatformFeaturesReactor extends AbstractReactor {
+
+	public GetUserPlatformFeaturesReactor() {
+		this.keysToGet = new String[]{};
+		this.keyRequired = new int[]{};
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		Map result = PlatformProfileUtils.getUserFeatures(user);
+		return new NounMetadata(result, PixelDataType.MAP);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Returns the platform feature flags applicable to the currently authenticated user.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/RemoveUserPlatformProfileReactor.java
+++ b/src/prerna/reactor/platformprofile/RemoveUserPlatformProfileReactor.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.auth.utils.SecurityAdminUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class RemoveUserPlatformProfileReactor extends AbstractReactor {
+
+	public RemoveUserPlatformProfileReactor() {
+		this.keysToGet = new String[]{"userId"};
+		this.keyRequired = new int[]{1};
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		SecurityAdminUtils adminUtils = SecurityAdminUtils.getInstance(user);
+		if (adminUtils == null) {
+			throw new IllegalArgumentException("User must be an admin to perform this function.");
+		}
+		String userId = this.keyValue.get("userId");
+		PlatformProfileUtils.removeUserProfile(userId, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Platform profile removed from user."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Removes the platform profile assignment from a user.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/SetPlatformFeatureReactor.java
+++ b/src/prerna/reactor/platformprofile/SetPlatformFeatureReactor.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.auth.utils.SecurityAdminUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class SetPlatformFeatureReactor extends AbstractReactor {
+
+	public SetPlatformFeatureReactor() {
+		this.keysToGet = new String[]{"profileId", "featureKey", "enabled"};
+		this.keyRequired = new int[]{1, 1, 1};
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		SecurityAdminUtils adminUtils = SecurityAdminUtils.getInstance(user);
+		if (adminUtils == null) {
+			throw new IllegalArgumentException("User must be an admin to perform this function.");
+		}
+		String profileId = this.keyValue.get("profileId");
+		String featureKey = this.keyValue.get("featureKey");
+		boolean enabled = Boolean.parseBoolean(this.keyValue.get("enabled"));
+		PlatformProfileUtils.setProfileFeature(profileId, featureKey, enabled, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Platform feature updated."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Enables or disables a specific feature on a platform profile.";
+	}
+}

--- a/src/prerna/reactor/platformprofile/UpdatePlatformProfileReactor.java
+++ b/src/prerna/reactor/platformprofile/UpdatePlatformProfileReactor.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.platformprofile;
+
+import prerna.auth.User;
+import prerna.auth.utils.PlatformProfileUtils;
+import prerna.auth.utils.SecurityAdminUtils;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+public class UpdatePlatformProfileReactor extends AbstractReactor {
+
+	public UpdatePlatformProfileReactor() {
+		this.keysToGet = new String[]{"profileId", "name", "description"};
+		this.keyRequired = new int[]{1, 0, 0};
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		User user = this.insight.getUser();
+		SecurityAdminUtils adminUtils = SecurityAdminUtils.getInstance(user);
+		if (adminUtils == null) {
+			throw new IllegalArgumentException("User must be an admin to perform this function.");
+		}
+		String profileId = this.keyValue.get("profileId");
+		String name = this.keyValue.get("name");
+		String desc = this.keyValue.get("description");
+		PlatformProfileUtils.updateProfile(profileId, name, desc, user);
+		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
+		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Platform profile updated."));
+		return noun;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Updates an existing platform profile's name and/or description.";
+	}
+}


### PR DESCRIPTION
## Description

Implements a Role-Based Feature Visibility system with two independent parts:

**Part A — App Profiles (fail-closed):** Controls which features are visible inside a specific app. Users with no profile assigned see no features.

**Part B — Platform Profiles (fail-open):** Controls which platform-level nav pages a user can see. Users with no profile assigned see all nav pages.

"Profile" (what users SEE) is intentionally separate from "role" (owner/editor/viewer — what users can DO).

## Changes Made

### Database Schema (`AbstractSecurityUtils.java`)
7 new tables added via `createTableIfNotExists` with column migration support:
- `APP_PROFILE` — profile definitions per app
- `APP_FEATURE` — feature key registry per app
- `APP_PROFILE_FEATURE` — profile↔feature mappings with enabled flag
- `APP_USER_PROFILE` — user↔profile assignments per app
- `PLATFORM_PROFILE` — platform-level profile definitions
- `PLATFORM_PROFILE_FEATURE` — platform profile↔feature mappings
- `PLATFORM_USER_PROFILE` — user↔platform profile assignments

### Utility Classes
- **`AppProfileUtils.java`** — full CRUD for app profiles, features, profile-feature mappings, user assignments; cascade delete helpers called by SecurityProjectUtils
- **`PlatformProfileUtils.java`** — admin-only CRUD; 5 predefined nav keys (`nav.app-catalog`, `nav.build`, `nav.skills`, `nav.settings`, `nav.engine`); fail-open when no profile assigned

### Cascade Deletes (`SecurityProjectUtils.java`)
6 sites wired to call `AppProfileUtils` when access is removed:
- `deleteProject` — cleans all app profiles for the project
- `removeProjectUser` — cleans one user's app profile
- `removeExpiredProjectUser` — cleans expired access
- `copyProjectPermissions` — clears target app profiles before copy
- `approveProjectUserAccessRequests` — cleans rejected users
- `removeProjectUsers` — batch user cleanup

### Pixel Reactors — App Profiles (`src/prerna/reactor/appprofile/`)
16 reactors: `CreateAppProfile`, `UpdateAppProfile`, `DeleteAppProfile`, `GetAppProfiles`, `CreateAppFeature`, `UpdateAppFeature`, `DeleteAppFeature`, `GetAppFeatures`, `SetProfileFeature`, `GetProfileFeatures`, `AssignUserProfile`, `RemoveUserProfile`, `GetUserProfile`, `GetProfileUsers`, `CheckFeature`, `GetUserFeatures`

### Pixel Reactors — Platform Profiles (`src/prerna/reactor/platformprofile/`)
9 reactors: `CreatePlatformProfile`, `UpdatePlatformProfile`, `DeletePlatformProfile`, `GetPlatformProfiles`, `SetPlatformFeature`, `GetPlatformFeatures`, `AssignUserPlatformProfile`, `RemoveUserPlatformProfile`, `GetUserPlatformFeatures`

## How to Test

```bash
make build-backend restart && make status
```

**Create an app profile:**
```
CreateAppProfile(app="<APP_ID>", name="Power Users", description="Full feature access", isDefault="false");
```

**Create a feature and toggle it on for the profile:**
```
CreateAppFeature(app="<APP_ID>", key="export-csv", description="CSV export button");
GetAppFeatures(app="<APP_ID>");
SetProfileFeature(app="<APP_ID>", profileId="<PROFILE_ID>", featureId="<FEATURE_ID>", enabled="true");
```

**Assign a user and check their features:**
```
AssignUserProfile(app="<APP_ID>", profileId="<PROFILE_ID>", userId="<USER_ID>");
CheckFeature(app="<APP_ID>", key="export-csv");
GetUserFeatures(app="<APP_ID>");
```

**Platform profile:**
```
CreatePlatformProfile(name="App Catalog Only", description="Can only see app catalog");
SetPlatformFeature(profileId="<PROFILE_ID>", featureKey="nav.app-catalog", enabled="true");
SetPlatformFeature(profileId="<PROFILE_ID>", featureKey="nav.build", enabled="false");
AssignUserPlatformProfile(profileId="<PROFILE_ID>", userId="<USER_ID>");
GetUserPlatformFeatures();
```

## Notes

- All reactors auto-discovered by class name — no `web.xml` changes needed
- `AppProfileUtils` and `PlatformProfileUtils` are in `prerna.auth.utils` (same package as `SecurityAdminUtils`, `SecurityProjectUtils`)
- Platform profile checks fail-open: no assigned profile → all 5 nav keys return `true`
- App profile checks fail-closed: no assigned profile → `GetUserFeatures()` returns empty map
- Admin check: `SecurityAdminUtils.getInstance(user)` — all platform reactors except `GetUserPlatformFeatures` gate on this