### PR TITLE
Include platform skills in `MyProjects(type="SKILL")`

### DIFF
--- a/docs/agents/skills/skills_doc.md
+++ b/docs/agents/skills/skills_doc.md
@@ -322,7 +322,7 @@ For a platform skill the `id` is the slug (platform skills have no project id). 
 ### How it differs from a normal listing
 
 - **Registry skills** come from the security DB (like any project) and carry the usual project fields (`project_id`, `project_name`, `project_date_created`, `permission`, requested `metaKeys`, etc.), plus `type = "SKILL"`.
-- **Platform skills** are disk-backed built-ins with no project row, so they carry only `type = "PLATFORM_SKILL"`, `slug`, `project_name`, `project_description`, and `origin = "PLATFORM"` - **no `project_id`**, no permissions, no favorites, no project metadata.
+- **Platform skills** are disk-backed built-ins with no project row, so they carry `type = "PLATFORM_SKILL"`, `slug`, `project_name`, `project_description`, `origin = "PLATFORM"`, and `tag = "PLATFORM"` - but no permissions, no favorites, no project metadata. The reactor stamps a **synthetic `project_id` of `SYSTEM_<slug>`** (e.g. `SYSTEM_build-and-publish`) so every entry has a stable, non-null id; it is not a real project and does not resolve in the security DB.
 - On the `SKILL` path, `sort`, `limit`, and `offset` are applied **in Java over the merged set** (registry + platform), not in SQL, so platform skills participate in paging and sorting alongside registry skills (they are interleaved by the sort, not grouped). Sort keys are the same as elsewhere (`PROJECTNAME`, `DATECREATED`, `DATELASTEDITED`); platform skills have no dates, so on a date sort they fall last. Default sort is `PROJECTNAME` ASC.
 - Platform skills are **omitted** when the call scopes on something only projects have: `onlyFavorites=true`, a non-empty `permissionFilters`, or a non-empty `metaFilters`. `filterWord` still applies to platform skills (matched on name/description).
 
@@ -359,9 +359,11 @@ MyProjects(
   {
     "type": "PLATFORM_SKILL",
     "slug": "database",
+    "project_id": "SYSTEM_database",
     "project_name": "database",
     "project_description": "Use when writing code that queries a relational or graph database on the platform...",
-    "origin": "PLATFORM"
+    "origin": "PLATFORM",
+    "tag": "PLATFORM"
   }
 ]
 ```

--- a/docs/agents/skills/skills_doc.md
+++ b/docs/agents/skills/skills_doc.md
@@ -7,6 +7,8 @@ Two reactors surface the skills available on the platform. They answer different
 
 Once you have a skill's identifier, attach it to a workspace with **`AttachSkillToWorkspace`** / **`DetachSkillFromWorkspace`**, or set a workspace's whole skill set with **`EditWorkspace`** - see [Managing skills on a workspace](#managing-skills-on-a-workspace).
 
+You can also list skills through the general project-listing reactor: **`MyProjects(type="SKILL")`** returns the skill-projects the user can view (they are real Projects of `PROJECT.TYPE='SKILL'`) **plus** all platform skills, merged and paged together. Every entry carries a `type` discriminator - `"SKILL"` for a project-backed registry skill (has `project_id`) or `"PLATFORM_SKILL"` for a disk-backed platform skill (no `project_id`; carries `slug` and `origin=PLATFORM`). Because platform skills have no `project_id`, permissions, favorites, or project metadata, they are omitted when the call also sets `onlyFavorites`, `permissionFilters`, or a non-empty `metaFilters`. See [MyProjects and skills](#myprojects-and-skills).
+
 ---
 
 ## ListSkills
@@ -310,3 +312,58 @@ EditWorkspace(
 ```
 
 For a platform skill the `id` is the slug (platform skills have no project id). The full `config_json` is returned alongside, so you can read `skills[]` and `platform_skills[]` directly if you prefer the raw form.
