### PR TITLE
Agent activity log, subagent runs, and automatic room naming

### DIFF
--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -249,6 +249,10 @@ public class ModelInferenceLogsUtils {
 					Arrays.asList("USER_ID", "WORKSPACE_ID", "DATE_CREATED"));
 			executeSql(conn, sql);
 
+			sql = queryUtil.createIndexIfNotExists("AGENT_RUN_USER_ROOM_DATE_INDEX", "AGENT_RUN",
+					Arrays.asList("USER_ID", "ROOM_ID", "DATE_CREATED"));
+			executeSql(conn, sql);
+
 			sql = queryUtil.createIndexIfNotExists("AGENT_RUN_ACTION_RUN_ID_INDEX", "AGENT_RUN_ACTION", "RUN_ID");
 			executeSql(conn, sql);
 			} else {
@@ -315,6 +319,12 @@ public class ModelInferenceLogsUtils {
 			if (!queryUtil.indexExists(engine, "AGENT_RUN_USER_WORKSPACE_DATE_INDEX", "AGENT_RUN", database, schema)) {
 				String sql = queryUtil.createIndex("AGENT_RUN_USER_WORKSPACE_DATE_INDEX", "AGENT_RUN",
 						Arrays.asList("USER_ID", "WORKSPACE_ID", "DATE_CREATED"));
+				executeSql(conn, sql);
+			}
+
+			if (!queryUtil.indexExists(engine, "AGENT_RUN_USER_ROOM_DATE_INDEX", "AGENT_RUN", database, schema)) {
+				String sql = queryUtil.createIndex("AGENT_RUN_USER_ROOM_DATE_INDEX", "AGENT_RUN",
+						Arrays.asList("USER_ID", "ROOM_ID", "DATE_CREATED"));
 				executeSql(conn, sql);
 			}
 

--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -1533,6 +1533,75 @@ public class ModelInferenceLogsUtils {
 	}
 
 	/**
+	 * Returns the current display name for a user's room.
+	 *
+	 * @param userId user identifier
+	 * @param roomId room identifier
+	 * @return current room name, or {@code null} when the room does not exist or
+	 *         has no name set
+	 */
+	public static String doGetRoomName(String userId, String roomId) {
+		IRDBMSEngine modelInferenceLogsDb = SystemEngineRegistry.getModelInferenceLogsDb();
+		String query = "SELECT ROOM_NAME FROM ROOM WHERE USER_ID = ? AND ROOM_ID = ?";
+		PreparedStatement ps = null;
+		try {
+			ps = modelInferenceLogsDb.getPreparedStatement(query);
+			int index = 1;
+			ps.setString(index++, userId);
+			ps.setString(index++, roomId);
+			if (ps.execute()) {
+				ResultSet rs = ps.getResultSet();
+				if (rs.next()) {
+					return rs.getString(1);
+				}
+			}
+		} catch (Exception e) {
+			classLogger.error("Failed to get room name for roomId '{}' and userId '{}'.", roomId, userId, e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(modelInferenceLogsDb, null, ps, null);
+		}
+		return null;
+	}
+
+	/**
+	 * Updates a room's display name only when the current name is still unset or
+	 * still equal to the auto-derived default (the truncated initial request set
+	 * at room creation). A custom name set by the user is never overwritten.
+	 *
+	 * @param userId      user identifier
+	 * @param roomId      room identifier
+	 * @param roomName    new room name
+	 * @param defaultName auto-derived name that is allowed to be replaced
+	 * @return {@code true} when a row was updated
+	 */
+	public static boolean doSetNameForRoomIfDefault(String userId, String roomId, String roomName,
+			String defaultName) {
+		IRDBMSEngine modelInferenceLogsDb = SystemEngineRegistry.getModelInferenceLogsDb();
+		String query = "UPDATE ROOM SET ROOM_NAME=? WHERE USER_ID=? AND ROOM_ID=? "
+				+ "AND (ROOM_NAME IS NULL OR ROOM_NAME='' OR ROOM_NAME=?)";
+		PreparedStatement ps = null;
+		try {
+			ps = modelInferenceLogsDb.getPreparedStatement(query);
+			int index = 1;
+			ps.setString(index++, roomName);
+			ps.setString(index++, userId);
+			ps.setString(index++, roomId);
+			ps.setString(index++, defaultName);
+			int rows = ps.executeUpdate();
+			if (!ps.getConnection().getAutoCommit()) {
+				ps.getConnection().commit();
+			}
+			return rows > 0;
+		} catch (Exception e) {
+			classLogger.error("Failed to conditionally update room name for roomId '{}' and userId '{}'.", roomId,
+					userId, e);
+			return false;
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(modelInferenceLogsDb, ps);
+		}
+	}
+
+	/**
 	 * Returns ask-message history for a room/user sorted by creation date.
 	 *
 	 * @param userId   user identifier

--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -245,6 +245,10 @@ public class ModelInferenceLogsUtils {
 			sql = queryUtil.createIndexIfNotExists("AGENT_RUN_PARENT_RUN_ID_INDEX", "AGENT_RUN", "PARENT_RUN_ID");
 			executeSql(conn, sql);
 
+			sql = queryUtil.createIndexIfNotExists("AGENT_RUN_USER_WORKSPACE_DATE_INDEX", "AGENT_RUN",
+					Arrays.asList("USER_ID", "WORKSPACE_ID", "DATE_CREATED"));
+			executeSql(conn, sql);
+
 			sql = queryUtil.createIndexIfNotExists("AGENT_RUN_ACTION_RUN_ID_INDEX", "AGENT_RUN_ACTION", "RUN_ID");
 			executeSql(conn, sql);
 			} else {
@@ -305,6 +309,12 @@ public class ModelInferenceLogsUtils {
 
 			if (!queryUtil.indexExists(engine, "AGENT_RUN_PARENT_RUN_ID_INDEX", "AGENT_RUN", database, schema)) {
 				String sql = queryUtil.createIndex("AGENT_RUN_PARENT_RUN_ID_INDEX", "AGENT_RUN", "PARENT_RUN_ID");
+				executeSql(conn, sql);
+			}
+
+			if (!queryUtil.indexExists(engine, "AGENT_RUN_USER_WORKSPACE_DATE_INDEX", "AGENT_RUN", database, schema)) {
+				String sql = queryUtil.createIndex("AGENT_RUN_USER_WORKSPACE_DATE_INDEX", "AGENT_RUN",
+						Arrays.asList("USER_ID", "WORKSPACE_ID", "DATE_CREATED"));
 				executeSql(conn, sql);
 			}
 

--- a/src/prerna/reactor/agent/AgentRunner.java
+++ b/src/prerna/reactor/agent/AgentRunner.java
@@ -48,6 +48,7 @@ import prerna.om.Insight;
 import prerna.om.ThreadStore;
 import prerna.reactor.agent.config.AgentConfig;
 import prerna.reactor.agent.config.AgentConfigLoader;
+import prerna.reactor.agent.run.AgentRoomNamer;
 import prerna.reactor.agent.sandbox.EnforcementMode;
 import prerna.reactor.agent.sandbox.SandboxPolicy;
 import prerna.reactor.agent.sandbox.SandboxPolicyBuilder;
@@ -240,10 +241,6 @@ public final class AgentRunner {
 			AgentRunContext ctx = AgentRunContext.builder().room(room).modelEngine(modelEngine).insight(insight)
 					.userId(room.getUserId()).input(input).runId(runId).sandboxPolicy(sandboxPolicy)
 					.mediaInputPaths(mediaInputPaths).mediaUrls(mediaUrls)
-					// Root runs are not registered as subagents and resolve to depth 0.
-					// Child runs are recorded by AgentSubAgentRegistry before their
-					// virtual thread starts, so this lookup can classify the run without
-					// storing transient spawn state on the durable room options.
 					.spawnDepth(resolveSpawnDepth())
 					.resumeMode(resumeMode)
 					.agentConfig(agentConfig).build();
@@ -253,6 +250,9 @@ public final class AgentRunner {
 			if (hasMediaInput(ctx) && !harness.supportsMediaInput()) {
 				throw new IllegalArgumentException("RunAgent media input is not supported for harnessType='"
 						+ harness.getName() + "'");
+			}
+			if (!resumeMode && ctx.getSpawnDepth() == 0) {
+				AgentRoomNamer.nameRoomAsync(roomId, input, modelId, room.getUserId(), insight);
 			}
 
 			// Apply a temporary workspace overlay so room-based lookups match AgentConfig.

--- a/src/prerna/reactor/agent/GetAgentActivityLogReactor.java
+++ b/src/prerna/reactor/agent/GetAgentActivityLogReactor.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.agent;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import prerna.reactor.AbstractReactor;
+import prerna.reactor.agent.run.AgentRunStore;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+/**
+ * Returns a page of durable agent runs owned by the current user.
+ */
+public class GetAgentActivityLogReactor extends AbstractReactor {
+
+	private static final String AGENT_ID_KEY = "agentId";
+	private static final String SORT_BY_ROOM_KEY = "sortByRoom";
+	private static final long DEFAULT_LIMIT = 20L;
+
+	public GetAgentActivityLogReactor() {
+		this.keysToGet = new String[] { AGENT_ID_KEY, ReactorKeysEnum.LIMIT.getKey(),
+				ReactorKeysEnum.OFFSET.getKey(), SORT_BY_ROOM_KEY };
+		this.keyRequired = new int[] { 1, 0, 0, 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		String agentId = StringUtils.trimToNull(this.keyValue.get(AGENT_ID_KEY));
+		if (agentId == null) {
+			throw new IllegalArgumentException("agentId is required");
+		}
+		long limit = getPageValue(ReactorKeysEnum.LIMIT.getKey(), DEFAULT_LIMIT);
+		long offset = getPageValue(ReactorKeysEnum.OFFSET.getKey(), 0L);
+		if (limit <= 0) {
+			throw new IllegalArgumentException("limit must be greater than 0");
+		}
+		if (offset < 0) {
+			throw new IllegalArgumentException("offset must be greater than or equal to 0");
+		}
+
+		List<Map<String, Object>> runs = new AgentRunStore().getActivityLog(this.insight, agentId, limit, offset);
+		if (Boolean.parseBoolean(this.keyValue.get(SORT_BY_ROOM_KEY))) {
+			return new NounMetadata(groupByRoom(runs), PixelDataType.MAP, PixelOperationType.OPERATION);
+		}
+		return new NounMetadata(runs, PixelDataType.VECTOR, PixelOperationType.OPERATION);
+	}
+
+	private Map<String, List<Map<String, Object>>> groupByRoom(List<Map<String, Object>> runs) {
+		Map<String, List<Map<String, Object>>> runsByRoom = new LinkedHashMap<>();
+		for (Map<String, Object> run : runs) {
+			Object roomIdValue = run.get("roomId");
+			String roomId = roomIdValue == null ? null : String.valueOf(roomIdValue);
+			runsByRoom.computeIfAbsent(roomId, key -> new ArrayList<>()).add(run);
+		}
+		return runsByRoom;
+	}
+
+	private long getPageValue(String key, long defaultValue) {
+		String value = this.keyValue.get(key);
+		return value == null || value.trim().isEmpty() ? defaultValue : Long.parseLong(value.trim());
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Retrieves a page of runs for the specified agent and current user, ordered newest first. Results can optionally be grouped by room.";
+	}
+
+	@Override
+	protected MCP_KEY_TYPE getKeyTypeForMCP(String key) {
+		if (SORT_BY_ROOM_KEY.equals(key)) {
+			return MCP_KEY_TYPE.BOOLEAN;
+		}
+		return super.getKeyTypeForMCP(key);
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (AGENT_ID_KEY.equals(key)) {
+			return "The agent ID to filter by. This corresponds to AGENT_RUN.WORKSPACE_ID.";
+		} else if (ReactorKeysEnum.LIMIT.getKey().equals(key)) {
+			return "Maximum number of agent runs to return. Defaults to 20 and must be greater than 0.";
+		} else if (ReactorKeysEnum.OFFSET.getKey().equals(key)) {
+			return "Number of agent runs to skip. Defaults to 0 and must not be negative.";
+		} else if (SORT_BY_ROOM_KEY.equals(key)) {
+			return "When true, returns a map keyed by room ID whose values are the runs for that room.";
+		}
+		return super.getDescriptionForKey(key);
+	}
+}

--- a/src/prerna/reactor/agent/GetAgentActivityLogReactor.java
+++ b/src/prerna/reactor/agent/GetAgentActivityLogReactor.java
@@ -72,19 +72,26 @@ public class GetAgentActivityLogReactor extends AbstractReactor {
 			throw new IllegalArgumentException("offset must be greater than or equal to 0");
 		}
 
-		List<Map<String, Object>> runs = new AgentRunStore().getActivityLog(this.insight, agentId, limit, offset);
+		AgentRunStore runStore = new AgentRunStore();
+		List<Map<String, Object>> runs = runStore.getActivityLog(this.insight, agentId, limit, offset);
 		if (Boolean.parseBoolean(this.keyValue.get(SORT_BY_ROOM_KEY))) {
-			return new NounMetadata(groupByRoom(runs), PixelDataType.MAP, PixelOperationType.OPERATION);
+			return new NounMetadata(loadAndGroupRunsByRoom(runStore, runs), PixelDataType.MAP,
+					PixelOperationType.OPERATION);
 		}
 		return new NounMetadata(runs, PixelDataType.VECTOR, PixelOperationType.OPERATION);
 	}
 
-	private Map<String, List<Map<String, Object>>> groupByRoom(List<Map<String, Object>> runs) {
+	private Map<String, List<Map<String, Object>>> loadAndGroupRunsByRoom(AgentRunStore runStore,
+			List<Map<String, Object>> seedRuns) {
 		Map<String, List<Map<String, Object>>> runsByRoom = new LinkedHashMap<>();
-		for (Map<String, Object> run : runs) {
+		for (Map<String, Object> run : seedRuns) {
 			Object roomIdValue = run.get("roomId");
 			String roomId = roomIdValue == null ? null : String.valueOf(roomIdValue);
-			runsByRoom.computeIfAbsent(roomId, key -> new ArrayList<>()).add(run);
+			if (roomId == null) {
+				runsByRoom.computeIfAbsent(null, key -> new ArrayList<>()).add(run);
+			} else if (!runsByRoom.containsKey(roomId)) {
+				runsByRoom.put(roomId, runStore.getRunsForRoom(this.insight, roomId));
+			}
 		}
 		return runsByRoom;
 	}
@@ -96,7 +103,7 @@ public class GetAgentActivityLogReactor extends AbstractReactor {
 
 	@Override
 	public String getReactorDescription() {
-		return "Retrieves a page of runs for the specified agent and current user, ordered newest first. Results can optionally be grouped by room.";
+		return "Retrieves a page of runs for the specified agent and current user, ordered newest first. When grouped by room, the page identifies rooms and all runs for each identified room are returned.";
 	}
 
 	@Override
@@ -116,7 +123,7 @@ public class GetAgentActivityLogReactor extends AbstractReactor {
 		} else if (ReactorKeysEnum.OFFSET.getKey().equals(key)) {
 			return "Number of agent runs to skip. Defaults to 0 and must not be negative.";
 		} else if (SORT_BY_ROOM_KEY.equals(key)) {
-			return "When true, returns a map keyed by room ID whose values are the runs for that room.";
+			return "When true, uses the paginated results to identify rooms, then returns a map keyed by room ID containing all current-user runs for each room.";
 		}
 		return super.getDescriptionForKey(key);
 	}

--- a/src/prerna/reactor/agent/GetSubagentRunsReactor.java
+++ b/src/prerna/reactor/agent/GetSubagentRunsReactor.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.agent;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+
+import prerna.reactor.AbstractReactor;
+import prerna.reactor.agent.run.AgentRunStore;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.PixelOperationType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+/**
+ * Returns the direct subagent runs for a parent run owned by the current user.
+ */
+public class GetSubagentRunsReactor extends AbstractReactor {
+
+	private static final String RUN_ID_KEY = "runId";
+
+	public GetSubagentRunsReactor() {
+		this.keysToGet = new String[] { RUN_ID_KEY };
+		this.keyRequired = new int[] { 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		String runId = StringUtils.trimToNull(this.keyValue.get(RUN_ID_KEY));
+		if (runId == null) {
+			throw new IllegalArgumentException("runId is required");
+		}
+
+		List<Map<String, Object>> runs = new AgentRunStore().getSubagentRuns(this.insight, runId);
+		return new NounMetadata(runs, PixelDataType.VECTOR, PixelOperationType.OPERATION);
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Returns all direct subagent runs owned by the current user whose parent run ID matches runId, ordered newest first.";
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (RUN_ID_KEY.equals(key)) {
+			return "The parent run ID whose direct subagent runs should be returned.";
+		}
+		return super.getDescriptionForKey(key);
+	}
+}

--- a/src/prerna/reactor/agent/run/AgentRoomNamer.java
+++ b/src/prerna/reactor/agent/run/AgentRoomNamer.java
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.agent.run;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.User;
+import prerna.engine.api.IModelEngine;
+import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
+import prerna.engine.impl.model.message.InputMessage;
+import prerna.engine.impl.model.message.ResponseMessage;
+import prerna.om.Insight;
+import prerna.util.Utility;
+
+/**
+ * Fire-and-forget background naming for agent-run rooms, mirroring the
+ * playground's GenerateRoomName flow. Generates a short LLM title from the
+ * run's initial user request and falls back to the truncated request text
+ * when the model call fails.
+ *
+ * The rename runs on a daemon thread and must never block, delay, or fail
+ * the agent run:
+ * - the title ask uses a DETACHED Room instance loaded straight from the DB
+ *   row (never the cached instance in the user's room hash), so it cannot
+ *   contend for the run's room lock;
+ * - persistence is a single conditional UPDATE that only replaces an unset
+ *   name or the auto-derived truncated-input default - a name set by the
+ *   user (e.g. via RenameRoom) is never overwritten;
+ * - every failure is logged and swallowed.
+ */
+public final class AgentRoomNamer {
+
+    private static final Logger logger = LogManager.getLogger(AgentRoomNamer.class);
+
+    /** Must match the room-creation default in RoomUtils.createRoomRowIfMissing. */
+    private static final int DEFAULT_NAME_CHAR_LIMIT = 100;
+
+    /** Truncate the request before sending it to the model (same as GenerateRoomNameReactor). */
+    private static final int PROMPT_CHAR_LIMIT = 500;
+
+    private static final String TITLE_INSTRUCTION =
+            "Generate a concise 3-5 word title summarizing the topic of the following user message. "
+            + "Return ONLY the title. No punctuation, no quotes, no explanation.";
+
+    private AgentRoomNamer() {
+        /* static utility */
+    }
+
+    /**
+     * Names the room from the run's initial user input on a background daemon
+     * thread. Returns immediately; the agent run proceeds regardless of the
+     * naming outcome.
+     *
+     * @param roomId  room to name
+     * @param input   the user's original request for this run
+     * @param modelId resolved model engine id used for title generation; when
+     *                null/blank the name falls back to the truncated input
+     * @param userId  owner user id on the ROOM row
+     * @param insight caller insight used for the one-off model ask
+     */
+    public static void nameRoomAsync(String roomId, String input, String modelId, String userId, Insight insight) {
+        if (roomId == null || roomId.trim().isEmpty()
+                || input == null || input.trim().isEmpty()
+                || userId == null || userId.trim().isEmpty()) {
+            return;
+        }
+        Thread namer = new Thread(() -> {
+            try {
+                nameRoom(roomId, input, modelId, userId, insight);
+            } catch (Exception e) {
+                logger.warn("AgentRoomNamer: room rename failed for room='{}' - run unaffected: {}",
+                        roomId, e.getMessage(), e);
+            }
+        }, "agent-room-namer-" + roomId);
+        namer.setDaemon(true);
+        namer.start();
+    }
+
+    private static void nameRoom(String roomId, String input, String modelId, String userId, Insight insight) {
+        String defaultName = truncate(input.trim(), DEFAULT_NAME_CHAR_LIMIT);
+
+        // Skip the model call entirely when the room already carries a custom name.
+        String currentName = ModelInferenceLogsUtils.doGetRoomName(userId, roomId);
+        if (currentName != null && !currentName.trim().isEmpty() && !currentName.equals(defaultName)) {
+            return;
+        }
+
+        String title = generateTitle(roomId, input, modelId, userId, insight);
+        if (title == null || title.trim().isEmpty()) {
+            title = defaultName;
+        }
+
+        boolean updated = ModelInferenceLogsUtils.doSetNameForRoomIfDefault(userId, roomId, title, defaultName);
+        if (updated) {
+            syncCachedRoomName(roomId, title, insight);
+            logger.info("AgentRoomNamer: room='{}' named '{}'", roomId, title);
+        }
+    }
+
+    /**
+     * One-off title generation mirroring GenerateRoomNameReactor: use_history
+     * off and appendToHistory=false so nothing is written back to the room.
+     * Runs against a detached Room instance so the shared room lock held by
+     * the run's own asks is never touched.
+     *
+     * @return cleaned title, or {@code null} when generation is unavailable or fails
+     */
+    private static String generateTitle(String roomId, String input, String modelId, String userId, Insight insight) {
+        if (modelId == null || modelId.trim().isEmpty()) {
+            return null;
+        }
+        try {
+            IModelEngine modelEngine = Utility.getModel(modelId);
+            if (modelEngine == null) {
+                return null;
+            }
+            Room detached = ModelInferenceLogsUtils.getRoomById(roomId, userId);
+            if (detached == null) {
+                return null;
+            }
+            detached.setInsight(insight);
+
+            Map<String, Object> paramMap = new HashMap<>();
+            paramMap.put("use_history", false);
+
+            InputMessage inputMsg = InputMessage.builder(detached)
+                    .withText(TITLE_INSTRUCTION + "\n\n" + truncate(input, PROMPT_CHAR_LIMIT))
+                    .withModelType(modelEngine.getModelType())
+                    .withParamMap(paramMap)
+                    .build();
+
+            ResponseMessage response = detached.ask(inputMsg, modelEngine, null, false);
+            String raw = response == null ? null : response.getContent();
+            if (raw == null || raw.trim().isEmpty()) {
+                return null;
+            }
+            String title = raw.trim()
+                    .replaceAll("^[\"']+|[\"']+$", "")
+                    .replaceAll("\\s+", " ")
+                    .trim();
+            return truncate(title, DEFAULT_NAME_CHAR_LIMIT);
+        } catch (Exception e) {
+            logger.warn("AgentRoomNamer: title generation failed for room='{}', falling back to truncated input: {}",
+                    roomId, e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Best-effort sync of the cached in-memory Room so a later
+     * persist(room, userId, roomName, engineId) from Room.ask's name backfill
+     * does not resurrect the old name.
+     */
+    private static void syncCachedRoomName(String roomId, String title, Insight insight) {
+        try {
+            User user = insight == null ? null : insight.getUser();
+            if (user == null) {
+                return;
+            }
+            Room cached = user.getRoomHash().get(roomId);
+            if (cached != null) {
+                cached.setRoomName(title);
+            }
+        } catch (Exception e) {
+            logger.debug("AgentRoomNamer: cached room name sync skipped for room='{}': {}", roomId, e.getMessage());
+        }
+    }
+
+    private static String truncate(String value, int max) {
+        if (value == null) {
+            return null;
+        }
+        return value.substring(0, Math.min(value.length(), max));
+    }
+}

--- a/src/prerna/reactor/agent/run/AgentRunStore.java
+++ b/src/prerna/reactor/agent/run/AgentRunStore.java
@@ -29,8 +29,10 @@ package prerna.reactor.agent.run;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -132,31 +134,64 @@ public final class AgentRunStore {
 			if (!rs.next()) {
 				return null;
 			}
-			Map<String, Object> map = new java.util.HashMap<>();
-			map.put("runId", rs.getString("RUN_ID"));
-			map.put("parentRunId", rs.getString("PARENT_RUN_ID"));
-			map.put("roomId", rs.getString("ROOM_ID"));
-			map.put("workspaceId", rs.getString("WORKSPACE_ID"));
-			map.put("modelId", rs.getString("MODEL_ID"));
-			map.put("harnessType", rs.getString("HARNESS_TYPE"));
-			map.put("jobId", rs.getString("JOB_ID"));
-			map.put("status", rs.getString("STATUS"));
-			map.put("input", rs.getString("INPUT"));
-			map.put("inputMessageId", rs.getString("INPUT_MESSAGE_ID"));
-			map.put("finalText", rs.getString("FINAL_OUTPUT"));
-			map.put("finalOutputMessageId", rs.getString("FINAL_OUTPUT_MESSAGE_ID"));
-			map.put("errorMessage", rs.getString("ERROR_MESSAGE"));
-			map.put("dateCreated", stringValue(rs.getTimestamp("DATE_CREATED")));
-			map.put("startedAt", stringValue(rs.getTimestamp("STARTED_AT")));
-			map.put("completedAt", stringValue(rs.getTimestamp("COMPLETED_AT")));
-			map.put("userId", rs.getString("USER_ID"));
-			map.put("artifacts", new ArrayList<>());
-			return map;
+			return runMapFromRow(rs);
 		} catch (Exception e) {
 			if (e instanceof SecurityException) {
 				throw (SecurityException) e;
 			}
 			throw new IllegalStateException("Failed to load AGENT_RUN details for runId=" + runId, e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(db, null, ps, rs);
+		}
+	}
+
+	/**
+	 * Return one page of runs for an agent owned by the current user, newest first.
+	 *
+	 * @param insight current request insight, used to scope the query to its user
+	 * @param agentId agent workspace identifier used to scope the runs
+	 * @param limit   maximum number of runs to return
+	 * @param offset  number of matching runs to skip
+	 * @return the requested page of agent runs
+	 */
+	public List<Map<String, Object>> getActivityLog(Insight insight, String agentId, long limit, long offset) {
+		if (agentId == null || agentId.trim().isEmpty()) {
+			throw new IllegalArgumentException("agentId is required");
+		}
+		if (limit <= 0) {
+			throw new IllegalArgumentException("limit must be greater than 0");
+		}
+		if (offset < 0) {
+			throw new IllegalArgumentException("offset must be greater than or equal to 0");
+		}
+
+		String userId = resolveInsightUserId(insight);
+		IRDBMSEngine db = SystemEngineRegistry.getModelInferenceLogsDb();
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			StringBuilder query = new StringBuilder(
+					"SELECT RUN_ID, PARENT_RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, HARNESS_TYPE, JOB_ID, STATUS, INPUT, "
+							+ "INPUT_MESSAGE_ID, FINAL_OUTPUT, FINAL_OUTPUT_MESSAGE_ID, ERROR_MESSAGE, "
+							+ "DATE_CREATED, STARTED_AT, COMPLETED_AT, USER_ID FROM AGENT_RUN "
+							+ "WHERE USER_ID = ? AND WORKSPACE_ID = ? ORDER BY DATE_CREATED DESC, RUN_ID DESC");
+			db.getQueryUtil().addLimitOffsetToQuery(query, limit, offset);
+
+			ps = db.getPreparedStatement(query.toString());
+			ps.setString(1, userId);
+			ps.setString(2, agentId.trim());
+			rs = ps.executeQuery();
+
+			List<Map<String, Object>> runs = new ArrayList<>();
+			while (rs.next()) {
+				runs.add(runMapFromRow(rs));
+			}
+			return runs;
+		} catch (Exception e) {
+			if (e instanceof SecurityException) {
+				throw (SecurityException) e;
+			}
+			throw new IllegalStateException("Failed to load AGENT_RUN activity log", e);
 		} finally {
 			ConnectionUtils.closeAllConnectionsIfPooling(db, null, ps, rs);
 		}
@@ -482,5 +517,28 @@ public final class AgentRunStore {
 
 	private static String stringValue(Object value) {
 		return value == null ? null : String.valueOf(value);
+	}
+
+	private static Map<String, Object> runMapFromRow(ResultSet rs) throws SQLException {
+		Map<String, Object> map = new HashMap<>();
+		map.put("runId", rs.getString("RUN_ID"));
+		map.put("parentRunId", rs.getString("PARENT_RUN_ID"));
+		map.put("roomId", rs.getString("ROOM_ID"));
+		map.put("workspaceId", rs.getString("WORKSPACE_ID"));
+		map.put("modelId", rs.getString("MODEL_ID"));
+		map.put("harnessType", rs.getString("HARNESS_TYPE"));
+		map.put("jobId", rs.getString("JOB_ID"));
+		map.put("status", rs.getString("STATUS"));
+		map.put("input", rs.getString("INPUT"));
+		map.put("inputMessageId", rs.getString("INPUT_MESSAGE_ID"));
+		map.put("finalText", rs.getString("FINAL_OUTPUT"));
+		map.put("finalOutputMessageId", rs.getString("FINAL_OUTPUT_MESSAGE_ID"));
+		map.put("errorMessage", rs.getString("ERROR_MESSAGE"));
+		map.put("dateCreated", stringValue(rs.getTimestamp("DATE_CREATED")));
+		map.put("startedAt", stringValue(rs.getTimestamp("STARTED_AT")));
+		map.put("completedAt", stringValue(rs.getTimestamp("COMPLETED_AT")));
+		map.put("userId", rs.getString("USER_ID"));
+		map.put("artifacts", new ArrayList<>());
+		return map;
 	}
 }

--- a/src/prerna/reactor/agent/run/AgentRunStore.java
+++ b/src/prerna/reactor/agent/run/AgentRunStore.java
@@ -48,6 +48,9 @@ import prerna.util.Utility;
 public final class AgentRunStore {
 
 	private static final Gson GSON = new Gson();
+	private static final String ACTIVITY_LOG_COLUMNS = "RUN_ID, PARENT_RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, "
+			+ "HARNESS_TYPE, JOB_ID, STATUS, INPUT, INPUT_MESSAGE_ID, FINAL_OUTPUT, FINAL_OUTPUT_MESSAGE_ID, "
+			+ "ERROR_MESSAGE, DATE_CREATED, STARTED_AT, COMPLETED_AT, USER_ID";
 
 	public void insertSubmitted(String runId, RunAgentRequest request, String userId) {
 		insert(runId, request, userId, AgentRunStatus.SUBMITTED);
@@ -170,11 +173,8 @@ public final class AgentRunStore {
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 		try {
-			StringBuilder query = new StringBuilder(
-					"SELECT RUN_ID, PARENT_RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, HARNESS_TYPE, JOB_ID, STATUS, INPUT, "
-							+ "INPUT_MESSAGE_ID, FINAL_OUTPUT, FINAL_OUTPUT_MESSAGE_ID, ERROR_MESSAGE, "
-							+ "DATE_CREATED, STARTED_AT, COMPLETED_AT, USER_ID FROM AGENT_RUN "
-							+ "WHERE USER_ID = ? AND WORKSPACE_ID = ? ORDER BY DATE_CREATED DESC, RUN_ID DESC");
+			StringBuilder query = new StringBuilder("SELECT " + ACTIVITY_LOG_COLUMNS + " FROM AGENT_RUN "
+					+ "WHERE USER_ID = ? AND WORKSPACE_ID = ? ORDER BY DATE_CREATED DESC, RUN_ID DESC");
 			db.getQueryUtil().addLimitOffsetToQuery(query, limit, offset);
 
 			ps = db.getPreparedStatement(query.toString());
@@ -192,6 +192,83 @@ public final class AgentRunStore {
 				throw (SecurityException) e;
 			}
 			throw new IllegalStateException("Failed to load AGENT_RUN activity log", e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(db, null, ps, rs);
+		}
+	}
+
+	/**
+	 * Return every run in a room owned by the current user, newest first.
+	 *
+	 * @param insight current request insight, used to scope the query to its user
+	 * @param roomId  room whose complete run history should be returned
+	 * @return all current-user runs for the room
+	 */
+	public List<Map<String, Object>> getRunsForRoom(Insight insight, String roomId) {
+		if (roomId == null || roomId.trim().isEmpty()) {
+			throw new IllegalArgumentException("roomId is required");
+		}
+
+		String userId = resolveInsightUserId(insight);
+		IRDBMSEngine db = SystemEngineRegistry.getModelInferenceLogsDb();
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			String query = "SELECT " + ACTIVITY_LOG_COLUMNS + " FROM AGENT_RUN "
+					+ "WHERE USER_ID = ? AND ROOM_ID = ? ORDER BY DATE_CREATED DESC, RUN_ID DESC";
+			ps = db.getPreparedStatement(query);
+			ps.setString(1, userId);
+			ps.setString(2, roomId.trim());
+			rs = ps.executeQuery();
+
+			List<Map<String, Object>> runs = new ArrayList<>();
+			while (rs.next()) {
+				runs.add(runMapFromRow(rs));
+			}
+			return runs;
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to load AGENT_RUN rows for roomId=" + roomId, e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(db, null, ps, rs);
+		}
+	}
+
+	/**
+	 * Return every direct subagent run for a parent run owned by the current user,
+	 * newest first.
+	 *
+	 * @param insight     current request insight, used to scope the query to its user
+	 * @param parentRunId parent run whose direct subagent runs should be returned
+	 * @return all current-user runs with the supplied parent run ID
+	 */
+	public List<Map<String, Object>> getSubagentRuns(Insight insight, String parentRunId) {
+		if (parentRunId == null || parentRunId.trim().isEmpty()) {
+			throw new IllegalArgumentException("runId is required");
+		}
+
+		String userId = resolveInsightUserId(insight);
+		IRDBMSEngine db = SystemEngineRegistry.getModelInferenceLogsDb();
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+		try {
+			String query = "SELECT " + ACTIVITY_LOG_COLUMNS + " FROM AGENT_RUN "
+					+ "WHERE USER_ID = ? AND PARENT_RUN_ID = ? ORDER BY DATE_CREATED DESC, RUN_ID DESC";
+			ps = db.getPreparedStatement(query);
+			ps.setString(1, userId);
+			ps.setString(2, parentRunId.trim());
+			rs = ps.executeQuery();
+
+			List<Map<String, Object>> runs = new ArrayList<>();
+			while (rs.next()) {
+				runs.add(runMapFromRow(rs));
+			}
+			return runs;
+		} catch (Exception e) {
+			if (e instanceof SecurityException) {
+				throw (SecurityException) e;
+			}
+			throw new IllegalStateException("Failed to load subagent AGENT_RUN rows for parentRunId=" + parentRunId,
+					e);
 		} finally {
 			ConnectionUtils.closeAllConnectionsIfPooling(db, null, ps, rs);
 		}

--- a/src/prerna/reactor/agent/run/AgentRunStore.java
+++ b/src/prerna/reactor/agent/run/AgentRunStore.java
@@ -48,9 +48,12 @@ import prerna.util.Utility;
 public final class AgentRunStore {
 
 	private static final Gson GSON = new Gson();
-	private static final String ACTIVITY_LOG_COLUMNS = "RUN_ID, PARENT_RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, "
-			+ "HARNESS_TYPE, JOB_ID, STATUS, INPUT, INPUT_MESSAGE_ID, FINAL_OUTPUT, FINAL_OUTPUT_MESSAGE_ID, "
-			+ "ERROR_MESSAGE, DATE_CREATED, STARTED_AT, COMPLETED_AT, USER_ID";
+	private static final String ACTIVITY_LOG_COLUMNS = "ar.RUN_ID, ar.PARENT_RUN_ID, ar.ROOM_ID, ar.WORKSPACE_ID, ar.MODEL_ID, "
+			+ "ar.HARNESS_TYPE, ar.JOB_ID, ar.STATUS, ar.INPUT, ar.INPUT_MESSAGE_ID, ar.FINAL_OUTPUT, ar.FINAL_OUTPUT_MESSAGE_ID, "
+			+ "ar.ERROR_MESSAGE, ar.DATE_CREATED, ar.STARTED_AT, ar.COMPLETED_AT, ar.USER_ID, r.ROOM_NAME";
+	// Rooms are keyed per user, so the name join must match on both columns.
+	private static final String ACTIVITY_LOG_FROM = "FROM AGENT_RUN ar "
+			+ "LEFT JOIN ROOM r ON ar.ROOM_ID = r.ROOM_ID AND ar.USER_ID = r.USER_ID";
 
 	public void insertSubmitted(String runId, RunAgentRequest request, String userId) {
 		insert(runId, request, userId, AgentRunStatus.SUBMITTED);
@@ -127,9 +130,8 @@ public final class AgentRunStore {
 		ResultSet rs = null;
 		try {
 			String userId = resolveInsightUserId(insight);
-			String query = "SELECT RUN_ID, PARENT_RUN_ID, ROOM_ID, WORKSPACE_ID, MODEL_ID, HARNESS_TYPE, JOB_ID, STATUS, INPUT, "
-					+ "REQUEST_JSON, INPUT_MESSAGE_ID, FINAL_OUTPUT, FINAL_OUTPUT_MESSAGE_ID, ERROR_MESSAGE, "
-					+ "DATE_CREATED, STARTED_AT, COMPLETED_AT, USER_ID FROM AGENT_RUN WHERE RUN_ID = ? AND USER_ID = ?";
+			String query = "SELECT " + ACTIVITY_LOG_COLUMNS + ", ar.REQUEST_JSON " + ACTIVITY_LOG_FROM
+					+ " WHERE ar.RUN_ID = ? AND ar.USER_ID = ?";
 			ps = db.getPreparedStatement(query);
 			ps.setString(1, runId);
 			ps.setString(2, userId);
@@ -173,8 +175,8 @@ public final class AgentRunStore {
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 		try {
-			StringBuilder query = new StringBuilder("SELECT " + ACTIVITY_LOG_COLUMNS + " FROM AGENT_RUN "
-					+ "WHERE USER_ID = ? AND WORKSPACE_ID = ? ORDER BY DATE_CREATED DESC, RUN_ID DESC");
+			StringBuilder query = new StringBuilder("SELECT " + ACTIVITY_LOG_COLUMNS + " " + ACTIVITY_LOG_FROM
+					+ " WHERE ar.USER_ID = ? AND ar.WORKSPACE_ID = ? ORDER BY ar.DATE_CREATED DESC, ar.RUN_ID DESC");
 			db.getQueryUtil().addLimitOffsetToQuery(query, limit, offset);
 
 			ps = db.getPreparedStatement(query.toString());
@@ -214,8 +216,8 @@ public final class AgentRunStore {
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 		try {
-			String query = "SELECT " + ACTIVITY_LOG_COLUMNS + " FROM AGENT_RUN "
-					+ "WHERE USER_ID = ? AND ROOM_ID = ? ORDER BY DATE_CREATED DESC, RUN_ID DESC";
+			String query = "SELECT " + ACTIVITY_LOG_COLUMNS + " " + ACTIVITY_LOG_FROM
+					+ " WHERE ar.USER_ID = ? AND ar.ROOM_ID = ? ORDER BY ar.DATE_CREATED DESC, ar.RUN_ID DESC";
 			ps = db.getPreparedStatement(query);
 			ps.setString(1, userId);
 			ps.setString(2, roomId.trim());
@@ -251,8 +253,8 @@ public final class AgentRunStore {
 		PreparedStatement ps = null;
 		ResultSet rs = null;
 		try {
-			String query = "SELECT " + ACTIVITY_LOG_COLUMNS + " FROM AGENT_RUN "
-					+ "WHERE USER_ID = ? AND PARENT_RUN_ID = ? ORDER BY DATE_CREATED DESC, RUN_ID DESC";
+			String query = "SELECT " + ACTIVITY_LOG_COLUMNS + " " + ACTIVITY_LOG_FROM
+					+ " WHERE ar.USER_ID = ? AND ar.PARENT_RUN_ID = ? ORDER BY ar.DATE_CREATED DESC, ar.RUN_ID DESC";
 			ps = db.getPreparedStatement(query);
 			ps.setString(1, userId);
 			ps.setString(2, parentRunId.trim());
@@ -601,6 +603,7 @@ public final class AgentRunStore {
 		map.put("runId", rs.getString("RUN_ID"));
 		map.put("parentRunId", rs.getString("PARENT_RUN_ID"));
 		map.put("roomId", rs.getString("ROOM_ID"));
+		map.put("roomName", rs.getString("ROOM_NAME"));
 		map.put("workspaceId", rs.getString("WORKSPACE_ID"));
 		map.put("modelId", rs.getString("MODEL_ID"));
 		map.put("harnessType", rs.getString("HARNESS_TYPE"));


### PR DESCRIPTION
## Summary

Adds durable read APIs for agent run history (activity log + subagent runs) and automatic background naming of rooms created by `RunAgent`, mirroring the playground's existing `GenerateRoomName` flow.

## Changes

### New reactors
- **`GetAgentActivityLogReactor`** (`src/prerna/reactor/agent/GetAgentActivityLogReactor.java`) — returns a paginated page of `AGENT_RUN` rows for the current user, scoped by `agentId` (`AGENT_RUN.WORKSPACE_ID`). Supports `limit`/`offset` (default limit 20) and an optional `sortByRoom` flag that regroups the page into a map keyed by room ID, backfilling the full run history for each room encountered on the page.
- **`GetSubagentRunsReactor`** (`src/prerna/reactor/agent/GetSubagentRunsReactor.java`) — returns all direct subagent runs for a given `runId` (i.e. rows whose `PARENT_RUN_ID` matches), owned by the current user, newest first.

### Automatic room naming (`AgentRoomNamer`)
- New class `src/prerna/reactor/agent/run/AgentRoomNamer.java` fires a background daemon thread from `AgentRunner.run(...)` (only for root runs — `spawnDepth == 0` — and only when not resuming) to generate a short 3-5 word title from the run's initial input, using the same prompt strategy as `GenerateRoomNameReactor`.
- Runs against a **detached** `Room` instance loaded straight from the DB (`ModelInferenceLogsUtils.getRoomById`) so it never contends for the live room lock held by the run's own asks.
- Persists via a new conditional update, `ModelInferenceLogsUtils.doSetNameForRoomIfDefault(...)`, which only overwrites a room name that is unset or still equal to the auto-derived truncated-input default — a name the user set manually (e.g. via `RenameRoom`) is never clobbered.
- Falls back silently to the truncated input if the model call fails or no model ID is available; all failures are logged and swallowed so naming can never affect the run itself.
- Added `ModelInferenceLogsUtils.doGetRoomName(...)` to short-circuit the model call entirely when a custom name is already set.

### `AgentRunStore` — shared run-row loading + room name join
- Added a shared `ACTIVITY_LOG_COLUMNS` / `ACTIVITY_LOG_FROM` (LEFT JOIN `AGENT_RUN` to `ROOM` on `ROOM_ID` + `USER_ID`) so every run map now includes `roomName`.
- Extracted the `ResultSet` → `Map` conversion into `runMapFromRow(...)`, reused by `getRun`, the new `getActivityLog`, `getRunsForRoom`, and `getSubagentRuns`.
- New methods: `getActivityLog(insight, agentId, limit, offset)`, `getRunsForRoom(insight, roomId)`, `getSubagentRuns(insight, parentRunId)` — all scoped to the current user via `resolveInsightUserId`.

### Indexing
- `ModelInferenceLogsUtils` — added `AGENT_RUN_USER_WORKSPACE_DATE_INDEX` (`USER_ID, WORKSPACE_ID, DATE_CREATED`) and `AGENT_RUN_USER_ROOM_DATE_INDEX` (`USER_ID, ROOM_ID, DATE_CREATED`) on `AGENT_RUN`, added to both the fresh-install and upgrade-path index creation blocks, to support the new activity log and per-room queries.

### `AgentRunner`
- Wires in `AgentRoomNamer.nameRoomAsync(roomId, input, modelId, room.getUserId(), insight)` right after the harness is resolved, gated on `!resumeMode && ctx.getSpawnDepth() == 0`.
- No behavioral change to run overloads; whitespace/line-ending normalization only (no semantic diff) on the two `run(...)` method signatures and the `AgentRunContext` builder block.