### PR TITLE
Store parent run IDs for RunAgent subagents

### DIFF
--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsOwlCreator.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsOwlCreator.java
@@ -140,6 +140,7 @@ public class ModelInferenceLogsOwlCreator extends AbstractOwlCreator {
 
 		addTable("AGENT_RUN", Arrays.asList(
 				Pair.with("RUN_ID", VARCHAR_50),
+				Pair.with("PARENT_RUN_ID", VARCHAR_50),
 				Pair.with("ROOM_ID", VARCHAR_50),
 				Pair.with("WORKSPACE_ID", VARCHAR_255),
 				Pair.with("MODEL_ID", VARCHAR_255),

--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -242,6 +242,9 @@ public class ModelInferenceLogsUtils {
 			sql = queryUtil.createIndexIfNotExists("AGENT_RUN_ROOM_ID_INDEX", "AGENT_RUN", "ROOM_ID");
 			executeSql(conn, sql);
 
+			sql = queryUtil.createIndexIfNotExists("AGENT_RUN_PARENT_RUN_ID_INDEX", "AGENT_RUN", "PARENT_RUN_ID");
+			executeSql(conn, sql);
+
 			sql = queryUtil.createIndexIfNotExists("AGENT_RUN_ACTION_RUN_ID_INDEX", "AGENT_RUN_ACTION", "RUN_ID");
 			executeSql(conn, sql);
 			} else {
@@ -297,6 +300,11 @@ public class ModelInferenceLogsUtils {
 
 			if (!queryUtil.indexExists(engine, "AGENT_RUN_ROOM_ID_INDEX", "AGENT_RUN", database, schema)) {
 				String sql = queryUtil.createIndex("AGENT_RUN_ROOM_ID_INDEX", "AGENT_RUN", "ROOM_ID");
+				executeSql(conn, sql);
+			}
+
+			if (!queryUtil.indexExists(engine, "AGENT_RUN_PARENT_RUN_ID_INDEX", "AGENT_RUN", database, schema)) {
+				String sql = queryUtil.createIndex("AGENT_RUN_PARENT_RUN_ID_INDEX", "AGENT_RUN", "PARENT_RUN_ID");
 				executeSql(conn, sql);
 			}
 

--- a/src/prerna/reactor/agent/run/AgentRunStore.java
+++ b/src/prerna/reactor/agent/run/AgentRunStore.java
@@ -55,13 +55,14 @@ public final class AgentRunStore {
 		IRDBMSEngine db = SystemEngineRegistry.getModelInferenceLogsDb();
 		PreparedStatement ps = null;
 		try {
-			String query = "INSERT INTO AGENT_RUN (RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, HARNESS_TYPE, JOB_ID, "
+			String query = "INSERT INTO AGENT_RUN (RUN_ID, PARENT_RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, HARNESS_TYPE, JOB_ID, "
 					+ "STATUS, INPUT, REQUEST_JSON, INPUT_MESSAGE_ID, FINAL_OUTPUT, FINAL_OUTPUT_MESSAGE_ID, ERROR_MESSAGE, "
 					+ "DATE_CREATED, STARTED_AT, COMPLETED_AT, USER_ID) "
-					+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+					+ "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
 			ps = db.getPreparedStatement(query);
 			int idx = 1;
 			ps.setString(idx++, runId);
+			setNullableString(ps, idx++, request.getParentRunId());
 			setNullableString(ps, idx++, request.getRoomId());
 			setNullableString(ps, idx++, request.getWorkspaceId());
 			setNullableString(ps, idx++, request.getEngineIdFallback());
@@ -93,7 +94,7 @@ public final class AgentRunStore {
 		ResultSet rs = null;
 		try {
 			String userId = resolveInsightUserId(insight);
-			String query = "SELECT RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, HARNESS_TYPE, STATUS, INPUT, REQUEST_JSON, "
+			String query = "SELECT RUN_ID, PARENT_RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, HARNESS_TYPE, STATUS, INPUT, REQUEST_JSON, "
 					+ "USER_ID, JOB_ID FROM AGENT_RUN WHERE RUN_ID = ? AND USER_ID = ?";
 			ps = db.getPreparedStatement(query);
 			ps.setString(1, runId);
@@ -121,7 +122,7 @@ public final class AgentRunStore {
 		ResultSet rs = null;
 		try {
 			String userId = resolveInsightUserId(insight);
-			String query = "SELECT RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, HARNESS_TYPE, JOB_ID, STATUS, INPUT, "
+			String query = "SELECT RUN_ID, PARENT_RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, HARNESS_TYPE, JOB_ID, STATUS, INPUT, "
 					+ "REQUEST_JSON, INPUT_MESSAGE_ID, FINAL_OUTPUT, FINAL_OUTPUT_MESSAGE_ID, ERROR_MESSAGE, "
 					+ "DATE_CREATED, STARTED_AT, COMPLETED_AT, USER_ID FROM AGENT_RUN WHERE RUN_ID = ? AND USER_ID = ?";
 			ps = db.getPreparedStatement(query);
@@ -133,6 +134,7 @@ public final class AgentRunStore {
 			}
 			Map<String, Object> map = new java.util.HashMap<>();
 			map.put("runId", rs.getString("RUN_ID"));
+			map.put("parentRunId", rs.getString("PARENT_RUN_ID"));
 			map.put("roomId", rs.getString("ROOM_ID"));
 			map.put("workspaceId", rs.getString("WORKSPACE_ID"));
 			map.put("modelId", rs.getString("MODEL_ID"));
@@ -182,7 +184,7 @@ public final class AgentRunStore {
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 		try {
-			String query = "SELECT RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, HARNESS_TYPE, STATUS, INPUT, REQUEST_JSON, "
+			String query = "SELECT RUN_ID, PARENT_RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, HARNESS_TYPE, STATUS, INPUT, REQUEST_JSON, "
 					+ "USER_ID, JOB_ID FROM AGENT_RUN WHERE STATUS = ? ORDER BY DATE_CREATED ASC, RUN_ID ASC";
 			ps = db.getPreparedStatement(query);
 			ps.setString(1, AgentRunStatus.SUBMITTED.name());
@@ -426,12 +428,16 @@ public final class AgentRunStore {
 			Map<String, Object> persisted = GSON.fromJson(requestJson, Map.class);
 			RunAgentRequest request = RunAgentRequest.fromPersistedMap(persisted, insight);
 			if (request != null) {
-				return request;
+				String parentRunId = rs.getString("PARENT_RUN_ID");
+				return request.getParentRunId() == null && parentRunId != null
+						? request.withParentRunId(parentRunId)
+						: request;
 			}
 		}
 		return new RunAgentRequest(rs.getString("ROOM_ID"), rs.getString("INPUT"), rs.getString("MODEL_ID"),
 				rs.getString("HARNESS_TYPE"), rs.getString("WORKSPACE_ID"), AgentRunContext.DEFAULT_MAX_TURNS,
-				AgentRunContext.DEFAULT_MAX_REFLECTIONS, null, null, null, null, insight);
+				AgentRunContext.DEFAULT_MAX_REFLECTIONS, null, null, null, null, insight)
+				.withParentRunId(rs.getString("PARENT_RUN_ID"));
 	}
 
 	private static AgentRunStatus parseRunStatus(String value) {

--- a/src/prerna/reactor/agent/run/RunAgentRequest.java
+++ b/src/prerna/reactor/agent/run/RunAgentRequest.java
@@ -40,6 +40,7 @@ import prerna.reactor.agent.AgentRunner;
 public final class RunAgentRequest {
 
 	private final String roomId;
+	private final String parentRunId;
 	private final String input;
 	private final String engineIdFallback;
 	private final String harnessType;
@@ -57,14 +58,23 @@ public final class RunAgentRequest {
 			String workspaceId, int maxTurns, int maxReflections, Map<String, Object> paramMap,
 			Map<String, Object> agentParamMap, List<String> mediaInputPaths, List<String> mediaUrls, Insight insight) {
 		this(roomId, input, engineIdFallback, harnessType, workspaceId, maxTurns, maxReflections, paramMap,
-				agentParamMap, mediaInputPaths, mediaUrls, insight, false);
+				agentParamMap, mediaInputPaths, mediaUrls, insight, false, null);
 	}
 
 	public RunAgentRequest(String roomId, String input, String engineIdFallback, String harnessType,
 			String workspaceId, int maxTurns, int maxReflections, Map<String, Object> paramMap,
 			Map<String, Object> agentParamMap, List<String> mediaInputPaths, List<String> mediaUrls, Insight insight,
 			boolean resumeMode) {
+		this(roomId, input, engineIdFallback, harnessType, workspaceId, maxTurns, maxReflections, paramMap,
+				agentParamMap, mediaInputPaths, mediaUrls, insight, resumeMode, null);
+	}
+
+	private RunAgentRequest(String roomId, String input, String engineIdFallback, String harnessType,
+			String workspaceId, int maxTurns, int maxReflections, Map<String, Object> paramMap,
+			Map<String, Object> agentParamMap, List<String> mediaInputPaths, List<String> mediaUrls, Insight insight,
+			boolean resumeMode, String parentRunId) {
 		this.roomId = roomId;
+		this.parentRunId = trimmedStringValue(parentRunId);
 		this.input = input;
 		this.engineIdFallback = engineIdFallback;
 		this.harnessType = harnessType;
@@ -91,6 +101,19 @@ public final class RunAgentRequest {
 
 	public String getRoomId() {
 		return roomId;
+	}
+
+	public String getParentRunId() {
+		return parentRunId;
+	}
+
+	/**
+	 * Returns an immutable copy associated with the durable run that spawned it.
+	 * Root runs use the original request and therefore retain a {@code null} parent.
+	 */
+	public RunAgentRequest withParentRunId(String parentRunId) {
+		return new RunAgentRequest(roomId, input, engineIdFallback, harnessType, workspaceId, maxTurns,
+				maxReflections, paramMap, agentParamMap, mediaInputPaths, mediaUrls, insight, resumeMode, parentRunId);
 	}
 
 	public String getInput() {
@@ -144,6 +167,7 @@ public final class RunAgentRequest {
 	public Map<String, Object> toPersistedMap() {
 		Map<String, Object> map = new HashMap<>();
 		map.put("roomId", roomId);
+		map.put("parentRunId", parentRunId);
 		map.put("input", input);
 		map.put("engineIdFallback", engineIdFallback);
 		map.put("harnessType", harnessType);
@@ -176,7 +200,8 @@ public final class RunAgentRequest {
 				listValue(map.get("mediaInputPaths")),
 				listValue(map.get("mediaUrls")),
 				insight,
-				booleanValue(map.get("resumeMode")));
+				booleanValue(map.get("resumeMode")),
+				stringValue(map.get("parentRunId")));
 	}
 
 	private static List<String> immutableStringList(List<String> values) {
@@ -214,6 +239,11 @@ public final class RunAgentRequest {
 		}
 		String str = String.valueOf(value);
 		return str.trim().isEmpty() ? null : str;
+	}
+
+	private static String trimmedStringValue(Object value) {
+		String str = stringValue(value);
+		return str == null ? null : str.trim();
 	}
 
 	private static int intValue(Object value, int defaultValue) {

--- a/src/prerna/reactor/agent/subagent/AgentSubAgentRegistry.java
+++ b/src/prerna/reactor/agent/subagent/AgentSubAgentRegistry.java
@@ -303,7 +303,7 @@ public final class AgentSubAgentRegistry {
             }
             RunAgentRequest runRequest = new RunAgentRequest(childRoomId, req.prompt, resolvedEngine, harnessType,
                     req.workspaceId, AgentRunContext.DEFAULT_MAX_TURNS, AgentRunContext.DEFAULT_MAX_REFLECTIONS,
-                    null, null, null, null, childInsight);
+                    null, null, null, null, childInsight).withParentRunId(req.parentJobId);
             RunAgentResult runResult = AgentRuntimeManager.get().runWithId(childRunId, runRequest);
             childStarted = true;
 


### PR DESCRIPTION
## Summary

- Add an indexed `PARENT_RUN_ID` column to the model logs `AGENT_RUN` table.
- Store the immediate parent run ID whenever RunAgent creates a subagent run; root runs remain `NULL`.
- Preserve the parent ID through request persistence/resume and expose it as `parentRunId` in run details.