+
+---
+
+## MyProjects and skills
+
+`MyProjects` is the general project-listing reactor (paging, sort, search, favorites, and `metaKeys` metadata). Skill-projects are real Projects, so `MyProjects(type="SKILL")` already lists the registry skills the user can view - and it now also merges in the platform skills so a single project-list surface shows every skill.
+
+### How it differs from a normal listing
+
+- **Registry skills** come from the security DB (like any project) and carry the usual project fields (`project_id`, `project_name`, `project_date_created`, `permission`, requested `metaKeys`, etc.), plus `type = "SKILL"`.
+- **Platform skills** are disk-backed built-ins with no project row, so they carry only `type = "PLATFORM_SKILL"`, `slug`, `project_name`, `project_description`, and `origin = "PLATFORM"` - **no `project_id`**, no permissions, no favorites, no project metadata.
+- On the `SKILL` path, `sort`, `limit`, and `offset` are applied **in Java over the merged set** (registry + platform), not in SQL, so platform skills participate in paging and sorting alongside registry skills (they are interleaved by the sort, not grouped). Sort keys are the same as elsewhere (`PROJECTNAME`, `DATECREATED`, `DATELASTEDITED`); platform skills have no dates, so on a date sort they fall last. Default sort is `PROJECTNAME` ASC.
+- Platform skills are **omitted** when the call scopes on something only projects have: `onlyFavorites=true`, a non-empty `permissionFilters`, or a non-empty `metaFilters`. `filterWord` still applies to platform skills (matched on name/description).
+
+Every other `MyProjects` call (no `type`, or `type="CODE"`/`"INSIGHTS"`, etc.) is unchanged and keeps SQL-side paging.
+
+### Example
+
+```
+MyProjects(
+  metaKeys=["tag","domain","data classification","data restrictions","description"],
+  metaFilters=[{}],
+  filterWord=[""],
+  sort=[{"PROJECTNAME":"ASC"}],
+  type="SKILL",
+  limit=[50],
+  offset=[0]
+);
+```
+
+### Response (abridged)
+
+```json
+[
+  {
+    "type": "SKILL",
+    "project_id": "019eb7d5-4998-76b4-8620-5e9a516816db",
+    "project_name": "pptx",
+    "project_type": "SKILL",
+    "project_date_created": "2026-06-11T17:57:49Z",
+    "permission": 1,
+    "tag": "Skill_Project",
+    "domain": "documents"
+  },
+  {
+    "type": "PLATFORM_SKILL",
+    "slug": "database",
+    "project_name": "database",
+    "project_description": "Use when writing code that queries a relational or graph database on the platform...",
+    "origin": "PLATFORM"
+  }
+]
+```
+
+`GetSkills` remains the skill-centric view (returns `skill_id`/`slug` shaped rows); `MyProjects(type="SKILL")` is the project-list-shaped view of the same skills.

