### PR TITLE
fix(agent-clone): preserve workspace config & agent data when cloning an agent

### DIFF
--- a/src/prerna/reactor/project/CreateAppFromTemplateReactor.java
+++ b/src/prerna/reactor/project/CreateAppFromTemplateReactor.java
@@ -33,13 +33,20 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.json.JSONObject;
 
+import prerna.auth.User;
 import prerna.auth.utils.SecurityProjectUtils;
+import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.cluster.util.ClusterUtil;
 import prerna.project.api.IProject;
 import prerna.project.impl.ProjectHelper;
@@ -140,6 +147,65 @@ public class CreateAppFromTemplateReactor extends AbstractReactor {
 			throw new IllegalArgumentException(
 					"New project was created but could not transfer over the assets from the template. Errror = "
 							+ e.getMessage());
+		}
+
+		// If the template is a WORKSPACE (agent), clone the inference-log workspace
+		// entry and CONFIG_JSON so the new agent inherits all configuration:
+		// system prompt, model selection, MCPs, skills, budgets, hooks, subagents.
+		if (IProject.PROJECT_TYPE.WORKSPACE == projectEnumType) {
+			try {
+				User user = this.insight.getUser();
+				String newProjectId = newProject.getProjectId();
+
+				Map<String, Object> sourceEntry = ModelInferenceLogsUtils.getWorkspaceEntry(projectTemplateId);
+				String sourceDescription = sourceEntry != null ? (String) sourceEntry.get("description") : null;
+				String sourceSystemPrompt = sourceEntry != null ? (String) sourceEntry.get("system_prompt") : null;
+				JSONObject sourceConfigJson = ModelInferenceLogsUtils.getWorkspaceConfigJson(projectTemplateId);
+				List<Map<String, Object>> sourceResources = ModelInferenceLogsUtils
+						.getWorkspaceResourcesByType(projectTemplateId, null);
+
+				List<Map<String, String>> clonedResources = new ArrayList<>();
+				List<Map<String, Object>> dependencyList = new ArrayList<>();
+				if (sourceResources != null) {
+					for (Map<String, Object> r : sourceResources) {
+						String resourceId = (String) r.get("resource_id");
+						String resourceType = (String) r.get("resource_type");
+						String resourceSubtype = (String) r.get("resource_subtype");
+						Map<String, String> entry = new HashMap<>();
+						entry.put("workspace_resource_id", UUID.randomUUID().toString());
+						entry.put("workspace_id", newProjectId);
+						entry.put("resource_id", resourceId);
+						entry.put("resource_type", resourceType);
+						entry.put("resource_subtype", resourceSubtype);
+						clonedResources.add(entry);
+						Map<String, Object> dep = new HashMap<>();
+						dep.put("ENGINEID", resourceId);
+						dep.put("ENGINETYPE", resourceType);
+						dependencyList.add(dep);
+					}
+				}
+
+				SecurityProjectUtils.updateProjectDependencies(user, newProjectId, dependencyList);
+				ModelInferenceLogsUtils.createNewWorkspaceEntry(newProjectId,
+						user.getPrimaryLoginToken().getId(),
+						newProjectName, sourceDescription, sourceSystemPrompt, clonedResources);
+				if (sourceConfigJson != null) {
+					ModelInferenceLogsUtils.updateWorkspaceConfigJson(newProjectId, sourceConfigJson);
+				}
+			} catch (Exception e) {
+				classLogger.error("Failed to clone workspace inference log entry from template '{}' to new project '{}'.",
+						projectTemplateId, newProject.getProjectId(), e);
+				// Roll back the project so the user doesn't end up with a broken agent
+				// that exists in the list but throws "Workspace not found" when opened.
+				try {
+					newProject.delete();
+				} catch (Exception rollbackEx) {
+					classLogger.error("Failed to roll back project '{}' after workspace entry clone failure.",
+							newProject.getProjectId(), rollbackEx);
+				}
+				throw new IllegalArgumentException(
+						"Failed to create workspace configuration for cloned agent: " + e.getMessage(), e);
+			}
 		}
 
 		Map<String, Object> retMap = UploadUtilities.getProjectReturnData(this.insight.getUser(),

--- a/src/prerna/reactor/project/CreateAppFromTemplateReactor.java
+++ b/src/prerna/reactor/project/CreateAppFromTemplateReactor.java
@@ -34,6 +34,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +65,9 @@ public class CreateAppFromTemplateReactor extends AbstractReactor {
 	private static final Logger classLogger = LogManager.getLogger(CreateAppFromTemplateReactor.class);
 
 	private static final String CLASS_NAME = CreateAppFromTemplateReactor.class.getName();
+
+	// PROJECTMETA tag marking a project as platform-managed; never copied onto a clone
+	private static final String SYSTEM_TAG = "SYSTEM";
 
 	/*
 	 * This class is used to construct a new project using an existing project as a
@@ -149,9 +153,7 @@ public class CreateAppFromTemplateReactor extends AbstractReactor {
 							+ e.getMessage());
 		}
 
-		// If the template is a WORKSPACE (agent), clone the inference-log workspace
-		// entry and CONFIG_JSON so the new agent inherits all configuration:
-		// system prompt, model selection, MCPs, skills, budgets, hooks, subagents.
+
 		if (IProject.PROJECT_TYPE.WORKSPACE == projectEnumType) {
 			try {
 				User user = this.insight.getUser();
@@ -192,11 +194,30 @@ public class CreateAppFromTemplateReactor extends AbstractReactor {
 				if (sourceConfigJson != null) {
 					ModelInferenceLogsUtils.updateWorkspaceConfigJson(newProjectId, sourceConfigJson);
 				}
+
+				Map<String, Object> sourceTagMeta = SecurityProjectUtils.getAggregateProjectMetadata(projectTemplateId,
+						Arrays.asList("tag"), false);
+				Object sourceTagValue = sourceTagMeta.get("tag");
+				List<Object> sourceTags = new ArrayList<>();
+				if (sourceTagValue instanceof List) {
+					sourceTags.addAll((List<?>) sourceTagValue);
+				} else if (sourceTagValue != null) {
+					sourceTags.add(sourceTagValue);
+				}
+				List<Object> clonedTags = new ArrayList<>();
+				for (Object tag : sourceTags) {
+					if (tag != null && !SYSTEM_TAG.equalsIgnoreCase(tag.toString())) {
+						clonedTags.add(tag);
+					}
+				}
+				if (!clonedTags.isEmpty()) {
+					Map<String, Object> tagUpdate = new HashMap<>();
+					tagUpdate.put("tag", clonedTags);
+					SecurityProjectUtils.updateProjectMetadata(newProjectId, tagUpdate);
+				}
 			} catch (Exception e) {
 				classLogger.error("Failed to clone workspace inference log entry from template '{}' to new project '{}'.",
 						projectTemplateId, newProject.getProjectId(), e);
-				// Roll back the project so the user doesn't end up with a broken agent
-				// that exists in the list but throws "Workspace not found" when opened.
 				try {
 					newProject.delete();
 				} catch (Exception rollbackEx) {


### PR DESCRIPTION
## Description
This PR fixes platform agent cloning so cloned agents are fully initialized as valid workspaces.
Previously, cloning created the new project and copied assets, but did not always create/copy the workspace inference configuration required for agent edit/save flows.

in reference to ticket - [https://github.com/SEMOSS/Semoss/issues/2833](url)
## Changes Made
Added WORKSPACE-specific clone handling in CreateAppFromTemplateReactor.
When cloning an agent template, the clone now copies:
workspace description
system prompt/instructions
workspace resources (including MCP/skill resource links)
full config JSON
Rebuilds workspace resource rows with new workspace_resource_id values for the new cloned workspace.
Updates project dependencies for cloned workspace resources.
Added rollback behavior: if workspace inference/config clone fails, the newly created project is deleted to avoid broken cloned agents.

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Pull this branch 
2. Go to agent page in semoss-ui
3. Clone agent and check to see if it clones with no errors, and all agent MCP selections , skill selections, instructions are copied over.

## Notes
<!-- Any further notes regarding changes -->
This change targets the actual UI clone path used for both app and agent cloning.