### PR TITLE
 Fix skill creation identity bugs and move new skill content to `public/`

### DIFF
--- a/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/GetWorkspaceReactor.java
+++ b/src/prerna/engine/impl/model/inferencetracking/reactors/workspaces/GetWorkspaceReactor.java
@@ -136,7 +136,7 @@ public class GetWorkspaceReactor extends AbstractReactor {
 				Map<String, String> skillMap = new HashMap<>();
 				skillMap.put("id", resourceId);
 				skillMap.put("type", rType);
-				skillMap.put("name", info.name);
+				skillMap.put("name", info.displayName);
 				skillMap.put("slug", info.slug);
 				if (info.description != null) {
 					skillMap.put("description", info.description);

--- a/src/prerna/reactor/agent/skill/CreateSkillReactor.java
+++ b/src/prerna/reactor/agent/skill/CreateSkillReactor.java
@@ -57,7 +57,7 @@ import prerna.util.AssetUtility;
  * <li>Creates the underlying Project via
  * {@link ProjectHelper#createSkillProject}.</li>
  * <li>Writes {@code SKILL.md} (and helper files, if any) into
- * {@code <project>/version/assets/skill/}.</li>
+ * {@code <project>/version/assets/public/}.</li>
  * </ol>
  *
  * <p>
@@ -65,10 +65,12 @@ import prerna.util.AssetUtility;
  * <ul>
  * <li>{@code skillContent} - SKILL.md body, with or without a YAML frontmatter
  * block (required)</li>
- * <li>{@code name} - display name. Required <i>only</i> when the frontmatter
- * omits one. When both are supplied, frontmatter wins.</li>
- * <li>{@code description} - same rule as {@code name}: required only when
- * frontmatter omits it.</li>
+ * <li>{@code name} - display name. Wins over the frontmatter's {@code name}
+ * when supplied; frontmatter is the fallback only when the param is omitted
+ * entirely.</li>
+ * <li>{@code description} - same rule as {@code name}: wins over the
+ * frontmatter's {@code description} when supplied; frontmatter is the
+ * fallback only when the param is omitted entirely.</li>
  * </ul>
  *
  * <p>
@@ -104,13 +106,14 @@ public class CreateSkillReactor extends AbstractReactor {
 			throw new IllegalArgumentException("skillContent is required");
 		}
 
-		// Frontmatter wins when present; params are the fallback. The file on disk
-		// is left alone if it already carries a frontmatter block (even if partial)
-		// and gets a synthesized block prepended only when one is entirely absent.
+		// Explicit name/description params win when supplied; frontmatter is the
+		// fallback only when a param is omitted entirely. The file on disk is left
+		// alone if it already carries a frontmatter block (even if partial) and
+		// gets a synthesized block prepended only when one is entirely absent.
 		Skill.Frontmatter fm = Skill.parseFrontmatter(skillContent);
 		boolean hasFrontmatter = Skill.hasFrontmatterBlock(skillContent);
-		String name = firstNonEmpty(fm.name, nameInput);
-		String description = firstNonEmpty(fm.description, descInput);
+		String name = firstNonEmpty(nameInput, fm.name);
+		String description = firstNonEmpty(descInput, fm.description);
 		if (name == null) {
 			throw new IllegalArgumentException(
 					"name is required: provide a 'name' input, or include 'name' in the SKILL.md frontmatter");
@@ -166,7 +169,7 @@ public class CreateSkillReactor extends AbstractReactor {
 
 	@Override
 	public String getReactorDescription() {
-		return "Creates a new skill (a SKILL-type Project) and writes its SKILL.md into the project's version/assets/skill/ folder";
+		return "Creates a new skill (a SKILL-type Project) and writes its SKILL.md into the project's version/assets/public/ folder";
 	}
 
 	@Override
@@ -176,12 +179,12 @@ public class CreateSkillReactor extends AbstractReactor {
 					+ "A frontmatter block will be synthesized from 'name' and 'description' if absent";
 		}
 		if (ReactorKeysEnum.NAME.getKey().equals(key)) {
-			return "Display name. Required only when the SKILL.md frontmatter omits 'name'. "
-					+ "Frontmatter wins when both are supplied";
+			return "Display name. Wins over the SKILL.md frontmatter's 'name' when supplied; "
+					+ "frontmatter is the fallback only when this param is omitted entirely";
 		}
 		if (ReactorKeysEnum.DESCRIPTION.getKey().equals(key)) {
-			return "Description. Required only when the SKILL.md frontmatter omits 'description'. "
-					+ "Frontmatter wins when both are supplied";
+			return "Description. Wins over the SKILL.md frontmatter's 'description' when supplied; "
+					+ "frontmatter is the fallback only when this param is omitted entirely";
 		}
 		return super.getDescriptionForKey(key);
 	}

--- a/src/prerna/reactor/agent/skill/Skill.java
+++ b/src/prerna/reactor/agent/skill/Skill.java
@@ -32,7 +32,9 @@ package prerna.reactor.agent.skill;
  *
  * <p>A skill is a Project of type {@code SKILL} (tagged {@code SKILL} in
  * {@code PROJECTMETA}). The Project owns the {@code SKILL.md} (stored under
- * {@code version/assets/skill/}), git-based versioning, and permissions; the
+ * {@code version/assets/public/}, or the legacy {@code version/assets/skill/}
+ * for skills created before that change), git-based versioning, and
+ * permissions; the
  * SKILL.md frontmatter is the source of truth for the skill's name and
  * description (see {@link SkillProjects}). This class holds the frontmatter
  * parse/build/strip helpers, {@link #slugify}, and the folder/file constants
@@ -51,9 +53,22 @@ public final class Skill {
 
 	/**
 	 * Subfolder under {@code <project>/version/assets/} that holds the skill
-	 * content. Mirrored by {@code SkillStager} when copying to a working dir.
+	 * content for newly-created skills, matching where the shipped platform
+	 * skill projects already keep theirs (see
+	 * {@link prerna.util.Constants#PUBLIC_ASSETS_FOLDER}) - so custom skills are
+	 * readable by users with only view (not edit) access to the skill project,
+	 * same as built-in ones. Mirrored by {@code SkillStager} when copying to a
+	 * working dir.
 	 */
-	public static final String SKILL_ASSET_SUBFOLDER = "skill";
+	public static final String SKILL_ASSET_SUBFOLDER = "public";
+
+	/**
+	 * Legacy subfolder under {@code <project>/version/assets/} used for skill
+	 * content written before it moved to {@link #SKILL_ASSET_SUBFOLDER}. Still
+	 * probed as a fallback (by {@link SkillProjects#resolveSkillDir}) so skills
+	 * created before that change keep resolving; no longer written to.
+	 */
+	public static final String LEGACY_SKILL_ASSET_SUBFOLDER = "skill";
 
 	// frontmatter keys
 	public static final String FRONTMATTER_DELIM = "---";

--- a/src/prerna/reactor/agent/skill/SkillProjects.java
+++ b/src/prerna/reactor/agent/skill/SkillProjects.java
@@ -45,26 +45,22 @@ import prerna.util.AssetUtility;
  * project's {@code SKILL.md} and are read on demand - there is no separate
  * registry table.
  *
- * <p>The skill content folder is {@code <project>/version/assets/skill/}
- * (written by {@code CreateSkillReactor}); the built-in platform skill
- * projects ship their {@code SKILL.md} under the read-only
- * {@code version/assets/public/} folder instead, so resolution probes both.
+ * <p>The skill content folder is {@code <project>/version/assets/public/}
+ * (written by {@code CreateSkillReactor}), matching where the built-in
+ * platform skill projects ship their {@code SKILL.md}; skills created before
+ * content moved to {@code public/} may still have theirs under the legacy
+ * {@code version/assets/skill/} folder instead, so resolution probes both.
  *
- * <p>{@link #resolve(String)} is best-effort and never throws: name and slug
- * always fall back (frontmatter name, then the securitydb display name, then
- * the project id) so callers can safely build responses and staging paths for
- * stale or partially-broken attachments.
+ * <p>{@link #resolve(String)} is best-effort and never throws: {@code name}
+ * and {@code slug} always fall back (frontmatter name, then the securitydb
+ * display name, then the project id), and {@code displayName} falls back in
+ * the opposite order (securitydb display name, then frontmatter name, then
+ * the project id), so callers can safely build responses and staging paths
+ * for stale or partially-broken attachments.
  */
 public final class SkillProjects {
 
 	private static final Logger logger = LogManager.getLogger(SkillProjects.class);
-
-	/**
-	 * Legacy subfolder under {@code <project>/version/assets/} where the shipped
-	 * platform skill projects keep their {@code SKILL.md} (readable by read-only
-	 * users). Probed after {@link Skill#SKILL_ASSET_SUBFOLDER}.
-	 */
-	public static final String LEGACY_SKILL_ASSET_SUBFOLDER = "public";
 
 	private SkillProjects() {}
 
@@ -74,8 +70,20 @@ public final class SkillProjects {
 	public static final class SkillInfo {
 		/** Project id (== skill id). Never null. */
 		public final String projectId;
-		/** Display name: frontmatter name, else display name, else project id. Never null. */
+		/**
+		 * Canonical, immutable content identity: frontmatter name, else display name,
+		 * else project id. This is what {@link UpdateSkillReactor} anchors its
+		 * name-immutability guard and frontmatter rewrite to, and what {@link #slug}
+		 * is derived from. Never null.
+		 */
 		public final String name;
+		/**
+		 * The project's own stored name (what the creator supplied at creation time),
+		 * else frontmatter name, else project id - for user-facing listings where the
+		 * caller's chosen name should be shown even if it differs from the content's
+		 * own declared {@code name:}. Never null.
+		 */
+		public final String displayName;
 		/** Frontmatter description, or null when absent/unreadable. */
 		public final String description;
 		/** Filesystem-safe folder name derived from {@link #name}. Never null. */
@@ -85,9 +93,11 @@ public final class SkillProjects {
 		/** True when the SKILL.md frontmatter was actually read. */
 		public final boolean found;
 
-		SkillInfo(String projectId, String name, String description, String slug, Path skillDir, boolean found) {
+		SkillInfo(String projectId, String name, String displayName, String description, String slug, Path skillDir,
+				boolean found) {
 			this.projectId = projectId;
 			this.name = name;
+			this.displayName = displayName;
 			this.description = description;
 			this.slug = slug;
 			this.skillDir = skillDir;
@@ -130,14 +140,15 @@ public final class SkillProjects {
 		}
 
 		String name = firstNonBlank(fm.name, displayNameQuiet(projectId), projectId);
+		String displayName = firstNonBlank(displayNameQuiet(projectId), fm.name, projectId);
 		String description = (fm.description == null || fm.description.isEmpty()) ? null : fm.description;
 		String slug = Skill.slugify(name);
-		return new SkillInfo(projectId, name, description, slug, skillDir, found);
+		return new SkillInfo(projectId, name, displayName, description, slug, skillDir, found);
 	}
 
 	/**
 	 * Returns the directory holding the project's {@code SKILL.md} - the
-	 * {@code skill/} assets subfolder, else the legacy {@code public/} subfolder -
+	 * {@code public/} assets subfolder, else the legacy {@code skill/} subfolder -
 	 * or null when the project cannot be resolved or neither folder has a
 	 * {@code SKILL.md}.
 	 */
@@ -159,7 +170,7 @@ public final class SkillProjects {
 		if (Files.isRegularFile(primary.resolve(Skill.SKILL_FILE))) {
 			return primary;
 		}
-		Path legacy = Paths.get(assetsFolder, LEGACY_SKILL_ASSET_SUBFOLDER);
+		Path legacy = Paths.get(assetsFolder, Skill.LEGACY_SKILL_ASSET_SUBFOLDER);
 		if (Files.isRegularFile(legacy.resolve(Skill.SKILL_FILE))) {
 			return legacy;
 		}

--- a/src/prerna/reactor/agent/skill/SkillStager.java
+++ b/src/prerna/reactor/agent/skill/SkillStager.java
@@ -53,8 +53,8 @@ import org.json.JSONObject;
  * <ol>
  *   <li>Resolves the skill project's identity and content folder via
  *       {@link SkillProjects#resolve} (SKILL.md frontmatter under the
- *       project's {@code version/assets/skill/} or legacy
- *       {@code version/assets/public/} folder).</li>
+ *       project's {@code version/assets/public/} or legacy
+ *       {@code version/assets/skill/} folder).</li>
  *   <li>Checks the existing {@code .skill-meta} sidecar at
  *       {@code <workingDir>/.claude/skills/<slug>/.skill-meta}. If the source
  *       folder's last-modified time matches what we previously staged, the


### PR DESCRIPTION
## Summary

Two related fixes to the `CreateSkill` / skill-project flow in `prerna.reactor.agent.skill`:

1. **Fixes a false "Project name already exists" error** when creating a skill whose content (YAML frontmatter) is identical to an existing skill's, even when a distinct project `name` is supplied.
2. **Moves newly-created skill content from `version/assets/skill/` to `version/assets/public/`**, matching where the built-in platform skills already ship theirs, so custom skills get the same view-only readability as built-in ones.

## Problem

Calling `CreateSkill` with a unique `name` param (e.g. `"obsidian 2"`) but `skillContent` whose frontmatter already declares `name: obsidian` (identical to a previously-created skill) failed with:

```
Failed to create skill: Project name already exists. Please provide a unique project name
```

### Root cause

`CreateSkillReactor` resolved the project's name via `firstNonEmpty(fm.name, nameInput)` — the frontmatter's `name:` field always won over the caller-supplied `name` pixel parameter whenever the content had a frontmatter block at all. That resolved value was passed straight into `ProjectHelper.createSkillProject(skillId, name, ...)` → `SmssUtilities.validateProject` → `AbstractSecurityUtils.containsProjectName(projectName)`, which does an **exact-string uniqueness check** against `PROJECT.PROJECTNAME`. Two callers pasting the same standard/public skill content (same frontmatter `name:`) would collide even though each supplied a distinct `name` param — the param was silently discarded.

This was the reactor's documented, intentional behavior ("frontmatter wins when both are supplied"), designed for callers who paste complete `SKILL.md` content without filling in the `name`/`description` params. But it broke the equally valid case of registering the *same* known skill content under a second, disambiguating project name.

**Verified safe to change:** skill invocation/discovery (`SkillScanner`, `SkillStager`) and the other skill reactors key everything off the project id and a derived slug — nothing assumes `PROJECT.PROJECTNAME` equals the frontmatter name.

**One real interaction found and handled:** `UpdateSkillReactor` resolves `SkillProjects.resolve(skillId).name` as a `canonicalName` anchor — it **rejects** any content update whose new frontmatter `name:` disagrees with that anchor ("Skill name is immutable..."), and re-synthesizes the file's frontmatter from that same anchor on every write. Blindly flipping `SkillProjects.resolve()`'s `name` resolution to prefer the caller-supplied name would have made re-submitting the *same* unchanged upstream content for an "obsidian 2"-style project permanently trip that guard. So `SkillInfo.name` (the canonical/immutable content identity used by Update) was left frontmatter-first, untouched — a separate `displayName` field was added instead for the one place that wants the project's own label.

## Changes

### `prerna/reactor/agent/skill/CreateSkillReactor.java`
- Flipped precedence: explicit `name`/`description` pixel params now win over frontmatter; frontmatter is only used as a fallback when a param is omitted entirely (`firstNonEmpty(nameInput, fm.name)` / `firstNonEmpty(descInput, fm.description)`).
- File-write behavior is unchanged — pasted custom frontmatter in `SKILL.md` is still written verbatim, never overwritten at create time. Only what's stored as the *project's* identity/description changed.
- Updated class javadoc and `getDescriptionForKey` text to match the new precedence, and to reflect the new `public/` write location (see below).

### `prerna/reactor/agent/skill/SkillProjects.java`
- Added a `displayName` field to `SkillInfo`, resolved DB-name-first (`firstNonBlank(displayNameQuiet(projectId), fm.name, projectId)`), for user-facing listings.
- Left the existing `name` field's frontmatter-first resolution untouched — it remains the canonical/immutable content identity that `UpdateSkillReactor`'s guard and slug generation depend on.
- `resolveSkillDir()` now probes `public/` first, falling back to the legacy `skill/` folder — see folder-move section below.

### `prerna/engine/impl/model/inferencetracking/reactors/workspaces/GetWorkspaceReactor.java`
- Workspace/skill listings now show `info.displayName` instead of `info.name`, so a skill created as "obsidian 2" actually displays as "obsidian 2" rather than the shared frontmatter name "obsidian".

### `prerna/reactor/agent/skill/Skill.java`
- `SKILL_ASSET_SUBFOLDER` now points at `"public"` instead of `"skill"` — new skill content is written to `<project>/version/assets/public/`.
- Added `LEGACY_SKILL_ASSET_SUBFOLDER = "skill"` for backward compatibility with skills created before this change.
- `CreateSkillReactor`, `CloneSkillReactor`, and `UpdateSkillReactor`'s missing-file repair path all write via this constant already, so no code changes were needed there — only the constant's value moved.

### `prerna/reactor/agent/skill/SkillStager.java`
- Doc comment updated to reflect the new primary/legacy folder order (`public/` primary, `skill/` legacy fallback).

## Consequence to be aware of

`public/` is a recognized, project-wide permission tier (`Constants.PUBLIC_ASSETS_FOLDER`) — per `FileSystemUtil.browseFileSystem` and `CopyAppAssetsToInsightReactor`, users with only **view** (not edit) access to a project are restricted to browsing/reading just that folder. This change means newly-created custom skills are now readable by view-only project members too, matching the built-in platform skills' visibility. Previously, custom skill content under `skill/` was only reachable via skill-specific reactors, not the generic asset browser/copy endpoints.

Existing skills already written under the old `skill/` folder are unaffected — `SkillProjects.resolveSkillDir()` still probes that folder as a fallback, so nothing breaks for previously-created content.