--- a/src/prerna/reactor/project/MyProjectsReactor.java
+++ b/src/prerna/reactor/project/MyProjectsReactor.java
@@ -58,6 +58,17 @@ public class MyProjectsReactor extends AbstractReactor {
 	 */
 	private static final String SKILL_TYPE = "SKILL";
 
+	/**
+	 * Synthetic {@code project_id} prefix stamped onto platform-skill entries (which have
+	 * no real project row), e.g. {@code SYSTEM_build-and-publish}. Added purely at the
+	 * reactor level so callers get a stable, non-null id per platform skill; it is not a
+	 * real project and does not resolve in the security DB.
+	 */
+	private static final String PLATFORM_PROJECT_ID_PREFIX = "SYSTEM_";
+
+	/** {@code tag} value stamped onto platform-skill entries in a SKILL listing. */
+	private static final String PLATFORM_TAG = "PLATFORM";
+
 	public MyProjectsReactor() {
 		this.keysToGet = new String[] { ReactorKeysEnum.FILTER_WORD.getKey(), ReactorKeysEnum.LIMIT.getKey(),
 				ReactorKeysEnum.OFFSET.getKey(), ReactorKeysEnum.ONLY_FAVORITES.getKey(),
@@ -214,9 +225,12 @@ public class MyProjectsReactor extends AbstractReactor {
 				Map<String, Object> entry = new LinkedHashMap<>();
 				entry.put("type", PlatformSkills.PLATFORM_SKILL_TYPE);
 				entry.put("slug", ps.get("slug"));
+				// synthetic, non-DB id so callers always get a stable project_id per platform skill
+				entry.put("project_id", PLATFORM_PROJECT_ID_PREFIX + stringOf(ps.get("slug")));
 				entry.put("project_name", name);
 				entry.put("project_description", description);
 				entry.put("origin", ps.get("origin"));
+				entry.put("tag", PLATFORM_TAG);
 				merged.add(entry);
 			}
 		}
@@ -325,8 +339,8 @@ public class MyProjectsReactor extends AbstractReactor {
 
 		JSONObject itemProperties = new JSONObject();
 
-		itemProperties.put("project_id",
-				new JSONObject().put("type", "string").put("description", "Unique project identifier (UUID)"));
+		itemProperties.put("project_id", new JSONObject().put("type", "string").put("description",
+				"Unique project identifier (UUID) for a project-backed entry. For a platform skill it is a synthetic id 'SYSTEM_<slug>' (e.g. SYSTEM_build-and-publish) that does not resolve in the security DB."));
 
 		itemProperties.put("project_name",
 				new JSONObject().put("type", "string").put("description", "Display name of the project"));
@@ -388,8 +402,8 @@ public class MyProjectsReactor extends AbstractReactor {
 		itemProperties.put("project_cost",
 				new JSONObject().put("type", "string").put("description", "Cost metadata, may be empty string"));
 
-		itemProperties.put("tag",
-				new JSONObject().put("type", "string").put("description", "Metadata tag associated with the project"));
+		itemProperties.put("tag", new JSONObject().put("type", "string").put("description",
+				"Metadata tag associated with the project. Platform-skill entries carry the literal tag 'PLATFORM'."));
 
 		itemProperties.put("low_project_name",
 				new JSONObject().put("type", "string").put("description", "Lowercase version of project_name"));

--- a/src/prerna/reactor/project/MyProjectsReactor.java
+++ b/src/prerna/reactor/project/MyProjectsReactor.java
@@ -30,6 +30,7 @@ package prerna.reactor.project;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -41,6 +42,7 @@ import org.json.JSONObject;
 import prerna.auth.utils.SecurityProjectUtils;
 import prerna.engine.api.IRawSelectWrapper;
 import prerna.reactor.AbstractReactor;
+import prerna.reactor.agent.skill.PlatformSkills;
 import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.PixelOperationType;
 import prerna.sablecc2.om.ReactorKeysEnum;
@@ -49,6 +51,12 @@ import prerna.sablecc2.om.nounmeta.NounMetadata;
 public class MyProjectsReactor extends AbstractReactor {
 
 	private static final Logger classLogger = LogManager.getLogger(MyProjectsReactor.class);
+
+	/**
+	 * Value of the {@code type} input (PROJECT.TYPE) that identifies a skill listing,
+	 * and the discriminator written onto project-backed skill entries in the response.
+	 */
+	private static final String SKILL_TYPE = "SKILL";
 
 	public MyProjectsReactor() {
 		this.keysToGet = new String[] { ReactorKeysEnum.FILTER_WORD.getKey(), ReactorKeysEnum.LIMIT.getKey(),
@@ -74,107 +82,224 @@ public class MyProjectsReactor extends AbstractReactor {
 		Map<String, Object> projectMetadataFilter = getMap(ReactorKeysEnum.META_FILTERS.getKey());
 		Map<String, String> sortFields = getMap(ReactorKeysEnum.SORT.getKey());
 
-		// for right now, do not apply filter on project type since it is not properly
-		// in some smss files
-		List<Map<String, Object>> projectInfo = SecurityProjectUtils.getUserProjectList(this.insight.getUser(),
-				projectTypeFilters, projectIdFilters, favoritesOnly, portalsOnly, projectMetadataFilter,
-				permissionFilters, searchTerm, limit, offset, sortFields);
+		boolean skillListing = projectTypeFilters != null && projectTypeFilters.contains(SKILL_TYPE);
 
-		if (!projectInfo.isEmpty() && (!noMeta || includeUserT)) {
-			Map<String, Integer> index = new HashMap<>(projectInfo.size());
-			int size = projectInfo.size();
-			// now we want to add most executed insights
-			for (int i = 0; i < size; i++) {
-				Map<String, Object> project = projectInfo.get(i);
-				String projectId = project.get("project_id").toString();
-				// keep list of project ids to get the index
-				index.put(projectId, Integer.valueOf(i));
-			}
-
-			if (!noMeta) {
-				IRawSelectWrapper wrapper = null;
-				try {
-					wrapper = SecurityProjectUtils.getProjectMetadataWrapper(index.keySet(),
-							getListString(ReactorKeysEnum.META_KEYS.getKey()), true);
-					while (wrapper.hasNext()) {
-						Object[] data = wrapper.next().getValues();
-						String projectId = (String) data[0];
-
-						String metaKey = (String) data[1];
-						String metaValue = (String) data[2];
-						if (metaValue == null) {
-							continue;
-						}
-
-						int indexToFind = index.get(projectId);
-						Map<String, Object> res = projectInfo.get(indexToFind);
-						// whatever it is, if it is single send a single value, if it is multi send as
-						// array
-						if (res.containsKey(metaKey)) {
-							Object obj = res.get(metaKey);
-							if (obj instanceof List) {
-								((List) obj).add(metaValue);
-							} else {
-								List<Object> newList = new ArrayList<>();
-								newList.add(obj);
-								newList.add(metaValue);
-								res.put(metaKey, newList);
-							}
-						} else {
-							res.put(metaKey, metaValue);
-						}
-					}
-				} catch (Exception e) {
-					classLogger.error("Failed to attach project metadata values to the project list response", e);
-				} finally {
-					if (wrapper != null) {
-						try {
-							wrapper.close();
-						} catch (IOException e) {
-							classLogger.error("Failed to close metadata wrapper while building project list response",
-									e);
-						}
-					}
-				}
-			}
-//			if(includeUserT) {
-//				IRawSelectWrapper wrapper = null;
-//				try {
-//					wrapper = UserCatalogVoteUtils.getAllVotesWrapper(index.keySet());
-//					while(wrapper.hasNext()) {
-//						Object[] data = wrapper.next().getValues();
-//						String databaseId = (String) data[0];
-//						int upvotes = ((Number) data[1]).intValue();
-//		
-//						int indexToFind = index.get(databaseId);
-//						Map<String, Object> res = projectInfo.get(indexToFind);
-//						res.put("upvotes", upvotes);
-//					}
-//				} catch (Exception e) {
-//					classLogger.error("Failed to attach vote totals to the project list response", e);
-//				} finally {
-//					if(wrapper!=null) {
-//						try {
-//							wrapper.close();
-//						} catch (IOException e) {
-//							classLogger.error("Failed to close vote wrapper while building project list response", e);
-//						}
-//					}
-//				}
-//				
-//				Map<String, Boolean> voted = UserCatalogVoteUtils.userEngineVotes(User.getUserIdAndType(this.insight.getUser()), index.keySet());
-//				for (String ks : index.keySet()) {
-//					int indexToFind = index.get(ks);
-//					Boolean hasUpvoted = voted.get(ks);
-//					if (hasUpvoted == null) {
-//						hasUpvoted = false;
-//					}
-//					engineInfo.get(indexToFind).put("hasUpvoted", hasUpvoted);
-//				}
-//			}
+		List<Map<String, Object>> projectInfo;
+		if (skillListing) {
+			projectInfo = buildSkillListing(searchTerm, limit, offset, projectTypeFilters, projectIdFilters,
+					favoritesOnly, portalsOnly, projectMetadataFilter, permissionFilters, noMeta, includeUserT,
+					sortFields);
+		} else {
+			// for right now, do not apply filter on project type since it is not properly
+			// in some smss files
+			projectInfo = SecurityProjectUtils.getUserProjectList(this.insight.getUser(), projectTypeFilters,
+					projectIdFilters, favoritesOnly, portalsOnly, projectMetadataFilter, permissionFilters, searchTerm,
+					limit, offset, sortFields);
+			attachProjectMetadata(projectInfo, noMeta, includeUserT);
 		}
 
 		return new NounMetadata(projectInfo, PixelDataType.CUSTOM_DATA_STRUCTURE, PixelOperationType.PROJECT_INFO);
+	}
+
+	/**
+	 * Attaches the requested {@code metaKeys} metadata to each project-backed entry.
+	 * Keyed strictly by {@code project_id}, so entries that lack one (platform skills)
+	 * must never be passed in here - the caller merges them only after this runs.
+	 */
+	private void attachProjectMetadata(List<Map<String, Object>> projectInfo, boolean noMeta, boolean includeUserT) {
+		if (projectInfo.isEmpty() || (noMeta && !includeUserT)) {
+			return;
+		}
+		Map<String, Integer> index = new HashMap<>(projectInfo.size());
+		int size = projectInfo.size();
+		// now we want to add most executed insights
+		for (int i = 0; i < size; i++) {
+			Map<String, Object> project = projectInfo.get(i);
+			String projectId = project.get("project_id").toString();
+			// keep list of project ids to get the index
+			index.put(projectId, Integer.valueOf(i));
+		}
+
+		if (!noMeta) {
+			IRawSelectWrapper wrapper = null;
+			try {
+				wrapper = SecurityProjectUtils.getProjectMetadataWrapper(index.keySet(),
+						getListString(ReactorKeysEnum.META_KEYS.getKey()), true);
+				while (wrapper.hasNext()) {
+					Object[] data = wrapper.next().getValues();
+					String projectId = (String) data[0];
+
+					String metaKey = (String) data[1];
+					String metaValue = (String) data[2];
+					if (metaValue == null) {
+						continue;
+					}
+
+					int indexToFind = index.get(projectId);
+					Map<String, Object> res = projectInfo.get(indexToFind);
+					// whatever it is, if it is single send a single value, if it is multi send as
+					// array
+					if (res.containsKey(metaKey)) {
+						Object obj = res.get(metaKey);
+						if (obj instanceof List) {
+							((List) obj).add(metaValue);
+						} else {
+							List<Object> newList = new ArrayList<>();
+							newList.add(obj);
+							newList.add(metaValue);
+							res.put(metaKey, newList);
+						}
+					} else {
+						res.put(metaKey, metaValue);
+					}
+				}
+			} catch (Exception e) {
+				classLogger.error("Failed to attach project metadata values to the project list response", e);
+			} finally {
+				if (wrapper != null) {
+					try {
+						wrapper.close();
+					} catch (IOException e) {
+						classLogger.error("Failed to close metadata wrapper while building project list response", e);
+					}
+				}
+			}
+		}
+	}
+
+	/**
+	 * Builds a SKILL listing: the project-backed (registry) skills the user can view,
+	 * merged with the read-only platform skills, then sorted and paged in Java.
+	 *
+	 * <p>Registry skills are fetched unpaged (limit/offset/sort passed as null) so the
+	 * merge with platform skills can be paged as one set. Every entry is tagged with a
+	 * {@code type} discriminator: {@code SKILL} for project-backed skills,
+	 * {@link PlatformSkills#PLATFORM_SKILL_TYPE} for platform skills. Platform skills
+	 * have no {@code project_id}, permissions, favorites, or project metadata, so they
+	 * are skipped whenever a filter that only they cannot satisfy is set.
+	 */
+	private List<Map<String, Object>> buildSkillListing(String searchTerm, String limit, String offset,
+			List<String> projectTypeFilters, List<String> projectIdFilters, boolean favoritesOnly, boolean portalsOnly,
+			Map<String, Object> projectMetadataFilter, List<Integer> permissionFilters, boolean noMeta,
+			boolean includeUserT, Map<String, String> sortFields) {
+		// registry skills, unpaged - Java applies sort/limit/offset over the union below
+		List<Map<String, Object>> registry = SecurityProjectUtils.getUserProjectList(this.insight.getUser(),
+				projectTypeFilters, projectIdFilters, favoritesOnly, portalsOnly, projectMetadataFilter,
+				permissionFilters, searchTerm, null, null, null);
+		attachProjectMetadata(registry, noMeta, includeUserT);
+		for (Map<String, Object> row : registry) {
+			row.put("type", SKILL_TYPE);
+		}
+
+		List<Map<String, Object>> merged = new ArrayList<>(registry);
+
+		boolean skipPlatform = favoritesOnly || (permissionFilters != null && !permissionFilters.isEmpty())
+				|| (projectMetadataFilter != null && !projectMetadataFilter.isEmpty());
+		if (skipPlatform) {
+			classLogger.debug(
+					"MyProjects: omitting platform skills from SKILL listing because a favorites/permission/metadata filter is set - platform skills have none of these.");
+		} else {
+			String term = (searchTerm == null) ? null : searchTerm.trim().toLowerCase();
+			for (Map<String, Object> ps : PlatformSkills.list()) {
+				String name = stringOf(ps.get("name"));
+				String description = stringOf(ps.get("description"));
+				// replicate the SQL filterWord LIKE match in Java (name + description)
+				if (term != null && !term.isEmpty()) {
+					String hay = ((name == null ? "" : name) + " " + (description == null ? "" : description))
+							.toLowerCase();
+					if (!hay.contains(term)) {
+						continue;
+					}
+				}
+				Map<String, Object> entry = new LinkedHashMap<>();
+				entry.put("type", PlatformSkills.PLATFORM_SKILL_TYPE);
+				entry.put("slug", ps.get("slug"));
+				entry.put("project_name", name);
+				entry.put("project_description", description);
+				entry.put("origin", ps.get("origin"));
+				merged.add(entry);
+			}
+		}
+
+		sortListing(merged, sortFields);
+		return page(merged, limit, offset);
+	}
+
+	/**
+	 * Sorts the merged listing in place by the first entry of {@code sortFields}
+	 * (defaulting to {@code project_name} ASC). Missing values (e.g. platform skills
+	 * have no dates) sort last regardless of direction.
+	 */
+	private static void sortListing(List<Map<String, Object>> rows, Map<String, String> sortFields) {
+		String field = "project_name";
+		boolean asc = true;
+		if (sortFields != null && !sortFields.isEmpty()) {
+			Map.Entry<String, String> e = sortFields.entrySet().iterator().next();
+			field = mapSortKey(e.getKey());
+			asc = !"DESC".equalsIgnoreCase(e.getValue());
+		}
+		final String sortField = field;
+		final int dir = asc ? 1 : -1;
+		rows.sort((a, b) -> {
+			String sa = stringOf(a.get(sortField));
+			String sb = stringOf(b.get(sortField));
+			if (sa == null && sb == null) {
+				return 0;
+			}
+			if (sa == null) {
+				return 1;
+			}
+			if (sb == null) {
+				return -1;
+			}
+			return dir * sa.compareToIgnoreCase(sb);
+		});
+	}
+
+	/** Maps a sort key (as accepted by getUserProjectList) to its response-map field. */
+	private static String mapSortKey(String key) {
+		if (key == null) {
+			return "project_name";
+		}
+		switch (key.toUpperCase()) {
+			case "DATECREATED":
+				return "project_date_created";
+			case "DATELASTEDITED":
+			case "DATE_LAST_EDITED":
+				return "project_date_last_edited";
+			case "PROJECTNAME":
+			default:
+				return "project_name";
+		}
+	}
+
+	/** Applies offset/limit in Java over the merged listing. */
+	private static List<Map<String, Object>> page(List<Map<String, Object>> rows, String limit, String offset) {
+		int off = parseInt(offset, 0);
+		if (off < 0) {
+			off = 0;
+		}
+		if (off >= rows.size()) {
+			return new ArrayList<>();
+		}
+		int lim = parseInt(limit, -1);
+		int end = (lim < 0) ? rows.size() : Math.min(rows.size(), off + lim);
+		return new ArrayList<>(rows.subList(off, end));
+	}
+
+	private static int parseInt(String s, int def) {
+		if (s == null || s.trim().isEmpty()) {
+			return def;
+		}
+		try {
+			return Integer.parseInt(s.trim());
+		} catch (NumberFormatException e) {
+			return def;
+		}
+	}
+
+	private static String stringOf(Object o) {
+		return o == null ? null : o.toString();
 	}
 
 	@Override
@@ -207,7 +332,23 @@ public class MyProjectsReactor extends AbstractReactor {
 				new JSONObject().put("type", "string").put("description", "Display name of the project"));
 
 		itemProperties.put("project_type", new JSONObject().put("type", "string")
-				.put("enum", new JSONArray().put("CODE").put("INSIGHTS")).put("description", "The type of project"));
+				.put("enum", new JSONArray().put("CODE").put("INSIGHTS").put("SKILL"))
+				.put("description", "The type of project"));
+
+		itemProperties.put("type", new JSONObject().put("type", "string")
+				.put("enum", new JSONArray().put("SKILL").put("PLATFORM_SKILL"))
+				.put("description",
+						"Only present in a SKILL listing (type=\"SKILL\"). 'SKILL' is a project-backed registry skill (has project_id); "
+								+ "'PLATFORM_SKILL' is a read-only disk-backed platform skill (no project_id; carries slug and origin=PLATFORM)."));
+
+		itemProperties.put("slug", new JSONObject().put("type", "string").put("description",
+				"Platform-skill folder name. Present only on PLATFORM_SKILL entries."));
+
+		itemProperties.put("origin", new JSONObject().put("type", "string").put("description",
+				"Skill origin, e.g. PLATFORM. Present on platform-skill entries in a SKILL listing."));
+
+		itemProperties.put("project_description", new JSONObject().put("type", "string")
+				.put("description", "Project/skill description from metadata; may be empty string"));
 
 		itemProperties.put("project_date_created", new JSONObject().put("type", "string").put("format", "datetime")
 				.put("description", "ISO datetime when project was created"));


### PR DESCRIPTION
## Summary
`MyProjects(type="SKILL")` previously returned only **registry** skills — the ones backed by real Projects (`PROJECT.TYPE='SKILL'`). It had no visibility into **platform** skills, which aren't Projects at all: they're read-only, disk-backed folders under `<BASE_FOLDER>/skills/<slug>/`, enumerated by `PlatformSkills.list()` and keyed by `slug` (no `project_id`).

This PR makes the SKILL listing surface **both**, merged into a single sorted/paged result, so one project-list view (with `metaKeys`, `sort`, paging, `filterWord`) shows every skill available to the user. This mirrors what `GetSkills` already does for its `accessible`/`platform` filters.

## What changed
- **Gated on `type="SKILL"`.** All other `MyProjects` listings (no `type`, `type="CODE"`, `type="INSIGHTS"`, etc.) are unchanged and keep their existing SQL-side paging.
- **New `buildSkillListing(...)` path:** fetches registry skills **unpaged** (`limit/offset/sort = null`), then merges in platform-skill entries, then applies `sort` + `limit` + `offset` **in Java** over the union (platform skills are invisible to the security-DB SQL paging, so paging has to happen after the merge).
- **`type` discriminator on every entry**, matching the existing `GetWorkspace` convention:
  - `type: "SKILL"` — project-backed registry skill (carries `project_id` + the usual project/`metaKeys` fields)
  - `type: "PLATFORM_SKILL"` — disk-backed platform skill (carries `slug`, `project_name`, `project_description`, `origin: "PLATFORM"`; **no `project_id`**)
- **Filter semantics:** `filterWord` is matched in Java against platform-skill name/description. Platform skills are omitted (with a `debug` log) when the call scopes on something only Projects have — `onlyFavorites`, `permissionFilters`, or a non-empty `metaFilters`.
- **Refactor:** extracted the existing `metaKeys` attachment into a reusable `attachProjectMetadata(...)` helper. It runs **before** platform skills are merged in, so the `project_id`-keyed loop never sees a platform entry (avoids an NPE on the missing `project_id`).
- **Docs:** `getResponseSchema()` updated (adds `type`/`slug`/`origin`, `SKILL` added to `project_type` enum) and a new "MyProjects and skills" section in `skills_doc.md`.

## Reuse (no changes)
- `prerna.reactor.agent.skill.PlatformSkills.list()` / `PLATFORM_SKILL_TYPE`
- `SecurityProjectUtils.getUserProjectList(...)` (called with null paging/sort on the SKILL path)

## Behavior notes
- Registry + platform skills are **interleaved by the requested sort** (default `PROJECTNAME` ASC), not grouped by type. Platform skills have no dates, so on a date sort they fall last.
- Because paging happens in Java for the SKILL path, the full registry-skill set is fetched before slicing. Skill counts are modest, so this is fine, but worth noting if the catalog ever grows large.

## Files
- `src/prerna/reactor/project/MyProjectsReactor.java`
- `docs/agents/skills/skills_doc.md`
