### PR TITLE
fix: Moving initialization of AbstractEmbedder engine after assigning model name to self in BedrockEmbedder class.

### DIFF
--- a/py/genai_client/embedders/bedrock_embedder.py
+++ b/py/genai_client/embedders/bedrock_embedder.py
@@ -17,16 +17,17 @@ class BedrockEmbedder(AbstractEmbedder):
         cohere_input_type: Optional[str] = None,
         **kwargs,
     ) -> None:
-        super().__init__(
-            model_name=self.model_name,
-            **kwargs,
-        )
         if model_name:
             self.model_name = model_name
         elif modelId:
             self.model_name = modelId
         else:
             raise ValueError("Either model_name or modelId must be provided")
+
+        super().__init__(
+            model_name=self.model_name,
+            **kwargs,
+        )
 
         self.access_key = access_key
         self.secret_key = secret_key


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Moving initialization of AbstractEmbedder engine after assigning model name to self in BedrockEmbedder class. 

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->