### PR TITLE
Fix stray javax.ws.rs import to jakarta.ws.rs

### DIFF
--- a/test_legacy/prerna/junit/pixel/PixelUnit.java
+++ b/test_legacy/prerna/junit/pixel/PixelUnit.java
@@ -58,7 +58,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.core.StreamingOutput;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.logging.log4j.LogManager;


### PR DESCRIPTION
## Description
Fixes a stray `javax.ws.rs.core.StreamingOutput` import in legacy test code, missed during the Jakarta EE migration.