### PR TITLE
feat(faiss): best-effort per-file embedding statuses

### DIFF
--- a/py/vector_database/faiss/faiss_client.py
+++ b/py/vector_database/faiss/faiss_client.py
@@ -891,105 +891,83 @@ class FAISSSearcher:
             "createdDocuments": [],
         }
 
-        # loop through and embed new docs
+        # Embed each input CSV in one call, then preserve the existing per-Source
+        # dataset/vector artifacts used by removal and master-index rebuilding.
         for document in documentFileLocation:
-            # Create the DataFrame for every file
             dataset = self._load_dataset(dataset_location=document)
-
-            # Change the unit of work
-            # From being the document
-            # To the individual source inside the document
             sources = dataset["Source"].unique().tolist()
+            directory = os.path.dirname(document)
+            effective_columns = (
+                list(dataset.columns)
+                if columns_to_index is None or len(columns_to_index) == 0
+                else columns_to_index
+            )
+            keyword_params = dict(keyword_search_params or {})
+            keyword_search = keyword_params.pop("keywordSearch", None) is True
+            prepared_sources = []
+
             for source_name in sources:
                 source_dataset = dataset[dataset["Source"] == source_name].reset_index(
                     drop=True
                 )
-
-                # Get the directory path and the base filename without extension
-                directory, base_filename = os.path.split(document)
-                dataset_extension = ".parquet"
-                vector_extension = ".npy"
-
-                if columns_to_index == None or len(columns_to_index) == 0:
-                    columns_to_index = list(source_dataset.columns)
-
-                # save the dataset, this is for efficiency after removing docs
-                new_file_path = os.path.join(
-                    directory, source_name + "_dataset" + dataset_extension
+                if len(source_dataset) == 0:
+                    continue
+                parts = source_dataset[effective_columns].astype(str)
+                source_dataset[target_column] = parts.apply(
+                    lambda row: separator.join(row) + separator, axis=1
                 )
-
-                # if applicable, create the concatenated columns
-                if len(source_dataset) > 0:
-                    # vectorized equivalent of mapping `_concatenate_columns`: build a
-                    # target_column whose value for each row is
-                    # `<v0><sep><v1><sep>...<vn-1><sep>` (note trailing separator,
-                    # preserved for parity with the previous Dataset.map behavior).
-                    parts = source_dataset[columns_to_index].astype(str)
-                    source_dataset[target_column] = parts.apply(
-                        lambda row: separator.join(row) + separator, axis=1
-                    )
-
-                    # transform chunks into keywords
-                    if (
-                        keyword_search_params != None
-                        and keyword_search_params.pop("keywordSearch", None) is True
-                    ):
-                        keywords_for_target_col = (
-                            self.keyword_engine.keyword_extraction(
-                                input=list(source_dataset[target_column]),
-                                insight_id=insight_id,
-                                param_dict=keyword_search_params,
-                            )
+                if keyword_search:
+                    source_dataset[target_column] = (
+                        self.keyword_engine.keyword_extraction(
+                            input=list(source_dataset[target_column]),
+                            insight_id=insight_id,
+                            param_dict=keyword_params,
                         )
-                        source_dataset[target_column] = keywords_for_target_col
-
-                    # get the embeddings for the document
-                    vectors = self.embeddings_engine.embeddings(
-                        strings_to_embed=list(source_dataset[target_column]),
-                        insight_id=insight_id,
                     )
-                    vectors = np.array(vectors[0]["response"], dtype=np.float32)
-                    assert vectors.ndim == 2
-
-                    columns_to_remove.append(target_column)
-                    columns_to_drop = list(
-                        set(columns_to_remove).intersection(set(source_dataset.columns))
+                    vectors = self._embed_and_validate(
+                        list(source_dataset[target_column]), insight_id
                     )
-                    source_dataset = source_dataset.drop(columns=columns_to_drop)
-
-                    # Keep per-source files dtype-consistent so subsequent
-                    # `_validateEmbeddingFiles` concatenations don't produce
-                    # mixed-type columns that fail pyarrow serialization.
-                    self._enforce_canonical_schema(source_dataset)
-                    source_dataset.to_parquet(new_file_path, index=False)
-
-                    # add the created source_dataset file path
-                    createDocumentsResponse["createdDocuments"].append(new_file_path)
-
-                    # normalize the vectors if using huggingface
-                    if type(self.tokenizer).__name__ == "HuggingfaceTokenizer":
-                        faiss.normalize_L2(vectors)
-
-                    # write out the vectors as a .npy file (no pickle)
-                    new_file_path = os.path.join(
-                        directory,
-                        source_name + "_vectors" + vector_extension,
-                    )
-                    np.save(new_file_path, vectors, allow_pickle=False)
-
-                    # add the created embeddings file path
-                    createDocumentsResponse["createdDocuments"].append(new_file_path)
-
-                    # TODO need to update the flow for how we instatiate
-                    if self.encoded_vectors is None:
-                        self.encoded_vectors = np.copy(vectors)
-                        self.vector_dimensions = self.encoded_vectors.shape
-                    else:
-                        # make sure the dimensions are the same
-                        assert self.vector_dimensions[1] == vectors.shape[1]
-                        self.encoded_vectors = np.concatenate(
-                            [self.encoded_vectors, vectors], axis=0
+                    createDocumentsResponse["createdDocuments"].extend(
+                        self._persist_source_artifacts(
+                            directory,
+                            source_name,
+                            source_dataset,
+                            vectors,
+                            columns_to_remove,
+                            target_column,
                         )
+                    )
+                    self._append_vectors(vectors)
+                else:
+                    prepared_sources.append((source_name, source_dataset))
+
+            if prepared_sources:
+                all_text = [
+                    value
+                    for _source_name, source_dataset in prepared_sources
+                    for value in source_dataset[target_column].tolist()
+                ]
+                all_vectors = self._embed_and_validate(all_text, insight_id)
+                offset = 0
+                for source_name, source_dataset in prepared_sources:
+                    source_rows = len(source_dataset)
+                    source_vectors = all_vectors[offset : offset + source_rows]
+                    offset += source_rows
+                    createDocumentsResponse["createdDocuments"].extend(
+                        self._persist_source_artifacts(
+                            directory,
+                            source_name,
+                            source_dataset,
+                            source_vectors,
+                            columns_to_remove,
+                            target_column,
+                        )
+                    )
+                if offset != len(all_vectors):
+                    raise ValueError(
+                        "Embedding rows could not be assigned to their Sources"
+                    )
+                self._append_vectors(all_vectors)
 
         master_indexClass_files, corrupted_file_sets = self.createMasterFiles(
             path_to_files=os.path.dirname(os.path.dirname(documentFileLocation[0]))
@@ -1002,6 +980,82 @@ class FAISSSearcher:
         createDocumentsResponse["createdDocuments"].extend(master_indexClass_files)
 
         return createDocumentsResponse
+
+    def _embed_and_validate(
+        self, strings_to_embed: List[str], insight_id: Optional[str]
+    ) -> np.ndarray:
+        """Embed one bounded CSV batch and validate it before writing artifacts."""
+        response = self.embeddings_engine.embeddings(
+            strings_to_embed=strings_to_embed,
+            insight_id=insight_id,
+        )
+        try:
+            vectors = np.asarray(response[0]["response"], dtype=np.float32)
+        except (IndexError, KeyError, TypeError, ValueError) as error:
+            raise ValueError(
+                "Embedding response does not contain a numeric response matrix"
+            ) from error
+        if (
+            vectors.ndim != 2
+            or vectors.shape[0] != len(strings_to_embed)
+            or vectors.shape[1] == 0
+        ):
+            raise ValueError(
+                "Embedding response shape does not match the submitted rows: "
+                f"expected {len(strings_to_embed)} rows, received {vectors.shape}"
+            )
+        if (
+            self.vector_dimensions is not None
+            and self.vector_dimensions[1] != vectors.shape[1]
+        ):
+            raise ValueError(
+                "Embedding dimensions do not match the existing FAISS index: "
+                f"expected {self.vector_dimensions[1]}, received {vectors.shape[1]}"
+            )
+        if type(self.tokenizer).__name__ == "HuggingfaceTokenizer":
+            faiss.normalize_L2(vectors)
+        return vectors
+
+    def _persist_source_artifacts(
+        self,
+        directory: str,
+        source_name: str,
+        source_dataset: pd.DataFrame,
+        vectors: np.ndarray,
+        columns_to_remove: Optional[List[str]],
+        target_column: str,
+    ) -> List[str]:
+        """Write the stable dataset and vector pair for one Source."""
+        if len(source_dataset) != len(vectors):
+            raise ValueError(
+                f"Source {source_name} has {len(source_dataset)} rows but {len(vectors)} vectors"
+            )
+        columns_to_drop = list(
+            set([*(columns_to_remove or []), target_column]).intersection(
+                set(source_dataset.columns)
+            )
+        )
+        stored_dataset = source_dataset.drop(columns=columns_to_drop)
+        self._enforce_canonical_schema(stored_dataset)
+        dataset_path = os.path.join(directory, source_name + "_dataset.parquet")
+        vector_path = os.path.join(directory, source_name + "_vectors.npy")
+        stored_dataset.to_parquet(dataset_path, index=False)
+        np.save(vector_path, vectors, allow_pickle=False)
+        return [dataset_path, vector_path]
+
+    def _append_vectors(self, vectors: np.ndarray) -> None:
+        """Maintain the in-memory vector shape until master files are rebuilt."""
+        if self.encoded_vectors is None:
+            self.encoded_vectors = np.copy(vectors)
+            self.vector_dimensions = self.encoded_vectors.shape
+            return
+        if self.vector_dimensions[1] != vectors.shape[1]:
+            raise ValueError(
+                "Embedding dimensions do not match the existing FAISS index: "
+                f"expected {self.vector_dimensions[1]}, received {vectors.shape[1]}"
+            )
+        self.encoded_vectors = np.concatenate([self.encoded_vectors, vectors], axis=0)
+        self.vector_dimensions = self.encoded_vectors.shape
 
     def createMasterFiles(self, path_to_files: str) -> Tuple[str]:
         """

--- a/py/vector_database/faiss/faiss_client.py
+++ b/py/vector_database/faiss/faiss_client.py
@@ -879,7 +879,11 @@ class FAISSSearcher:
             The unique identifier of the insight from which the call is being made
 
         Returns:
-            `Dict` A dictionary listing which documents have been successfully created
+            `Dict` with `createdDocuments` (artifact paths written) and `documentStatuses`
+            (one SUCCESS/PARTIAL/FAILED entry per input CSV, in input order, with
+            insertedRecords/failedRecords/totalRecords and an error message on failure).
+            Embedding is best-effort: a document that fails is reported FAILED and rolled
+            back while the remaining documents are still processed.
         """
         # make sure they are all in indexed_files dir
         assert {
@@ -887,87 +891,145 @@ class FAISSSearcher:
         } == {"indexed_files"}
 
         # create a list of the documents created so that we can push the files back to the cloud
+        # documentStatuses reports one SUCCESS/PARTIAL/FAILED entry per input CSV so a
+        # single bad document no longer fails the whole batch (best-effort embedding)
         createDocumentsResponse = {
             "createdDocuments": [],
+            "documentStatuses": [],
         }
+        # per-document [(artifact_paths, rows)] aligned with documentStatuses
+        per_document_artifacts = []
 
         # Embed each input CSV in one call, then preserve the existing per-Source
         # dataset/vector artifacts used by removal and master-index rebuilding.
         for document in documentFileLocation:
-            dataset = self._load_dataset(dataset_location=document)
-            sources = dataset["Source"].unique().tolist()
-            directory = os.path.dirname(document)
-            effective_columns = (
-                list(dataset.columns)
-                if columns_to_index is None or len(columns_to_index) == 0
-                else columns_to_index
+            file_name = os.path.basename(document)
+            # _append_vectors always rebinds to new arrays, so holding the previous
+            # references is a complete rollback for a failed document
+            snapshot_vectors = self.encoded_vectors
+            snapshot_dimensions = self.vector_dimensions
+            created_artifacts = []
+            total_rows = 0
+            try:
+                dataset = self._load_dataset(dataset_location=document)
+                total_rows = len(dataset)
+                sources = dataset["Source"].unique().tolist()
+                directory = os.path.dirname(document)
+                effective_columns = (
+                    list(dataset.columns)
+                    if columns_to_index is None or len(columns_to_index) == 0
+                    else columns_to_index
+                )
+                keyword_params = dict(keyword_search_params or {})
+                keyword_search = keyword_params.pop("keywordSearch", None) is True
+                prepared_sources = []
+
+                for source_name in sources:
+                    source_dataset = dataset[
+                        dataset["Source"] == source_name
+                    ].reset_index(drop=True)
+                    if len(source_dataset) == 0:
+                        continue
+                    parts = source_dataset[effective_columns].astype(str)
+                    source_dataset[target_column] = parts.apply(
+                        lambda row: separator.join(row) + separator, axis=1
+                    )
+                    if keyword_search:
+                        source_dataset[target_column] = (
+                            self.keyword_engine.keyword_extraction(
+                                input=list(source_dataset[target_column]),
+                                insight_id=insight_id,
+                                param_dict=keyword_params,
+                            )
+                        )
+                        vectors = self._embed_and_validate(
+                            list(source_dataset[target_column]), insight_id
+                        )
+                        created_artifacts.append(
+                            (
+                                self._persist_source_artifacts(
+                                    directory,
+                                    source_name,
+                                    source_dataset,
+                                    vectors,
+                                    columns_to_remove,
+                                    target_column,
+                                ),
+                                len(source_dataset),
+                            )
+                        )
+                        self._append_vectors(vectors)
+                    else:
+                        prepared_sources.append((source_name, source_dataset))
+
+                if prepared_sources:
+                    all_text = [
+                        value
+                        for _source_name, source_dataset in prepared_sources
+                        for value in source_dataset[target_column].tolist()
+                    ]
+                    all_vectors = self._embed_and_validate(all_text, insight_id)
+                    offset = 0
+                    for source_name, source_dataset in prepared_sources:
+                        source_rows = len(source_dataset)
+                        source_vectors = all_vectors[offset : offset + source_rows]
+                        offset += source_rows
+                        created_artifacts.append(
+                            (
+                                self._persist_source_artifacts(
+                                    directory,
+                                    source_name,
+                                    source_dataset,
+                                    source_vectors,
+                                    columns_to_remove,
+                                    target_column,
+                                ),
+                                source_rows,
+                            )
+                        )
+                    if offset != len(all_vectors):
+                        raise ValueError(
+                            "Embedding rows could not be assigned to their Sources"
+                        )
+                    self._append_vectors(all_vectors)
+            except Exception as error:
+                self.class_logger.exception(
+                    "Embedding failed for document %s", document
+                )
+                for artifact_paths, _rows in created_artifacts:
+                    for artifact_path in artifact_paths:
+                        try:
+                            os.remove(artifact_path)
+                        except OSError:
+                            pass
+                self.encoded_vectors = snapshot_vectors
+                self.vector_dimensions = snapshot_dimensions
+                per_document_artifacts.append([])
+                createDocumentsResponse["documentStatuses"].append(
+                    {
+                        "fileName": file_name,
+                        "status": "FAILED",
+                        "insertedRecords": 0,
+                        "failedRecords": total_rows,
+                        "totalRecords": total_rows,
+                        "error": str(error),
+                    }
+                )
+                continue
+
+            inserted_rows = sum(rows for _paths, rows in created_artifacts)
+            for artifact_paths, _rows in created_artifacts:
+                createDocumentsResponse["createdDocuments"].extend(artifact_paths)
+            per_document_artifacts.append(created_artifacts)
+            createDocumentsResponse["documentStatuses"].append(
+                {
+                    "fileName": file_name,
+                    "status": "SUCCESS",
+                    "insertedRecords": inserted_rows,
+                    "failedRecords": total_rows - inserted_rows,
+                    "totalRecords": total_rows,
+                }
             )
-            keyword_params = dict(keyword_search_params or {})
-            keyword_search = keyword_params.pop("keywordSearch", None) is True
-            prepared_sources = []
-
-            for source_name in sources:
-                source_dataset = dataset[dataset["Source"] == source_name].reset_index(
-                    drop=True
-                )
-                if len(source_dataset) == 0:
-                    continue
-                parts = source_dataset[effective_columns].astype(str)
-                source_dataset[target_column] = parts.apply(
-                    lambda row: separator.join(row) + separator, axis=1
-                )
-                if keyword_search:
-                    source_dataset[target_column] = (
-                        self.keyword_engine.keyword_extraction(
-                            input=list(source_dataset[target_column]),
-                            insight_id=insight_id,
-                            param_dict=keyword_params,
-                        )
-                    )
-                    vectors = self._embed_and_validate(
-                        list(source_dataset[target_column]), insight_id
-                    )
-                    createDocumentsResponse["createdDocuments"].extend(
-                        self._persist_source_artifacts(
-                            directory,
-                            source_name,
-                            source_dataset,
-                            vectors,
-                            columns_to_remove,
-                            target_column,
-                        )
-                    )
-                    self._append_vectors(vectors)
-                else:
-                    prepared_sources.append((source_name, source_dataset))
-
-            if prepared_sources:
-                all_text = [
-                    value
-                    for _source_name, source_dataset in prepared_sources
-                    for value in source_dataset[target_column].tolist()
-                ]
-                all_vectors = self._embed_and_validate(all_text, insight_id)
-                offset = 0
-                for source_name, source_dataset in prepared_sources:
-                    source_rows = len(source_dataset)
-                    source_vectors = all_vectors[offset : offset + source_rows]
-                    offset += source_rows
-                    createDocumentsResponse["createdDocuments"].extend(
-                        self._persist_source_artifacts(
-                            directory,
-                            source_name,
-                            source_dataset,
-                            source_vectors,
-                            columns_to_remove,
-                            target_column,
-                        )
-                    )
-                if offset != len(all_vectors):
-                    raise ValueError(
-                        "Embedding rows could not be assigned to their Sources"
-                    )
-                self._append_vectors(all_vectors)
 
         master_indexClass_files, corrupted_file_sets = self.createMasterFiles(
             path_to_files=os.path.dirname(os.path.dirname(documentFileLocation[0]))
@@ -976,6 +1038,33 @@ class FAISSSearcher:
         for corrupted_set in corrupted_file_sets:
             for file_path in corrupted_set:
                 createDocumentsResponse["createdDocuments"].remove(file_path)
+
+        # downgrade documents whose artifacts failed post-write validation so the
+        # removal is reported instead of silently shrinking createdDocuments
+        corrupted_paths = {
+            file_path
+            for corrupted_set in corrupted_file_sets
+            for file_path in corrupted_set
+        }
+        if corrupted_paths:
+            for status, created_artifacts in zip(
+                createDocumentsResponse["documentStatuses"], per_document_artifacts
+            ):
+                lost_rows = sum(
+                    rows
+                    for artifact_paths, rows in created_artifacts
+                    if corrupted_paths.intersection(artifact_paths)
+                )
+                if status["status"] != "SUCCESS" or lost_rows == 0:
+                    continue
+                status["insertedRecords"] -= lost_rows
+                status["failedRecords"] += lost_rows
+                status["status"] = (
+                    "FAILED" if status["insertedRecords"] == 0 else "PARTIAL"
+                )
+                status["error"] = (
+                    "Source artifacts failed validation after writing and were removed"
+                )
 
         createDocumentsResponse["createdDocuments"].extend(master_indexClass_files)
 

--- a/py/vector_database/tests/test_faiss_batch_vector_csv.py
+++ b/py/vector_database/tests/test_faiss_batch_vector_csv.py
@@ -1,0 +1,202 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+import numpy as np
+import pandas as pd
+
+from vector_database.faiss.faiss_client import FAISSSearcher
+
+
+class RecordingEmbedder:
+    def __init__(self):
+        self.calls = []
+
+    def embeddings(self, *, strings_to_embed, insight_id):
+        self.calls.append((list(strings_to_embed), insight_id))
+        vectors = np.arange(len(strings_to_embed) * 3, dtype=np.float32).reshape(-1, 3)
+        return [{"response": vectors.tolist()}]
+
+
+class RecordingKeywordEngine:
+    def __init__(self):
+        self.calls = []
+
+    def keyword_extraction(self, *, input, insight_id, param_dict):
+        self.calls.append((list(input), insight_id, dict(param_dict)))
+        return [f"keywords:{value}" for value in input]
+
+
+class FaissBatchVectorCsvTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.indexed_files = (
+            Path(self.temporary_directory.name) / "schema" / "default" / "indexed_files"
+        )
+        self.indexed_files.mkdir(parents=True)
+        self.document = self.indexed_files / "batch.csv"
+        self.document.write_text("unused", encoding="utf-8")
+
+    def searcher(self, dataset, embedder=None, keyword_engine=None):
+        searcher = object.__new__(FAISSSearcher)
+        searcher.embeddings_engine = embedder or RecordingEmbedder()
+        searcher.keyword_engine = keyword_engine or RecordingKeywordEngine()
+        searcher.tokenizer = object()
+        searcher.encoded_vectors = None
+        searcher.vector_dimensions = None
+        searcher._load_dataset = Mock(return_value=dataset.copy())
+        searcher.createMasterFiles = Mock(
+            return_value=(
+                [
+                    str(self.indexed_files.parent / "vectors.npy"),
+                    str(self.indexed_files.parent / "dataset.parquet"),
+                ],
+                [],
+            )
+        )
+        return searcher
+
+    def test_embeds_one_csv_once_and_slices_stable_source_artifacts(self):
+        dataset = pd.DataFrame(
+            {
+                "Source": ["alpha.java", "alpha.java", "beta.java"],
+                "Modality": ["text", "text", "text"],
+                "Divider": ["a#L1-L1", "a#L2-L2", "b#L1-L1"],
+                "Part": [1, 2, 1],
+                "Tokens": [2, 2, 2],
+                "Content": ["alpha one", "alpha two", "beta one"],
+            }
+        )
+        embedder = RecordingEmbedder()
+        searcher = self.searcher(dataset, embedder=embedder)
+
+        response = searcher._vector_addDocument(
+            [str(self.document)],
+            ["Content"],
+            [],
+            "text",
+            "|",
+            {},
+            "insight-1",
+        )
+
+        self.assertEqual(len(embedder.calls), 1)
+        self.assertEqual(
+            embedder.calls[0],
+            (["alpha one|", "alpha two|", "beta one|"], "insight-1"),
+        )
+        alpha_vectors = np.load(
+            self.indexed_files / "alpha.java_vectors.npy", allow_pickle=False
+        )
+        beta_vectors = np.load(
+            self.indexed_files / "beta.java_vectors.npy", allow_pickle=False
+        )
+        np.testing.assert_array_equal(alpha_vectors, np.arange(6).reshape(2, 3))
+        np.testing.assert_array_equal(beta_vectors, np.arange(6, 9).reshape(1, 3))
+        self.assertTrue((self.indexed_files / "alpha.java_dataset.parquet").is_file())
+        self.assertTrue((self.indexed_files / "beta.java_dataset.parquet").is_file())
+        self.assertEqual(searcher.createMasterFiles.call_count, 1)
+        searcher.createMasterFiles.assert_called_once_with(
+            path_to_files=str(self.indexed_files.parent)
+        )
+        self.assertIn(
+            str(self.indexed_files / "alpha.java_dataset.parquet"),
+            response["createdDocuments"],
+        )
+        self.assertIn(
+            str(self.indexed_files / "alpha.java_vectors.npy"),
+            response["createdDocuments"],
+        )
+
+    def test_oversized_single_source_is_embedded_in_one_call(self):
+        row_count = 368
+        dataset = pd.DataFrame(
+            {
+                "Source": ["Parser.java"] * row_count,
+                "Content": [f"chunk {index}" for index in range(row_count)],
+            }
+        )
+        embedder = RecordingEmbedder()
+        searcher = self.searcher(dataset, embedder=embedder)
+
+        searcher._vector_addDocument(
+            [str(self.document)], ["Content"], [], "text", "|", {}, "insight-1"
+        )
+
+        self.assertEqual(len(embedder.calls), 1)
+        self.assertEqual(len(embedder.calls[0][0]), row_count)
+        vectors = np.load(
+            self.indexed_files / "Parser.java_vectors.npy", allow_pickle=False
+        )
+        self.assertEqual(vectors.shape, (row_count, 3))
+
+    def test_invalid_embedding_row_count_writes_no_source_artifacts(self):
+        class ShortEmbedder:
+            def embeddings(self, *, strings_to_embed, insight_id):
+                del insight_id
+                return [{"response": [[1.0, 2.0]] * (len(strings_to_embed) - 1)}]
+
+        dataset = pd.DataFrame(
+            {"Source": ["alpha.java", "beta.java"], "Content": ["alpha", "beta"]}
+        )
+        searcher = self.searcher(dataset, embedder=ShortEmbedder())
+
+        with self.assertRaisesRegex(ValueError, "shape does not match"):
+            searcher._vector_addDocument(
+                [str(self.document)], ["Content"], [], "text", "|", {}, "insight-1"
+            )
+
+        self.assertEqual(list(self.indexed_files.glob("*_dataset.parquet")), [])
+        self.assertEqual(list(self.indexed_files.glob("*_vectors.npy")), [])
+        searcher.createMasterFiles.assert_not_called()
+
+    def test_keyword_search_remains_a_per_source_fallback(self):
+        dataset = pd.DataFrame(
+            {
+                "Source": ["alpha.java", "alpha.java", "beta.java"],
+                "Content": ["alpha one", "alpha two", "beta one"],
+            }
+        )
+        embedder = RecordingEmbedder()
+        keyword_engine = RecordingKeywordEngine()
+        searcher = self.searcher(
+            dataset, embedder=embedder, keyword_engine=keyword_engine
+        )
+
+        searcher._vector_addDocument(
+            [str(self.document)],
+            ["Content"],
+            [],
+            "text",
+            "|",
+            {"keywordSearch": True, "limit": 4},
+            "insight-1",
+        )
+
+        self.assertEqual(len(keyword_engine.calls), 2)
+        self.assertEqual(len(embedder.calls), 2)
+        self.assertEqual(keyword_engine.calls[0][2], {"limit": 4})
+        self.assertEqual(keyword_engine.calls[1][2], {"limit": 4})
+
+    def test_per_source_artifact_names_remain_removal_compatible(self):
+        dataset = pd.DataFrame({"Source": ["alpha.java"], "Content": ["alpha one"]})
+        searcher = self.searcher(dataset)
+        searcher._vector_addDocument(
+            [str(self.document)], ["Content"], [], "text", "|", {}, "insight-1"
+        )
+
+        dataset_path = self.indexed_files / "alpha.java_dataset.parquet"
+        vector_path = self.indexed_files / "alpha.java_vectors.npy"
+        self.assertTrue(dataset_path.is_file())
+        self.assertTrue(vector_path.is_file())
+        os.remove(dataset_path)
+        os.remove(vector_path)
+        self.assertFalse(dataset_path.exists())
+        self.assertFalse(vector_path.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/py/vector_database/tests/test_faiss_batch_vector_csv.py
+++ b/py/vector_database/tests/test_faiss_batch_vector_csv.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import tempfile
 import unittest
@@ -42,6 +43,7 @@ class FaissBatchVectorCsvTests(unittest.TestCase):
 
     def searcher(self, dataset, embedder=None, keyword_engine=None):
         searcher = object.__new__(FAISSSearcher)
+        searcher.class_logger = logging.getLogger(__name__)
         searcher.embeddings_engine = embedder or RecordingEmbedder()
         searcher.keyword_engine = keyword_engine or RecordingKeywordEngine()
         searcher.tokenizer = object()
@@ -133,7 +135,7 @@ class FaissBatchVectorCsvTests(unittest.TestCase):
         )
         self.assertEqual(vectors.shape, (row_count, 3))
 
-    def test_invalid_embedding_row_count_writes_no_source_artifacts(self):
+    def test_invalid_embedding_row_count_marks_document_failed(self):
         class ShortEmbedder:
             def embeddings(self, *, strings_to_embed, insight_id):
                 del insight_id
@@ -144,14 +146,16 @@ class FaissBatchVectorCsvTests(unittest.TestCase):
         )
         searcher = self.searcher(dataset, embedder=ShortEmbedder())
 
-        with self.assertRaisesRegex(ValueError, "shape does not match"):
-            searcher._vector_addDocument(
-                [str(self.document)], ["Content"], [], "text", "|", {}, "insight-1"
-            )
+        response = searcher._vector_addDocument(
+            [str(self.document)], ["Content"], [], "text", "|", {}, "insight-1"
+        )
 
+        status = response["documentStatuses"][0]
+        self.assertEqual(status["status"], "FAILED")
+        self.assertIn("shape does not match", status["error"])
         self.assertEqual(list(self.indexed_files.glob("*_dataset.parquet")), [])
         self.assertEqual(list(self.indexed_files.glob("*_vectors.npy")), [])
-        searcher.createMasterFiles.assert_not_called()
+        self.assertEqual(searcher.createMasterFiles.call_count, 1)
 
     def test_keyword_search_remains_a_per_source_fallback(self):
         dataset = pd.DataFrame(

--- a/py/vector_database/tests/test_faiss_best_effort_status.py
+++ b/py/vector_database/tests/test_faiss_best_effort_status.py
@@ -1,0 +1,241 @@
+import logging
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock
+
+import numpy as np
+import pandas as pd
+
+from vector_database.faiss.faiss_client import FAISSSearcher
+
+
+class RecordingEmbedder:
+    def __init__(self, fail_for=()):
+        self.calls = []
+        self.fail_for = set(fail_for)
+
+    def embeddings(self, *, strings_to_embed, insight_id):
+        self.calls.append((list(strings_to_embed), insight_id))
+        if self.fail_for.intersection(strings_to_embed):
+            raise RuntimeError("embedding engine rejected the request")
+        vectors = np.arange(len(strings_to_embed) * 3, dtype=np.float32).reshape(-1, 3)
+        return [{"response": vectors.tolist()}]
+
+
+class BestEffortStatusTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary_directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary_directory.cleanup)
+        self.indexed_files = (
+            Path(self.temporary_directory.name) / "schema" / "default" / "indexed_files"
+        )
+        self.indexed_files.mkdir(parents=True)
+
+    def document(self, name):
+        path = self.indexed_files / name
+        path.write_text("unused", encoding="utf-8")
+        return str(path)
+
+    def searcher(self, datasets_by_document, embedder=None, corrupted_file_sets=()):
+        searcher = object.__new__(FAISSSearcher)
+        searcher.class_logger = logging.getLogger(__name__)
+        searcher.embeddings_engine = embedder or RecordingEmbedder()
+        searcher.keyword_engine = Mock()
+        searcher.tokenizer = object()
+        searcher.encoded_vectors = None
+        searcher.vector_dimensions = None
+        searcher._load_dataset = Mock(
+            side_effect=lambda dataset_location: datasets_by_document[
+                Path(dataset_location).name
+            ].copy()
+        )
+        searcher.createMasterFiles = Mock(
+            return_value=(
+                [str(self.indexed_files.parent / "dataset.parquet")],
+                list(corrupted_file_sets),
+            )
+        )
+        return searcher
+
+    def add(self, searcher, documents):
+        return searcher._vector_addDocument(
+            documents, ["Content"], [], "text", "|", {}, "insight-1"
+        )
+
+    def test_failed_document_is_reported_and_the_rest_still_embed(self):
+        datasets = {
+            "good.csv": pd.DataFrame(
+                {"Source": ["alpha.java"], "Content": ["alpha one"]}
+            ),
+            "bad.csv": pd.DataFrame({"Source": ["beta.java"], "Content": ["boom"]}),
+        }
+        embedder = RecordingEmbedder(fail_for=["boom|"])
+        searcher = self.searcher(datasets, embedder=embedder)
+
+        response = self.add(
+            searcher, [self.document("good.csv"), self.document("bad.csv")]
+        )
+
+        self.assertEqual(
+            [status["status"] for status in response["documentStatuses"]],
+            ["SUCCESS", "FAILED"],
+        )
+        self.assertEqual(
+            [status["fileName"] for status in response["documentStatuses"]],
+            ["good.csv", "bad.csv"],
+        )
+        failed = response["documentStatuses"][1]
+        self.assertEqual(failed["insertedRecords"], 0)
+        self.assertEqual(failed["totalRecords"], 1)
+        self.assertIn("embedding engine rejected", failed["error"])
+        self.assertTrue((self.indexed_files / "alpha.java_dataset.parquet").is_file())
+        self.assertTrue((self.indexed_files / "alpha.java_vectors.npy").is_file())
+        self.assertFalse((self.indexed_files / "beta.java_dataset.parquet").exists())
+        self.assertIn(
+            str(self.indexed_files / "alpha.java_dataset.parquet"),
+            response["createdDocuments"],
+        )
+        self.assertNotIn(
+            str(self.indexed_files / "beta.java_dataset.parquet"),
+            response["createdDocuments"],
+        )
+
+    def test_failed_document_rolls_back_in_memory_vectors_and_artifacts(self):
+        datasets = {
+            "good.csv": pd.DataFrame(
+                {"Source": ["alpha.java"], "Content": ["alpha one"]}
+            ),
+            # two sources: the first embeds via the keyword-free batch path in one
+            # call, so make the whole batch fail after nothing was appended, then a
+            # keyword-free mixed failure is covered by the load failure below
+            "bad.csv": pd.DataFrame({"Source": ["beta.java"], "Content": ["boom"]}),
+        }
+        embedder = RecordingEmbedder(fail_for=["boom|"])
+        searcher = self.searcher(datasets, embedder=embedder)
+
+        self.add(searcher, [self.document("good.csv"), self.document("bad.csv")])
+
+        self.assertEqual(searcher.encoded_vectors.shape, (1, 3))
+        self.assertEqual(searcher.vector_dimensions, (1, 3))
+
+    def test_load_failure_reports_failed_with_zero_totals(self):
+        datasets = {
+            "good.csv": pd.DataFrame(
+                {"Source": ["alpha.java"], "Content": ["alpha one"]}
+            ),
+        }
+        searcher = self.searcher(datasets)
+        searcher._load_dataset = Mock(
+            side_effect=lambda dataset_location: (
+                (_ for _ in ()).throw(ValueError("unreadable csv"))
+                if Path(dataset_location).name == "bad.csv"
+                else datasets["good.csv"].copy()
+            )
+        )
+
+        response = self.add(
+            searcher, [self.document("bad.csv"), self.document("good.csv")]
+        )
+
+        self.assertEqual(
+            [status["status"] for status in response["documentStatuses"]],
+            ["FAILED", "SUCCESS"],
+        )
+        failed = response["documentStatuses"][0]
+        self.assertEqual(failed["totalRecords"], 0)
+        self.assertIn("unreadable csv", failed["error"])
+
+    def test_all_documents_succeed(self):
+        datasets = {
+            "one.csv": pd.DataFrame({"Source": ["a.java"], "Content": ["a"]}),
+            "two.csv": pd.DataFrame(
+                {"Source": ["b.java", "b.java"], "Content": ["b1", "b2"]}
+            ),
+        }
+        searcher = self.searcher(datasets)
+
+        response = self.add(
+            searcher, [self.document("one.csv"), self.document("two.csv")]
+        )
+
+        self.assertEqual(
+            response["documentStatuses"],
+            [
+                {
+                    "fileName": "one.csv",
+                    "status": "SUCCESS",
+                    "insertedRecords": 1,
+                    "failedRecords": 0,
+                    "totalRecords": 1,
+                },
+                {
+                    "fileName": "two.csv",
+                    "status": "SUCCESS",
+                    "insertedRecords": 2,
+                    "failedRecords": 0,
+                    "totalRecords": 2,
+                },
+            ],
+        )
+
+    def test_all_documents_fail_without_raising(self):
+        datasets = {
+            "bad.csv": pd.DataFrame({"Source": ["beta.java"], "Content": ["boom"]}),
+        }
+        embedder = RecordingEmbedder(fail_for=["boom|"])
+        searcher = self.searcher(datasets, embedder=embedder)
+
+        response = self.add(searcher, [self.document("bad.csv")])
+
+        self.assertEqual(
+            [status["status"] for status in response["documentStatuses"]], ["FAILED"]
+        )
+        self.assertEqual(searcher.createMasterFiles.call_count, 1)
+
+    def test_corrupted_artifacts_downgrade_document_status(self):
+        datasets = {
+            "mixed.csv": pd.DataFrame(
+                {
+                    "Source": ["alpha.java", "beta.java"],
+                    "Content": ["alpha one", "beta one"],
+                }
+            ),
+        }
+        corrupted_pair = [
+            str(self.indexed_files / "beta.java_dataset.parquet"),
+            str(self.indexed_files / "beta.java_vectors.npy"),
+        ]
+        searcher = self.searcher(datasets, corrupted_file_sets=[corrupted_pair])
+
+        response = self.add(searcher, [self.document("mixed.csv")])
+
+        status = response["documentStatuses"][0]
+        self.assertEqual(status["status"], "PARTIAL")
+        self.assertEqual(status["insertedRecords"], 1)
+        self.assertEqual(status["failedRecords"], 1)
+        self.assertIn("failed validation", status["error"])
+        for corrupted_path in corrupted_pair:
+            self.assertNotIn(corrupted_path, response["createdDocuments"])
+
+    def test_corruption_of_every_source_marks_document_failed(self):
+        datasets = {
+            "single.csv": pd.DataFrame(
+                {"Source": ["alpha.java"], "Content": ["alpha one"]}
+            ),
+        }
+        corrupted_pair = [
+            str(self.indexed_files / "alpha.java_dataset.parquet"),
+            str(self.indexed_files / "alpha.java_vectors.npy"),
+        ]
+        searcher = self.searcher(datasets, corrupted_file_sets=[corrupted_pair])
+
+        response = self.add(searcher, [self.document("single.csv")])
+
+        status = response["documentStatuses"][0]
+        self.assertEqual(status["status"], "FAILED")
+        self.assertEqual(status["insertedRecords"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/prerna/engine/impl/vector/FaissDatabaseEngine.java
+++ b/src/prerna/engine/impl/vector/FaissDatabaseEngine.java
@@ -72,6 +72,7 @@ import prerna.reactor.qs.SubQueryExpression;
 import prerna.reactor.vector.VectorDatabaseParamOptionsEnum;
 import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.util.Constants;
 import prerna.util.Utility;
 import prerna.util.sql.AbstractSqlQueryUtil;
 
@@ -307,7 +308,37 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 					filesToCopyToCloud.stream().toArray(String[]::new)));
 		}
 
-		// verify the index class loaded the dataset
+		// python reports one best-effort status per input csv - use it when present
+		Object documentStatuses = pythonResponseAfterCreatingFiles.get("documentStatuses");
+		if (documentStatuses instanceof List) {
+			List<FileEmbeddingStatus> fileStatusList = new ArrayList<>();
+			for (Object entry : (List<Object>) documentStatuses) {
+				if (!(entry instanceof Map)) {
+					continue;
+				}
+				Map<String, Object> statusMap = (Map<String, Object>) entry;
+				String file = String.valueOf(statusMap.get("fileName"));
+				String status = String.valueOf(statusMap.get("status"));
+				long totalRecords = asLong(statusMap.get("totalRecords"),
+						fileRecordCountMap.getOrDefault(file, 0));
+				long inserted = asLong(statusMap.get("insertedRecords"),
+						"SUCCESS".equals(status) ? totalRecords : 0);
+				long failed = asLong(statusMap.get("failedRecords"), totalRecords - inserted);
+
+				FileEmbeddingStatus fileStatus = new FileEmbeddingStatus(file, status, inserted, failed,
+						totalRecords);
+				Object error = statusMap.get("error");
+				if (error != null) {
+					Map<String, Object> errorMap = new HashMap<>();
+					errorMap.put(Constants.ERROR_MESSAGE, error.toString());
+					fileStatus.setError(errorMap);
+				}
+				fileStatusList.add(fileStatus);
+			}
+			return fileStatusList;
+		}
+
+		// older python runtime - fall back to the coarse index-level check
 		StringBuilder checkForEmptyDatabase = new StringBuilder();
 		checkForEmptyDatabase.append(this.vectorDatabaseSearcher).append(".searchers['").append(indexClass).append("']")
 				.append(".datasetsLoaded()");
@@ -335,6 +366,19 @@ public class FaissDatabaseEngine extends AbstractVectorDatabaseEngine {
 		}
 
 		return fileStatusList;
+	}
+
+	/**
+	 *
+	 * @param value
+	 * @param fallback
+	 * @return
+	 */
+	private static long asLong(Object value, long fallback) {
+		if (value instanceof Number) {
+			return ((Number) value).longValue();
+		}
+		return fallback;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- embed each vector CSV independently so one bad document no longer fails the whole batch
- report a per-file SUCCESS/PARTIAL/FAILED entry in a new `documentStatuses` list, with inserted/failed/total record counts and an error message on failure
- roll a failed document back fully: its already-written per-Source artifacts are deleted and the in-memory vector state is restored, so no partially-indexed data survives under a FAILED label
- downgrade a document to PARTIAL or FAILED when post-write validation removes its artifacts, instead of silently shrinking `createdDocuments`
- build real per-file `FileEmbeddingStatus` entries in `FaissDatabaseEngine` from `documentStatuses`, keeping the previous index-level `datasetsLoaded()` check as a fallback when the response omits them

## Why

#2205 made document embedding best-effort: every file is attempted and the reactor reports per-file FAILED/PARTIAL statuses. The FAISS engine bypasses that contract on its batched path — a single bad CSV raises out of Python and fails the entire batch, and when the batch completes the engine stamps every file SUCCESS or every file FAILED from one index-level boolean. Separately, artifacts that fail validation after writing are removed from `createdDocuments` without any signal to the caller. This PR extends the #2205 contract to FAISS.

## Behavior change

Per-file embedding failures in the FAISS batch path now return FAILED statuses instead of raising — the same deliberate shift #2205 made for the documents path. Batch-level guards ahead of the loop are unchanged and still raise.

## Depends on

Builds on #2759 (its first commit); only the top commit here is new. Review #2759 first.

## Verification

- 12 Python unit tests pass (7 new in `test_faiss_best_effort_status.py`; 5 in `test_faiss_batch_vector_csv.py`, of which one was updated because it asserted the old fail-fast behavior)
- `mvn compile` succeeds on the full project
- Black clean on changed files; Ruff reports only the six pre-existing diagnostics in `faiss_client.py`
