### PR TITLE
Update PostgresQueryUtil.checkIfFunctionExists to be case insensitive on function name

### DIFF
--- a/src/prerna/util/sql/PostgresQueryUtil.java
+++ b/src/prerna/util/sql/PostgresQueryUtil.java
@@ -165,7 +165,7 @@ public class PostgresQueryUtil extends AnsiSqlQueryUtil {
 				    SELECT 1
 				    FROM pg_proc p
 				    JOIN pg_namespace n ON p.pronamespace = n.oid
-				    WHERE p.proname = '<functionName>'
+				    WHERE p.proname ILIKE '<functionName>'
 				    AND n.nspname = '<schema>'
 				) AS function_exists
 				""".replace("<functionName>", functionName).replace("<schema>", schema);


### PR DESCRIPTION
PR for issue https://github.com/SEMOSS/Semoss/issues/2814

```
[ERROR] 2026-07-27 14:19:21 p.u.s.PostgresQueryUtil:114 [user=user] Error creating SMSS_DATEDIFF function
org.postgresql.util.PSQLException: ERROR: tuple concurrently updated
	at org.postgresql.core.v3.QueryExecutorImpl.receiveErrorResponse(QueryExecutorImpl.java:2734)
	at org.postgresql.core.v3.QueryExecutorImpl.processResults(QueryExecutorImpl.java:2421)
	at org.postgresql.core.v3.QueryExecutorImpl.execute(QueryExecutorImpl.java:372)
	at org.postgresql.jdbc.PgStatement.executeInternal(PgStatement.java:518)
	at org.postgresql.jdbc.PgStatement.execute(PgStatement.java:435)
```
Ended up changing the WHERE condition to use an ILIKE for case insensitive comparison, but not sure if the better solution would be to force postgres to [create the function](https://github.com/SEMOSS/Semoss/blob/2b36a652189ed8ccf96d06a5afcea2c63cc13591/src/prerna/util/sql/PostgresQueryUtil.java#L90-L91) in upper case by using double quotes i.e.:
"CREATE OR REPLACE FUNCTION "<functionname>" when defining the datediffsql string