### PR TITLE
feat: changes to support fips - pom modifications + image building changes

### DIFF
--- a/.github/workflows/al2023.yml
+++ b/.github/workflows/al2023.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     - cron: '30 7 * * *'  # Runs every day at 7:30 AM UTC, which is 3:30 AM EDT (2:30 AM EST)
 
+
 jobs:
   # ---------------------------------------------------------------------------
   # Resolve the release/non-release naming ONCE so the build legs and the merge
@@ -22,6 +23,8 @@ jobs:
       semoss_version: ${{ steps.vars.outputs.semoss_version }}
       tag_args: ${{ steps.vars.outputs.tag_args }}
       primary_tag: ${{ steps.vars.outputs.primary_tag }}
+      tag_args_fips: ${{ steps.vars.outputs.tag_args_fips }}
+      primary_tag_fips: ${{ steps.vars.outputs.primary_tag_fips }}
     steps:
       - name: Determine image, version and tags
         id: vars
@@ -32,17 +35,23 @@ jobs:
             SV="${{ vars.VERSION }}"
             PRIMARY="${IMAGE}:${{ vars.VERSION }}-al2023"
             TAGS="-t ${PRIMARY}"
+            PRIMARY_FIPS="${IMAGE}:${{ vars.VERSION }}-al2023-fips"
+            TAGS_FIPS="-t ${PRIMARY_FIPS}"
           else
             DATE=$(date +'%Y-%m-%d')
             IMAGE="quay.io/semoss/semoss-dev"
             SV="${{ vars.VERSION }}-SNAPSHOT"
             PRIMARY="${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-al2023-${DATE}"
             TAGS="-t ${PRIMARY} -t ${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-al2023-latest"
+            PRIMARY_FIPS="${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-al2023-fips-${DATE}"
+            TAGS_FIPS="-t ${PRIMARY_FIPS} -t ${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-al2023-fips-latest"
           fi
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
           echo "semoss_version=${SV}" >> "$GITHUB_OUTPUT"
           echo "tag_args=${TAGS}" >> "$GITHUB_OUTPUT"
           echo "primary_tag=${PRIMARY}" >> "$GITHUB_OUTPUT"
+          echo "tag_args_fips=${TAGS_FIPS}" >> "$GITHUB_OUTPUT"
+          echo "primary_tag_fips=${PRIMARY_FIPS}" >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------------------
   # Build each arch natively (amd64 + arm64 CodeBuild fleets) and push BY DIGEST.
@@ -54,13 +63,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Cross-product: (amd64|arm64) x (standard|fips). include entries
+        # match on arch, so they fill in both fips legs.
+        fips: [false, true]
+        arch: [amd64, arm64]
         include:
-          - platform: linux/amd64
-            arch: amd64
+          - arch: amd64
+            platform: linux/amd64
             runner_prefix: codebuild-semoss-github-runner
             container: quay.io/semoss/test-quay:ubuntu-dind
-          - platform: linux/arm64
-            arch: arm64
+          - arch: arm64
+            platform: linux/arm64
             runner_prefix: codebuild-semoss-github-runner-arm64
             container: quay.io/semoss/test-quay:ubuntu-dind-arm64
     runs-on: ${{ matrix.runner_prefix }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -92,6 +105,8 @@ jobs:
           build-args: |
             SEMOSS_VERSION=${{ needs.prepare.outputs.semoss_version }}
             BASE_REGISTRY=public.ecr.aws/amazonlinux
+            TOMCAT_TAG_SUFFIX=${{ matrix.fips && '-fips' || '' }}
+            SEMOSS_FIPS=${{ matrix.fips }}
           outputs: type=image,name=${{ needs.prepare.outputs.image }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -103,7 +118,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.arch }}
+          name: digests-${{ matrix.fips }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -114,12 +129,16 @@ jobs:
   merge:
     needs: [ prepare, build ]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        fips: [false, true]
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-${{ matrix.fips }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -135,8 +154,8 @@ jobs:
       - name: Create and push manifest list
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create ${{ needs.prepare.outputs.tag_args }} \
+          docker buildx imagetools create ${{ matrix.fips && needs.prepare.outputs.tag_args_fips || needs.prepare.outputs.tag_args }} \
             $(printf "${{ needs.prepare.outputs.image }}@sha256:%s " *)
 
       - name: Inspect manifest list
-        run: docker buildx imagetools inspect "${{ needs.prepare.outputs.primary_tag }}"
+        run: docker buildx imagetools inspect "${{ matrix.fips && needs.prepare.outputs.primary_tag_fips || needs.prepare.outputs.primary_tag }}"

--- a/.github/workflows/docker-build-ubi8.yml
+++ b/.github/workflows/docker-build-ubi8.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     - cron: '30 7 * * *'  # Runs every day at 7:30 AM UTC, which is 3:30 AM EDT (2:30 AM EST)
 
+
 jobs:
   # Resolve release/non-release naming once (repo, SEMOSS_VERSION build-arg, tags).
   prepare:
@@ -19,6 +20,8 @@ jobs:
       semoss_version: ${{ steps.vars.outputs.semoss_version }}
       tag_args: ${{ steps.vars.outputs.tag_args }}
       primary_tag: ${{ steps.vars.outputs.primary_tag }}
+      tag_args_fips: ${{ steps.vars.outputs.tag_args_fips }}
+      primary_tag_fips: ${{ steps.vars.outputs.primary_tag_fips }}
     steps:
       - name: Determine image, version and tags
         id: vars
@@ -29,17 +32,23 @@ jobs:
             SV="${{ vars.VERSION }}"
             PRIMARY="${IMAGE}:${{ vars.VERSION }}-ubi8"
             TAGS="-t ${PRIMARY}"
+            PRIMARY_FIPS="${IMAGE}:${{ vars.VERSION }}-ubi8-fips"
+            TAGS_FIPS="-t ${PRIMARY_FIPS}"
           else
             DATE=$(date +'%Y-%m-%d')
             IMAGE="quay.io/semoss/semoss-dev"
             SV="${{ vars.VERSION }}-SNAPSHOT"
             PRIMARY="${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubi8-${DATE}"
             TAGS="-t ${PRIMARY} -t ${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubi8-latest"
+            PRIMARY_FIPS="${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubi8-fips-${DATE}"
+            TAGS_FIPS="-t ${PRIMARY_FIPS} -t ${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubi8-fips-latest"
           fi
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
           echo "semoss_version=${SV}" >> "$GITHUB_OUTPUT"
           echo "tag_args=${TAGS}" >> "$GITHUB_OUTPUT"
           echo "primary_tag=${PRIMARY}" >> "$GITHUB_OUTPUT"
+          echo "tag_args_fips=${TAGS_FIPS}" >> "$GITHUB_OUTPUT"
+          echo "primary_tag_fips=${PRIMARY_FIPS}" >> "$GITHUB_OUTPUT"
 
   # Build each arch natively (amd64 + arm64 CodeBuild fleets) and push BY DIGEST.
   build:
@@ -47,13 +56,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Cross-product: (amd64|arm64) x (standard|fips). include entries
+        # match on arch, so they fill in both fips legs.
+        fips: [false, true]
+        arch: [amd64, arm64]
         include:
-          - platform: linux/amd64
-            arch: amd64
+          - arch: amd64
+            platform: linux/amd64
             runner_prefix: codebuild-semoss-github-runner
             container: quay.io/semoss/test-quay:ubuntu-dind
-          - platform: linux/arm64
-            arch: arm64
+          - arch: arm64
+            platform: linux/arm64
             runner_prefix: codebuild-semoss-github-runner-arm64
             container: quay.io/semoss/test-quay:ubuntu-dind-arm64
     runs-on: ${{ matrix.runner_prefix }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -84,6 +97,8 @@ jobs:
           no-cache: true
           build-args: |
             SEMOSS_VERSION=${{ needs.prepare.outputs.semoss_version }}
+            TOMCAT_TAG_SUFFIX=${{ matrix.fips && '-fips' || '' }}
+            SEMOSS_FIPS=${{ matrix.fips }}
           outputs: type=image,name=${{ needs.prepare.outputs.image }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -95,7 +110,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.arch }}
+          name: digests-${{ matrix.fips }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -104,12 +119,16 @@ jobs:
   merge:
     needs: [ prepare, build ]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        fips: [false, true]
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-${{ matrix.fips }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -125,8 +144,8 @@ jobs:
       - name: Create and push manifest list
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create ${{ needs.prepare.outputs.tag_args }} \
+          docker buildx imagetools create ${{ matrix.fips && needs.prepare.outputs.tag_args_fips || needs.prepare.outputs.tag_args }} \
             $(printf "${{ needs.prepare.outputs.image }}@sha256:%s " *)
 
       - name: Inspect manifest list
-        run: docker buildx imagetools inspect "${{ needs.prepare.outputs.primary_tag }}"
+        run: docker buildx imagetools inspect "${{ matrix.fips && needs.prepare.outputs.primary_tag_fips || needs.prepare.outputs.primary_tag }}"

--- a/.github/workflows/docker-build-ubi9.yml
+++ b/.github/workflows/docker-build-ubi9.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     - cron: '30 7 * * *'  # Runs every day at 7:30 AM UTC, which is 3:30 AM EDT (2:30 AM EST)
 
+
 jobs:
   # Resolve release/non-release naming once (repo, SEMOSS_VERSION build-arg, tags).
   prepare:
@@ -19,6 +20,8 @@ jobs:
       semoss_version: ${{ steps.vars.outputs.semoss_version }}
       tag_args: ${{ steps.vars.outputs.tag_args }}
       primary_tag: ${{ steps.vars.outputs.primary_tag }}
+      tag_args_fips: ${{ steps.vars.outputs.tag_args_fips }}
+      primary_tag_fips: ${{ steps.vars.outputs.primary_tag_fips }}
     steps:
       - name: Determine image, version and tags
         id: vars
@@ -29,17 +32,23 @@ jobs:
             SV="${{ vars.VERSION }}"
             PRIMARY="${IMAGE}:${{ vars.VERSION }}-ubi9"
             TAGS="-t ${PRIMARY}"
+            PRIMARY_FIPS="${IMAGE}:${{ vars.VERSION }}-ubi9-fips"
+            TAGS_FIPS="-t ${PRIMARY_FIPS}"
           else
             DATE=$(date +'%Y-%m-%d')
             IMAGE="quay.io/semoss/semoss-dev"
             SV="${{ vars.VERSION }}-SNAPSHOT"
             PRIMARY="${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubi9-${DATE}"
             TAGS="-t ${PRIMARY} -t ${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubi9-latest"
+            PRIMARY_FIPS="${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubi9-fips-${DATE}"
+            TAGS_FIPS="-t ${PRIMARY_FIPS} -t ${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubi9-fips-latest"
           fi
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
           echo "semoss_version=${SV}" >> "$GITHUB_OUTPUT"
           echo "tag_args=${TAGS}" >> "$GITHUB_OUTPUT"
           echo "primary_tag=${PRIMARY}" >> "$GITHUB_OUTPUT"
+          echo "tag_args_fips=${TAGS_FIPS}" >> "$GITHUB_OUTPUT"
+          echo "primary_tag_fips=${PRIMARY_FIPS}" >> "$GITHUB_OUTPUT"
 
   # Build each arch natively (amd64 + arm64 CodeBuild fleets) and push BY DIGEST.
   build:
@@ -47,13 +56,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Cross-product: (amd64|arm64) x (standard|fips). include entries
+        # match on arch, so they fill in both fips legs.
+        fips: [false, true]
+        arch: [amd64, arm64]
         include:
-          - platform: linux/amd64
-            arch: amd64
+          - arch: amd64
+            platform: linux/amd64
             runner_prefix: codebuild-semoss-github-runner
             container: quay.io/semoss/test-quay:ubuntu-dind
-          - platform: linux/arm64
-            arch: arm64
+          - arch: arm64
+            platform: linux/arm64
             runner_prefix: codebuild-semoss-github-runner-arm64
             container: quay.io/semoss/test-quay:ubuntu-dind-arm64
     runs-on: ${{ matrix.runner_prefix }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -84,6 +97,8 @@ jobs:
           no-cache: true
           build-args: |
             SEMOSS_VERSION=${{ needs.prepare.outputs.semoss_version }}
+            TOMCAT_TAG_SUFFIX=${{ matrix.fips && '-fips' || '' }}
+            SEMOSS_FIPS=${{ matrix.fips }}
           outputs: type=image,name=${{ needs.prepare.outputs.image }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -95,7 +110,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.arch }}
+          name: digests-${{ matrix.fips }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -104,12 +119,16 @@ jobs:
   merge:
     needs: [ prepare, build ]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        fips: [false, true]
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-${{ matrix.fips }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -125,8 +144,8 @@ jobs:
       - name: Create and push manifest list
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create ${{ needs.prepare.outputs.tag_args }} \
+          docker buildx imagetools create ${{ matrix.fips && needs.prepare.outputs.tag_args_fips || needs.prepare.outputs.tag_args }} \
             $(printf "${{ needs.prepare.outputs.image }}@sha256:%s " *)
 
       - name: Inspect manifest list
-        run: docker buildx imagetools inspect "${{ needs.prepare.outputs.primary_tag }}"
+        run: docker buildx imagetools inspect "${{ matrix.fips && needs.prepare.outputs.primary_tag_fips || needs.prepare.outputs.primary_tag }}"

--- a/.github/workflows/tomcat-builder.yml
+++ b/.github/workflows/tomcat-builder.yml
@@ -31,13 +31,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Cross-product: 4 jobs (amd64|arm64) x (standard|fips). The include
+        # entries match on `arch`, so they fill in platform/runner/uname_arch for
+        # both fips values rather than adding extra jobs.
+        fips: [false, true]
+        arch: [amd64, arm64]
         include:
-          - platform: linux/amd64
-            arch: amd64
+          - arch: amd64
+            platform: linux/amd64
             runner: ubuntu-latest
             uname_arch: x86_64
-          - platform: linux/arm64
-            arch: arm64
+          - arch: arm64
+            platform: linux/arm64
             runner: ubuntu-24.04-arm
             uname_arch: aarch64
     runs-on: ${{ matrix.runner }}
@@ -67,6 +72,7 @@ jobs:
           build-args: |
             TOMCAT_VERSION=${{ env.TOMCAT_VERSION }}
             BASE_REGISTRY=public.ecr.aws/docker/library
+            FIPS_ENABLED=${{ matrix.fips }}
           # push-by-digest: publish the blobs + per-arch manifest, but DO NOT tag.
           # The merge job stitches the digests into a single tagged manifest list.
           outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
@@ -85,6 +91,22 @@ jobs:
             test "$(uname -m)" = "${{ matrix.uname_arch }}"
             java -version 2>&1 | grep -q "openjdk version \"25\."
             mvn -version | grep -q "Java version: 25\."
+            if [ "${{ matrix.fips }}" = "true" ]; then
+              test -d "$JAVA_HOME/lib/fips"
+              test -f "$JAVA_HOME/lib/security/cacerts.bcfks"
+              grep -q "^security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider" "$JAVA_HOME/conf/security/java.security"
+              grep -q "^security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider" "$JAVA_HOME/conf/security/java.security"
+              grep -q "approved_only=true" "$TOMCAT_HOME/bin/setenv.sh"
+              echo "FIPS variant verified"
+            else
+              # The standard image must carry NO FIPS artifacts at all, otherwise
+              # FIPS_ENABLED is leaking and the two tags are not really distinct.
+              test ! -e "$JAVA_HOME/lib/fips"
+              test ! -e "$JAVA_HOME/lib/security/cacerts.bcfks"
+              ! grep -q "BouncyCastleFipsProvider" "$JAVA_HOME/conf/security/java.security"
+              ! grep -q "approved_only" "$TOMCAT_HOME/bin/setenv.sh"
+              echo "standard variant verified clean"
+            fi
           '
 
       - name: Export digest
@@ -96,7 +118,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.arch }}
+          name: digests-${{ matrix.fips }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -109,6 +131,10 @@ jobs:
   merge:
     needs: build
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        fips: [false, true]
     env:
       TOMCAT_VERSION: ${{ github.event.inputs.version || '11.0.24' }}
     steps:
@@ -116,7 +142,9 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*
+          # Only this variant's digests, or the two tags would point at a mixed
+          # manifest list containing both FIPS and standard images.
+          pattern: digests-${{ matrix.fips }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -133,11 +161,14 @@ jobs:
         id: meta
         shell: bash
         run: |
-          TAGS=( "-t" "${IMAGE}:${TOMCAT_VERSION}" )
+          SUFFIX=""
+          if [[ "${{ matrix.fips }}" == "true" ]]; then SUFFIX="-fips"; fi
+          TAGS=( "-t" "${IMAGE}:${TOMCAT_VERSION}${SUFFIX}" )
           if [[ "${{ vars.RELEASE }}" == "TRUE" ]]; then
-            TAGS+=( "-t" "${IMAGE}:${TOMCAT_VERSION}-${{ vars.VERSION }}" )
+            TAGS+=( "-t" "${IMAGE}:${TOMCAT_VERSION}-${{ vars.VERSION }}${SUFFIX}" )
           fi
           echo "args=${TAGS[*]}" >> "$GITHUB_OUTPUT"
+          echo "primary=${IMAGE}:${TOMCAT_VERSION}${SUFFIX}" >> "$GITHUB_OUTPUT"
 
       - name: Create and push manifest list
         working-directory: /tmp/digests
@@ -146,4 +177,4 @@ jobs:
             $(printf "${IMAGE}@sha256:%s " *)
 
       - name: Inspect manifest list
-        run: docker buildx imagetools inspect "${IMAGE}:${TOMCAT_VERSION}"
+        run: docker buildx imagetools inspect "${{ steps.meta.outputs.primary }}"

--- a/.github/workflows/ubuntu2204.yml
+++ b/.github/workflows/ubuntu2204.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     - cron: '30 7 * * *'  # Runs every day at 7:30 AM UTC, which is 3:30 AM EDT (2:30 AM EST)
 
+
 jobs:
   # ---------------------------------------------------------------------------
   # Resolve the release/non-release naming ONCE so the build legs and the merge
@@ -22,6 +23,8 @@ jobs:
       semoss_version: ${{ steps.vars.outputs.semoss_version }}
       tag_args: ${{ steps.vars.outputs.tag_args }}
       primary_tag: ${{ steps.vars.outputs.primary_tag }}
+      tag_args_fips: ${{ steps.vars.outputs.tag_args_fips }}
+      primary_tag_fips: ${{ steps.vars.outputs.primary_tag_fips }}
     steps:
       - name: Determine image, version and tags
         id: vars
@@ -32,17 +35,23 @@ jobs:
             SV="${{ vars.VERSION }}"
             PRIMARY="${IMAGE}:${{ vars.VERSION }}-ubuntu22"
             TAGS="-t ${PRIMARY}"
+            PRIMARY_FIPS="${IMAGE}:${{ vars.VERSION }}-ubuntu22-fips"
+            TAGS_FIPS="-t ${PRIMARY_FIPS}"
           else
             DATE=$(date +'%Y-%m-%d')
             IMAGE="quay.io/semoss/semoss-dev"
             SV="${{ vars.VERSION }}-SNAPSHOT"
             PRIMARY="${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubuntu22-${DATE}"
             TAGS="-t ${PRIMARY} -t ${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubuntu22-latest"
+            PRIMARY_FIPS="${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubuntu22-fips-${DATE}"
+            TAGS_FIPS="-t ${PRIMARY_FIPS} -t ${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubuntu22-fips-latest"
           fi
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
           echo "semoss_version=${SV}" >> "$GITHUB_OUTPUT"
           echo "tag_args=${TAGS}" >> "$GITHUB_OUTPUT"
           echo "primary_tag=${PRIMARY}" >> "$GITHUB_OUTPUT"
+          echo "tag_args_fips=${TAGS_FIPS}" >> "$GITHUB_OUTPUT"
+          echo "primary_tag_fips=${PRIMARY_FIPS}" >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------------------
   # Build each arch natively (amd64 + arm64 CodeBuild fleets) and push BY DIGEST.
@@ -54,13 +63,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Cross-product: (amd64|arm64) x (standard|fips). include entries
+        # match on arch, so they fill in both fips legs.
+        fips: [false, true]
+        arch: [amd64, arm64]
         include:
-          - platform: linux/amd64
-            arch: amd64
+          - arch: amd64
+            platform: linux/amd64
             runner_prefix: codebuild-semoss-github-runner
             container: quay.io/semoss/test-quay:ubuntu-dind
-          - platform: linux/arm64
-            arch: arm64
+          - arch: arm64
+            platform: linux/arm64
             runner_prefix: codebuild-semoss-github-runner-arm64
             container: quay.io/semoss/test-quay:ubuntu-dind-arm64
     runs-on: ${{ matrix.runner_prefix }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -92,6 +105,8 @@ jobs:
           build-args: |
             SEMOSS_VERSION=${{ needs.prepare.outputs.semoss_version }}
             BASE_REGISTRY=public.ecr.aws/docker/library
+            TOMCAT_TAG_SUFFIX=${{ matrix.fips && '-fips' || '' }}
+            SEMOSS_FIPS=${{ matrix.fips }}
           outputs: type=image,name=${{ needs.prepare.outputs.image }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -103,7 +118,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-${{ matrix.arch }}
+          name: digests-${{ matrix.fips }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -114,12 +129,16 @@ jobs:
   merge:
     needs: [ prepare, build ]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        fips: [false, true]
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-*
+          pattern: digests-${{ matrix.fips }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -135,8 +154,8 @@ jobs:
       - name: Create and push manifest list
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create ${{ needs.prepare.outputs.tag_args }} \
+          docker buildx imagetools create ${{ matrix.fips && needs.prepare.outputs.tag_args_fips || needs.prepare.outputs.tag_args }} \
             $(printf "${{ needs.prepare.outputs.image }}@sha256:%s " *)
 
       - name: Inspect manifest list
-        run: docker buildx imagetools inspect "${{ needs.prepare.outputs.primary_tag }}"
+        run: docker buildx imagetools inspect "${{ matrix.fips && needs.prepare.outputs.primary_tag_fips || needs.prepare.outputs.primary_tag }}"

--- a/.github/workflows/ubuntu2204_cuda.yml
+++ b/.github/workflows/ubuntu2204_cuda.yml
@@ -12,8 +12,13 @@ on:
   schedule:
     - cron: '30 7 * * *'  # Runs every day at 7:30 AM UTC, which is 3:30 AM EDT (2:30 AM EST)
 
+
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        fips: [false, true]
 
     runs-on: codebuild-semoss-github-runner-${{ github.run_id }}-${{ github.run_attempt }}
     container:
@@ -44,14 +49,17 @@ jobs:
       - name: Determine Image Tag and Repository
         id: vars
         run: |
+          # -fips goes on the flavour segment so "latest" stays the trailing word
+          SUFFIX=""
+          if [ "${{ matrix.fips }}" = "true" ]; then SUFFIX="-fips"; fi
           if [ "${{ vars.RELEASE }}" = "TRUE" ]; then
             echo "IMAGE_REPO=semoss/semoss" >> $GITHUB_ENV
-            echo "IMAGE_TAG=${{ vars.VERSION }}-ubuntu22-cuda" >> $GITHUB_ENV
+            echo "IMAGE_TAG=${{ vars.VERSION }}-ubuntu22-cuda${SUFFIX}" >> $GITHUB_ENV
           else
             DATE=$(date +'%Y-%m-%d')
             echo "IMAGE_REPO=semoss/semoss-dev" >> $GITHUB_ENV
-            echo "IMAGE_TAG=${{ vars.VERSION }}-SNAPSHOT--ubuntu22-cuda-$DATE" >> $GITHUB_ENV
-            echo "IMAGE_TAG_LATEST=${{ vars.VERSION }}-SNAPSHOT--ubuntu22-cuda-latest" >> $GITHUB_ENV
+            echo "IMAGE_TAG=${{ vars.VERSION }}-SNAPSHOT--ubuntu22-cuda${SUFFIX}-$DATE" >> $GITHUB_ENV
+            echo "IMAGE_TAG_LATEST=${{ vars.VERSION }}-SNAPSHOT--ubuntu22-cuda${SUFFIX}-latest" >> $GITHUB_ENV
           fi
           
       - name: Build and push Ubuntu Docker image - Release Build
@@ -67,6 +75,8 @@ jobs:
           build-args: |
             SEMOSS_VERSION=${{ vars.VERSION }}
             BASE_REGISTRY=public.ecr.aws
+            TOMCAT_TAG_SUFFIX=${{ matrix.fips && '-fips' || '' }}
+            SEMOSS_FIPS=${{ matrix.fips }}
 
       - name: Build and push Ubuntu Docker image - Non-Release Build
         if: ${{ vars.RELEASE == 'FALSE' }}
@@ -83,3 +93,5 @@ jobs:
           build-args: |
             SEMOSS_VERSION=${{ vars.VERSION }}-SNAPSHOT
             BASE_REGISTRY=public.ecr.aws
+            TOMCAT_TAG_SUFFIX=${{ matrix.fips && '-fips' || '' }}
+            SEMOSS_FIPS=${{ matrix.fips }}

--- a/.github/workflows/ubuntu2404.yml
+++ b/.github/workflows/ubuntu2404.yml
@@ -10,6 +10,7 @@ on:
   schedule:
     - cron: '30 7 * * *'  # Runs every day at 7:30 AM UTC, which is 3:30 AM EDT (2:30 AM EST)
 
+
 jobs:
   # ---------------------------------------------------------------------------
   # Resolve the release/non-release naming ONCE so the build legs and the merge
@@ -22,6 +23,8 @@ jobs:
       semoss_version: ${{ steps.vars.outputs.semoss_version }}
       tag_args: ${{ steps.vars.outputs.tag_args }}
       primary_tag: ${{ steps.vars.outputs.primary_tag }}
+      tag_args_fips: ${{ steps.vars.outputs.tag_args_fips }}
+      primary_tag_fips: ${{ steps.vars.outputs.primary_tag_fips }}
     steps:
       - name: Determine image, version and tags
         id: vars
@@ -32,17 +35,23 @@ jobs:
             SV="${{ vars.VERSION }}"
             PRIMARY="${IMAGE}:${{ vars.VERSION }}-ubuntu24"
             TAGS="-t ${PRIMARY}"
+            PRIMARY_FIPS="${IMAGE}:${{ vars.VERSION }}-ubuntu24-fips"
+            TAGS_FIPS="-t ${PRIMARY_FIPS}"
           else
             DATE=$(date +'%Y-%m-%d')
             IMAGE="quay.io/semoss/semoss-dev"
             SV="${{ vars.VERSION }}-SNAPSHOT"
             PRIMARY="${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubuntu24-${DATE}"
             TAGS="-t ${PRIMARY} -t ${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubuntu24-latest"
+            PRIMARY_FIPS="${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubuntu24-fips-${DATE}"
+            TAGS_FIPS="-t ${PRIMARY_FIPS} -t ${IMAGE}:${{ vars.VERSION }}-SNAPSHOT-ubuntu24-fips-latest"
           fi
           echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
           echo "semoss_version=${SV}" >> "$GITHUB_OUTPUT"
           echo "tag_args=${TAGS}" >> "$GITHUB_OUTPUT"
           echo "primary_tag=${PRIMARY}" >> "$GITHUB_OUTPUT"
+          echo "tag_args_fips=${TAGS_FIPS}" >> "$GITHUB_OUTPUT"
+          echo "primary_tag_fips=${PRIMARY_FIPS}" >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------------------
   # Build each arch natively (amd64 + arm64 CodeBuild fleets) and push BY DIGEST.
@@ -54,14 +63,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Cross-product: (amd64|arm64) x (standard|fips). include entries
+        # match on arch, so they fill in both fips legs.
+        fips: [false, true]
+        arch: [amd64, arm64]
         include:
-          - platform: linux/amd64
-            arch: amd64
+          - arch: amd64
+            platform: linux/amd64
             uname_arch: x86_64
             runner_prefix: codebuild-semoss-github-runner
             container: quay.io/semoss/test-quay:ubuntu-dind
-          - platform: linux/arm64
-            arch: arm64
+          - arch: arm64
+            platform: linux/arm64
             uname_arch: aarch64
             runner_prefix: codebuild-semoss-github-runner-arm64
             container: quay.io/semoss/test-quay:ubuntu-dind-arm64
@@ -94,6 +107,8 @@ jobs:
           build-args: |
             SEMOSS_VERSION=${{ needs.prepare.outputs.semoss_version }}
             BASE_REGISTRY=public.ecr.aws/docker/library
+            TOMCAT_TAG_SUFFIX=${{ matrix.fips && '-fips' || '' }}
+            SEMOSS_FIPS=${{ matrix.fips }}
           outputs: type=image,name=${{ needs.prepare.outputs.image }},push-by-digest=true,name-canonical=true,push=true
 
       # Java comes from the ARG defaults in Dockerfile.tomcat, so match on the
@@ -150,7 +165,7 @@ jobs:
       - name: Upload digest
         uses: actions/upload-artifact@v4
         with:
-          name: digests-ubuntu24-${{ matrix.arch }}
+          name: digests-${{ matrix.fips }}-${{ matrix.arch }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
@@ -161,12 +176,16 @@ jobs:
   merge:
     needs: [ prepare, build ]
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        fips: [false, true]
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
         with:
           path: /tmp/digests
-          pattern: digests-ubuntu24-*
+          pattern: digests-${{ matrix.fips }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
@@ -182,8 +201,8 @@ jobs:
       - name: Create and push manifest list
         working-directory: /tmp/digests
         run: |
-          docker buildx imagetools create ${{ needs.prepare.outputs.tag_args }} \
+          docker buildx imagetools create ${{ matrix.fips && needs.prepare.outputs.tag_args_fips || needs.prepare.outputs.tag_args }} \
             $(printf "${{ needs.prepare.outputs.image }}@sha256:%s " *)
 
       - name: Inspect manifest list
-        run: docker buildx imagetools inspect "${{ needs.prepare.outputs.primary_tag }}"
+        run: docker buildx imagetools inspect "${{ matrix.fips && needs.prepare.outputs.primary_tag_fips || needs.prepare.outputs.primary_tag }}"

--- a/docker/Dockerfile.al2023
+++ b/docker/Dockerfile.al2023
@@ -7,11 +7,19 @@ ARG COPILOT_VERSION=latest
 
 #global argument for tomcat
 ARG TOMCAT_VERSION=11.0.24
+# Which tomcat-builder variant to base on. Empty = the standard image; pass
+#   --build-arg TOMCAT_TAG_SUFFIX=-fips
+# for the FIPS 140-3 variant. Only the SUFFIX crosses the workflow boundary, so
+# TOMCAT_VERSION above stays the single source of truth for the version.
+# A -fips base MUST be paired with SEMOSS_FIPS=true, or the war brings its own
+# BouncyCastle into WEB-INF/lib beside the validated bc-fips and the result
+# boots cleanly while being non-compliant.
+ARG TOMCAT_TAG_SUFFIX=
 ARG JAVA_HOME=/usr/lib/jvm/zulu25
 ARG MAVEN_HOME=/opt/apache-maven-3.9.14
 
 #setting up the tomcat builder for later below. this is for env var expansion.
-FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION} AS tomcat_builder
+FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION}${TOMCAT_TAG_SUFFIX} AS tomcat_builder
 ARG COPILOT_VERSION
 # Provided automatically by buildx (amd64/arm64). Defaults to amd64 when building
 # without buildx (TARGETARCH unset). copilot uses x64/arm64.
@@ -44,11 +52,15 @@ ARG TOMCAT_VERSION
 ARG JAVA_HOME
 ARG MAVEN_HOME
 ARG SEMOSS_VERSION
+# Selects the fips / libraries-fips Maven classifiers in
+# update_latest_dev.sh. Must be true whenever TOMCAT_TAG is a -fips tag.
+ARG SEMOSS_FIPS=false
 ENV JAVA_HOME=${JAVA_HOME}
 ENV TOMCAT_HOME=/opt/apache-tomcat-${TOMCAT_VERSION}
 ENV MAVEN_HOME=${MAVEN_HOME}
 ENV PATH=$PATH:$MAVEN_HOME/bin:$TOMCAT_HOME/bin:$JAVA_HOME/bin
 ENV SEMOSS_VERSION=${SEMOSS_VERSION}
+ENV SEMOSS_FIPS=${SEMOSS_FIPS}
 ENV MAVEN_ARGS="-B -ntp"
 # ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/Dockerfile.nvidia.cuda.12.5.1.ubuntu22.04
+++ b/docker/Dockerfile.nvidia.cuda.12.5.1.ubuntu22.04
@@ -6,11 +6,19 @@ ARG COPILOT_VERSION=latest
 
 #global argument for tomcat
 ARG TOMCAT_VERSION=11.0.24
+# Which tomcat-builder variant to base on. Empty = the standard image; pass
+#   --build-arg TOMCAT_TAG_SUFFIX=-fips
+# for the FIPS 140-3 variant. Only the SUFFIX crosses the workflow boundary, so
+# TOMCAT_VERSION above stays the single source of truth for the version.
+# A -fips base MUST be paired with SEMOSS_FIPS=true, or the war brings its own
+# BouncyCastle into WEB-INF/lib beside the validated bc-fips and the result
+# boots cleanly while being non-compliant.
+ARG TOMCAT_TAG_SUFFIX=
 ARG JAVA_HOME=/usr/lib/jvm/zulu25
 ARG MAVEN_HOME=/opt/apache-maven-3.9.14
 
 #setting up the tomcat builder for later below. this is for env var expansion.
-FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION} AS tomcat_builder
+FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION}${TOMCAT_TAG_SUFFIX} AS tomcat_builder
 ARG COPILOT_VERSION
 
 RUN apt-get update -y \
@@ -35,11 +43,15 @@ ARG TOMCAT_VERSION
 ARG JAVA_HOME
 ARG MAVEN_HOME
 ARG SEMOSS_VERSION
+# Selects the fips / libraries-fips Maven classifiers in
+# update_latest_dev.sh. Must be true whenever TOMCAT_TAG is a -fips tag.
+ARG SEMOSS_FIPS=false
 ENV JAVA_HOME=${JAVA_HOME}
 ENV TOMCAT_HOME=/opt/apache-tomcat-${TOMCAT_VERSION}
 ENV MAVEN_HOME=${MAVEN_HOME}
 ENV PATH=$PATH:$MAVEN_HOME/bin:$TOMCAT_HOME/bin:$JAVA_HOME/bin
 ENV SEMOSS_VERSION=${SEMOSS_VERSION}
+ENV SEMOSS_FIPS=${SEMOSS_FIPS}
 
 
 # Get tomcat, maven and java from another image called tomcat-builder

--- a/docker/Dockerfile.tomcat
+++ b/docker/Dockerfile.tomcat
@@ -12,6 +12,36 @@ ARG AZUL_ZULU_VERSION=25.34.17
 ARG JAVA_HOME=/usr/lib/jvm/zulu25
 ARG JDK_VERSION=25.0.3
 
+# FIPS 140-3 build switch. This file produces two images from one definition:
+#
+#   docker build -f Dockerfile.tomcat -t quay.io/semoss/tomcat-builder:11.0.24 .
+#   docker build -f Dockerfile.tomcat --build-arg FIPS_ENABLED=true \
+#       -t quay.io/semoss/tomcat-builder:11.0.24-fips .
+#
+# With FIPS_ENABLED=false nothing below is installed, so the non-FIPS image is
+# byte-identical to what it was before this switch existed. Downstream images
+# pick a base with --build-arg TOMCAT_TAG=11.0.24-fips.
+#
+# IMPORTANT: a -fips base must be paired with a war built using -P dev,fips.
+# A default war carries BouncyCastle in WEB-INF/lib, which would sit alongside
+# the validated bc-fips on the system classloader - two copies of the
+# org.bouncycastle.* namespace across two classloaders. That combination boots
+# cleanly and is quietly non-compliant.
+ARG FIPS_ENABLED=false
+
+# BouncyCastle FIPS provider jars, staged into ${JAVA_HOME}/lib/fips so they
+# travel with the existing "COPY --from=tomcat_builder /usr/lib/jvm/zulu25"
+# in every downstream image.
+#
+# Only bc-fips is the CMVP-validated module - bctls/bcpkix/bcutil are companion
+# libraries outside the certificate boundary that call into it. Before bumping
+# BC_FIPS_VERSION, confirm the new version is on the CMVP active list, not just
+# published to Maven Central.
+ARG BC_FIPS_VERSION=2.1.2
+ARG BCTLS_FIPS_VERSION=2.1.24
+ARG BCPKIX_FIPS_VERSION=2.1.12
+ARG BCUTIL_FIPS_VERSION=2.1.7
+
 # Maven default version
 ARG MAVEN_HOME=/opt/apache-maven-3.9.14
 
@@ -35,6 +65,13 @@ ARG AZUL_ZULU_VERSION
 ARG JAVA_HOME
 ARG JDK_VERSION
 
+# BouncyCastle FIPS arguments
+ARG FIPS_ENABLED
+ARG BC_FIPS_VERSION
+ARG BCTLS_FIPS_VERSION
+ARG BCPKIX_FIPS_VERSION
+ARG BCUTIL_FIPS_VERSION
+
 
 #JAVA env values for install_java.sh
 ENV AZUL_ZULU_VERSION=${AZUL_ZULU_VERSION}
@@ -45,7 +82,6 @@ LABEL maintainer="semoss@semoss.org"
 ENV TOMCAT_HOME=${TOMCAT_HOME}
 ENV JAVA_HOME=${JAVA_HOME}
 ENV PATH=$PATH:$MAVEN_HOME/bin:$TOMCAT_HOME/bin:$JAVA_HOME/bin
-# Needed for JEP
 
 RUN printenv | grep -E '^(JAVA_HOME|TOMCAT_HOME|MAVEN_HOME|PATH)=' | awk '{print "export " $0}' >> /opt/set_env.env
 
@@ -82,6 +118,10 @@ RUN apt-get -y install apt-transport-https ca-certificates git wget dirmngr gnup
 	&& chmod +x config.sh \
 	&& /bin/bash config.sh \
 	&& echo 'CATALINA_PID="$CATALINA_BASE/bin/catalina.pid"' > $TOMCAT_HOME/bin/setenv.sh \
+	&& echo '# Let ${VAR} / ${VAR:-default} in server.xml and context.xml resolve against' >> $TOMCAT_HOME/bin/setenv.sh \
+	&& echo '# container environment variables. Tomcat keeps its SystemPropertySource too,' >> $TOMCAT_HOME/bin/setenv.sh \
+	&& echo '# so -D overrides still work. Used by the <Manager> in conf/context.xml.' >> $TOMCAT_HOME/bin/setenv.sh \
+	&& echo 'CATALINA_OPTS="$CATALINA_OPTS -Dorg.apache.tomcat.util.digester.PROPERTY_SOURCE=org.apache.tomcat.util.digester.EnvironmentPropertySource"' >> $TOMCAT_HOME/bin/setenv.sh \
 	&& wget https://archive.apache.org/dist/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz\
 	&& tar -zxvf apache-maven-*.tar.gz \
 	&& mkdir /opt/apache-maven-3.9.14 \
@@ -97,11 +137,88 @@ RUN apt-get -y install apt-transport-https ca-certificates git wget dirmngr gnup
 	&& chmod 777 /opt/apache-maven-3.9.14/bin/*.cmd \
 	&& apt-get clean all
 
+# ---------------------------------------------------------------------------
+# FIPS 140-3 wiring. Entirely skipped when FIPS_ENABLED != true.
+#
+# Step order matters: the truststore is converted BEFORE the provider swap,
+# because JKS integrity checking is SHA-1 based and keytool can no longer read
+# the source store once approved-only mode is in force.
+# ---------------------------------------------------------------------------
+RUN if [ "$FIPS_ENABLED" != "true" ]; then echo "FIPS_ENABLED=$FIPS_ENABLED - skipping FIPS wiring"; exit 0; fi; \
+	set -eux; \
+	\
+	# 1. Stage the provider jars. Hashes are pinned here on purpose rather than
+	#    fetched alongside the jars - pulling an artifact and its checksum from
+	#    the same source verifies nothing. A mismatch fails the build, which is
+	#    the intended behavior for a compliance boundary.
+	M2=https://repo1.maven.org/maven2/org/bouncycastle; \
+	mkdir -p ${JAVA_HOME}/lib/fips; \
+	cd ${JAVA_HOME}/lib/fips; \
+	wget -q $M2/bc-fips/${BC_FIPS_VERSION}/bc-fips-${BC_FIPS_VERSION}.jar; \
+	wget -q $M2/bctls-fips/${BCTLS_FIPS_VERSION}/bctls-fips-${BCTLS_FIPS_VERSION}.jar; \
+	wget -q $M2/bcpkix-fips/${BCPKIX_FIPS_VERSION}/bcpkix-fips-${BCPKIX_FIPS_VERSION}.jar; \
+	wget -q $M2/bcutil-fips/${BCUTIL_FIPS_VERSION}/bcutil-fips-${BCUTIL_FIPS_VERSION}.jar; \
+	{ echo "044fcd8a29d236edea8a5b414406cdae63b475f9ad9f05fe2dc904a277941115  bc-fips-${BC_FIPS_VERSION}.jar"; \
+	  echo "d2233207daecc2dfccdc317a53bd874b12c21a6dc5be78e390d8826eb726194c  bctls-fips-${BCTLS_FIPS_VERSION}.jar"; \
+	  echo "48f418d70c9551ac9225f333e5e9dfe872b4501cc566728b6d2bc7364a2223d4  bcpkix-fips-${BCPKIX_FIPS_VERSION}.jar"; \
+	  echo "a30e550f06dcfa0fd7da1e9a501f111421406fa237467522b3ca05187429832d  bcutil-fips-${BCUTIL_FIPS_VERSION}.jar"; } > sha256.manifest; \
+	sha256sum -c sha256.manifest; \
+	rm sha256.manifest; \
+	\
+	# 2. Convert the truststore while the stock providers can still read JKS.
+	keytool -importkeystore -noprompt \
+		-srckeystore ${JAVA_HOME}/lib/security/cacerts -srcstoretype JKS -srcstorepass changeit \
+		-destkeystore ${JAVA_HOME}/lib/security/cacerts.bcfks -deststoretype BCFKS -deststorepass changeit \
+		-providername BCFIPS \
+		-providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
+		-providerpath ${JAVA_HOME}/lib/fips/bc-fips-${BC_FIPS_VERSION}.jar; \
+	\
+	# 3. Register BCFIPS/BCJSSE and drop the rest. SUN must stay: BCFIPS seeds its
+	#    DRBG from a core SecureRandom, and without SUN that lookup recurses back
+	#    into BCFIPS and dies with StackOverflowError. BCFIPS supplies X.509
+	#    CertificateFactory and PKIX CertPathValidator itself, so SUN is only an
+	#    entropy seed source - fine for compliance, the approved DRBG is still
+	#    BCFIPS's. Consequence: SUN also serves MD5, so approved-only mode cannot
+	#    block MD5 for application code. That has to be caught by code review.
+	sed -i -E '/^security\.provider\.[0-9]+=/d' ${JAVA_HOME}/conf/security/java.security; \
+	printf '%s\n' \
+		'security.provider.1=org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider' \
+		'security.provider.2=org.bouncycastle.jsse.provider.BouncyCastleJsseProvider fips:BCFIPS' \
+		'security.provider.3=SUN' \
+		>> ${JAVA_HOME}/conf/security/java.security; \
+	\
+	# 4. Providers named in java.security load from the SYSTEM classloader, so the
+	#    jars go on CLASSPATH. $TOMCAT_HOME/lib would not work - that is Tomcat's
+	#    common classloader, which is not consulted for provider loading.
+	{ echo ''; \
+	  echo '# --- FIPS 140-3 ---'; \
+	  echo 'FIPS_LIB="$JAVA_HOME/lib/fips"'; \
+	  echo '# Prepended, not assigned, so a container-level CLASSPATH survives. The'; \
+	  echo '# provider jars must come first regardless.'; \
+	  echo "CLASSPATH=\"\$FIPS_LIB/bc-fips-${BC_FIPS_VERSION}.jar:\$FIPS_LIB/bctls-fips-${BCTLS_FIPS_VERSION}.jar:\$FIPS_LIB/bcpkix-fips-${BCPKIX_FIPS_VERSION}.jar:\$FIPS_LIB/bcutil-fips-${BCUTIL_FIPS_VERSION}.jar\${CLASSPATH:+:\$CLASSPATH}\""; \
+	  echo 'export CLASSPATH'; \
+	  echo 'CATALINA_OPTS="$CATALINA_OPTS -Dorg.bouncycastle.fips.approved_only=true"'; \
+	  echo 'CATALINA_OPTS="$CATALINA_OPTS -Djavax.net.ssl.trustStore=$JAVA_HOME/lib/security/cacerts.bcfks"'; \
+	  echo 'CATALINA_OPTS="$CATALINA_OPTS -Djavax.net.ssl.trustStoreType=BCFKS"'; \
+	  echo 'CATALINA_OPTS="$CATALINA_OPTS -Djavax.net.ssl.trustStorePassword=changeit"'; \
+	  echo '# Session id entropy. conf/context.xml reads these; without them Tomcat'; \
+	  echo '# defaults to SHA1PRNG, which BCFIPS does not implement, so JSESSIONID'; \
+	  echo '# generation silently falls through to SUN.'; \
+	  echo ': "${SESSION_SECURE_RANDOM_PROVIDER:=BCFIPS}"'; \
+	  echo ': "${SESSION_SECURE_RANDOM_ALGORITHM:=DEFAULT}"'; \
+	  echo 'export SESSION_SECURE_RANDOM_PROVIDER SESSION_SECURE_RANDOM_ALGORITHM'; } \
+	  >> $TOMCAT_HOME/bin/setenv.sh
+
 FROM scratch AS final
 ARG JAVA_HOME
 ARG TOMCAT_HOME
 ARG MAVEN_HOME
+ARG FIPS_ENABLED
 LABEL maintainer="semoss@semoss.org"
+# Lets downstream builds and running containers self-identify:
+#   docker inspect -f '{{index .Config.Labels "org.semoss.fips"}}' <image>
+LABEL org.semoss.fips="${FIPS_ENABLED}"
+ENV SEMOSS_FIPS=${FIPS_ENABLED}
 
 ENV TOMCAT_HOME=$TOMCAT_HOME
 ENV JAVA_HOME=$JAVA_HOME

--- a/docker/Dockerfile.ubi8
+++ b/docker/Dockerfile.ubi8
@@ -6,11 +6,19 @@ ARG COPILOT_VERSION=latest
 
 #global argument for tomcat
 ARG TOMCAT_VERSION=11.0.24
+# Which tomcat-builder variant to base on. Empty = the standard image; pass
+#   --build-arg TOMCAT_TAG_SUFFIX=-fips
+# for the FIPS 140-3 variant. Only the SUFFIX crosses the workflow boundary, so
+# TOMCAT_VERSION above stays the single source of truth for the version.
+# A -fips base MUST be paired with SEMOSS_FIPS=true, or the war brings its own
+# BouncyCastle into WEB-INF/lib beside the validated bc-fips and the result
+# boots cleanly while being non-compliant.
+ARG TOMCAT_TAG_SUFFIX=
 ARG JAVA_HOME=/usr/lib/jvm/zulu25
 ARG MAVEN_HOME=/opt/apache-maven-3.9.14
 
 #setting up the tomcat builder for later below. this is for env var expansion.
-FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION} AS tomcat_builder
+FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION}${TOMCAT_TAG_SUFFIX} AS tomcat_builder
 ARG COPILOT_VERSION
 # Provided automatically by buildx (amd64/arm64). Defaults to amd64 when building
 # without buildx (TARGETARCH unset).
@@ -42,11 +50,15 @@ ARG TOMCAT_VERSION
 ARG JAVA_HOME
 ARG MAVEN_HOME
 ARG SEMOSS_VERSION
+# Selects the fips / libraries-fips Maven classifiers in
+# update_latest_dev.sh. Must be true whenever TOMCAT_TAG is a -fips tag.
+ARG SEMOSS_FIPS=false
 ENV JAVA_HOME=${JAVA_HOME}
 ENV TOMCAT_HOME=/opt/apache-tomcat-${TOMCAT_VERSION}
 ENV MAVEN_HOME=${MAVEN_HOME}
 ENV PATH=$PATH:$MAVEN_HOME/bin:$TOMCAT_HOME/bin:$JAVA_HOME/bin
 ENV SEMOSS_VERSION=${SEMOSS_VERSION}
+ENV SEMOSS_FIPS=${SEMOSS_FIPS}
 
 # Get tomcat, maven and java from another image called tomcat-builder
 COPY --from=tomcat_builder /opt /opt

--- a/docker/Dockerfile.ubi9
+++ b/docker/Dockerfile.ubi9
@@ -6,11 +6,19 @@ ARG COPILOT_VERSION=latest
 
 #global argument for tomcat
 ARG TOMCAT_VERSION=11.0.24
+# Which tomcat-builder variant to base on. Empty = the standard image; pass
+#   --build-arg TOMCAT_TAG_SUFFIX=-fips
+# for the FIPS 140-3 variant. Only the SUFFIX crosses the workflow boundary, so
+# TOMCAT_VERSION above stays the single source of truth for the version.
+# A -fips base MUST be paired with SEMOSS_FIPS=true, or the war brings its own
+# BouncyCastle into WEB-INF/lib beside the validated bc-fips and the result
+# boots cleanly while being non-compliant.
+ARG TOMCAT_TAG_SUFFIX=
 ARG JAVA_HOME=/usr/lib/jvm/zulu25
 ARG MAVEN_HOME=/opt/apache-maven-3.9.14
 
 #setting up the tomcat builder for later below. this is for env var expansion.
-FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION} AS tomcat_builder
+FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION}${TOMCAT_TAG_SUFFIX} AS tomcat_builder
 ARG COPILOT_VERSION
 # Provided automatically by buildx (amd64/arm64). Defaults to amd64 when building
 # without buildx (TARGETARCH unset).
@@ -41,11 +49,15 @@ ARG TOMCAT_VERSION
 ARG JAVA_HOME
 ARG MAVEN_HOME
 ARG SEMOSS_VERSION
+# Selects the fips / libraries-fips Maven classifiers in
+# update_latest_dev.sh. Must be true whenever TOMCAT_TAG is a -fips tag.
+ARG SEMOSS_FIPS=false
 ENV JAVA_HOME=${JAVA_HOME}
 ENV TOMCAT_HOME=/opt/apache-tomcat-${TOMCAT_VERSION}
 ENV MAVEN_HOME=${MAVEN_HOME}
 ENV PATH=$PATH:$MAVEN_HOME/bin:$TOMCAT_HOME/bin:$JAVA_HOME/bin
 ENV SEMOSS_VERSION=${SEMOSS_VERSION}
+ENV SEMOSS_FIPS=${SEMOSS_FIPS}
 
 # Get tomcat, maven and java from another image called tomcat-builder
 COPY --from=tomcat_builder /opt /opt

--- a/docker/Dockerfile.ubuntu22.04
+++ b/docker/Dockerfile.ubuntu22.04
@@ -7,11 +7,19 @@ ARG COPILOT_VERSION=latest
 
 #global argument for tomcat
 ARG TOMCAT_VERSION=11.0.24
+# Which tomcat-builder variant to base on. Empty = the standard image; pass
+#   --build-arg TOMCAT_TAG_SUFFIX=-fips
+# for the FIPS 140-3 variant. Only the SUFFIX crosses the workflow boundary, so
+# TOMCAT_VERSION above stays the single source of truth for the version.
+# A -fips base MUST be paired with SEMOSS_FIPS=true, or the war brings its own
+# BouncyCastle into WEB-INF/lib beside the validated bc-fips and the result
+# boots cleanly while being non-compliant.
+ARG TOMCAT_TAG_SUFFIX=
 ARG JAVA_HOME=/usr/lib/jvm/zulu25
 ARG MAVEN_HOME=/opt/apache-maven-3.9.14
 
 #setting up the tomcat builder for later below. this is for env var expansion.
-FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION} AS tomcat_builder
+FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION}${TOMCAT_TAG_SUFFIX} AS tomcat_builder
 ARG COPILOT_VERSION
 # Provided automatically by buildx (amd64/arm64). Defaults to amd64 when building
 # without buildx (TARGETARCH unset). copilot uses x64/arm64.
@@ -42,11 +50,15 @@ ARG TOMCAT_VERSION
 ARG JAVA_HOME
 ARG MAVEN_HOME
 ARG SEMOSS_VERSION
+# Selects the fips / libraries-fips Maven classifiers in
+# update_latest_dev.sh. Must be true whenever TOMCAT_TAG is a -fips tag.
+ARG SEMOSS_FIPS=false
 ENV JAVA_HOME=${JAVA_HOME}
 ENV TOMCAT_HOME=/opt/apache-tomcat-${TOMCAT_VERSION}
 ENV MAVEN_HOME=${MAVEN_HOME}
 ENV PATH=$PATH:$MAVEN_HOME/bin:$TOMCAT_HOME/bin:$JAVA_HOME/bin
 ENV SEMOSS_VERSION=${SEMOSS_VERSION}
+ENV SEMOSS_FIPS=${SEMOSS_FIPS}
 ENV MAVEN_ARGS="-B -ntp"
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/Dockerfile.ubuntu24.04
+++ b/docker/Dockerfile.ubuntu24.04
@@ -7,11 +7,19 @@ ARG COPILOT_VERSION=latest
 
 #global argument for tomcat
 ARG TOMCAT_VERSION=11.0.24
+# Which tomcat-builder variant to base on. Empty = the standard image; pass
+#   --build-arg TOMCAT_TAG_SUFFIX=-fips
+# for the FIPS 140-3 variant. Only the SUFFIX crosses the workflow boundary, so
+# TOMCAT_VERSION above stays the single source of truth for the version.
+# A -fips base MUST be paired with SEMOSS_FIPS=true, or the war brings its own
+# BouncyCastle into WEB-INF/lib beside the validated bc-fips and the result
+# boots cleanly while being non-compliant.
+ARG TOMCAT_TAG_SUFFIX=
 ARG JAVA_HOME=/usr/lib/jvm/zulu25
 ARG MAVEN_HOME=/opt/apache-maven-3.9.14
 
 #setting up the tomcat builder for later below. this is for env var expansion.
-FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION} AS tomcat_builder
+FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION}${TOMCAT_TAG_SUFFIX} AS tomcat_builder
 ARG COPILOT_VERSION
 # Provided automatically by buildx (amd64/arm64). Defaults to amd64 when building
 # without buildx (TARGETARCH unset). copilot uses x64/arm64.
@@ -42,11 +50,15 @@ ARG TOMCAT_VERSION
 ARG JAVA_HOME
 ARG MAVEN_HOME
 ARG SEMOSS_VERSION
+# Selects the fips / libraries-fips Maven classifiers in
+# update_latest_dev.sh. Must be true whenever TOMCAT_TAG is a -fips tag.
+ARG SEMOSS_FIPS=false
 ENV JAVA_HOME=${JAVA_HOME}
 ENV TOMCAT_HOME=/opt/apache-tomcat-${TOMCAT_VERSION}
 ENV MAVEN_HOME=${MAVEN_HOME}
 ENV PATH=$PATH:$MAVEN_HOME/bin:$TOMCAT_HOME/bin:$JAVA_HOME/bin
 ENV SEMOSS_VERSION=${SEMOSS_VERSION}
+ENV SEMOSS_FIPS=${SEMOSS_FIPS}
 ENV MAVEN_ARGS="-B -ntp"
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/docker/FIPS.README.md
+++ b/docker/FIPS.README.md
@@ -1,0 +1,265 @@
+# FIPS 140-3 Builds
+
+How SEMOSS produces a FIPS 140-3 image, what changes across the three repos, and
+what is deliberately still out of scope.
+
+
+## 1. What is actually being validated
+
+FIPS 140-3 validates a **cryptographic module**, not an application. Tomcat and
+SEMOSS are consumers. Three things have to be true:
+
+1. A validated module is present
+2. It operates in approved mode
+3. All security-relevant cryptography goes through it
+
+The module is **BouncyCastle BC-FJA** (`bc-fips`). The companion jars
+(`bctls-fips`, `bcpkix-fips`, `bcutil-fips`) sit **outside** the certificate
+boundary and call into it. Only `bc-fips` carries the CMVP certificate.
+
+Note what this does NOT require: the JVM does not have to be incapable of
+computing a non-approved algorithm. See section 8.
+
+
+## 2. Layout across the repos
+
+| Repo | Owns |
+|------|------|
+| **Semoss** | `Dockerfile.tomcat` (both tomcat bases), the six final Dockerfiles, all the docker workflows, `PBEncryptionUtility` |
+| **semoss-artifacts** | `update_latest_dev.sh`, `artifacts/lib/pom.xml`, `context-*.xml` |
+| **Monolith** | `libraries.xml` / `libraries-fips.xml`, the local dev overlay, `fips-check.sh` |
+
+Two switches have to agree for an image to be correct:
+
+```
+-fips tomcat (base)        supplies bc-fips on the system classloader
+libraries-fips (tarball)   leaves BouncyCastle out of WEB-INF/lib
+```
+
+One without the other gives you either two copies of `org.bouncycastle.*` across
+two classloaders (ClassCastException on key objects) or none at all. Neither
+fails at build time, which is why the pairing is wired to a single matrix value
+rather than left to whoever runs the build.
+
+
+## 3. Publish: Monolith
+
+A normal deploy publishes **three** artifacts under one version. No flag:
+
+```
+monolith-<ver>.war                     shared by both image variants
+monolith-<ver>-libraries.tar.gz        includes BouncyCastle
+monolith-<ver>-libraries-fips.tar.gz   BouncyCastle removed
+```
+
+The war is shared because it contains only `semoss-<ver>-shaded-dependencies.jar`,
+which Semoss builds and which does not differ between variants. Publishing it
+twice would duplicate 82 MB for nothing.
+
+`libraries-fips.xml` excludes BouncyCastle **by filename**, not by Maven scope.
+That is what lets both tarballs come out of one build: scope changes what lands
+in `target/<finalName>/WEB-INF/lib`, so it would need two builds, whereas a
+filename filter reads the same directory twice.
+
+Both the standard and `-fips` images resolve the same `SEMOSS_VERSION`, so both
+tarballs must exist under that version. A Maven profile toggle would publish only
+one of them per run and the other image would fail to resolve.
+
+The deploy and release jobs assert the split is real in both directions: the fips
+tarball must contain no BouncyCastle, and the standard one must still contain it.
+The second half matters - a descriptor that excluded everything would otherwise
+pass silently.
+
+
+## 4. Build: the tomcat base
+
+`docker/Dockerfile.tomcat` builds both variants from one definition, switched by
+`FIPS_ENABLED`:
+
+```
+tomcat-builder:<ver>        FIPS_ENABLED=false   nothing FIPS-related installed
+tomcat-builder:<ver>-fips   FIPS_ENABLED=true
+```
+
+With `FIPS_ENABLED=true` it, in this order:
+
+1. Downloads the four BouncyCastle jars into `$JAVA_HOME/lib/fips`, verified
+   against SHA-256 hashes pinned in the Dockerfile
+2. Converts `cacerts` to BCFKS
+3. Rewrites `java.security` to BCFIPS / BCJSSE / SUN
+4. Appends the FIPS block to `setenv.sh`
+
+**Step 2 must precede step 3.** JKS integrity checking is SHA-1 based, so once
+approved-only mode is in force keytool can no longer read the source truststore.
+
+Hashes are pinned in the Dockerfile rather than fetched next to the jars.
+Downloading an artifact and its checksum from the same source verifies nothing.
+
+`tomcat-builder.yml` crosses `arch` with `fips` (4 build jobs, 2 merge jobs) and
+asserts each variant is genuinely what it claims - including that the standard
+image contains **no** FIPS artifacts, which catches `FIPS_ENABLED` leaking.
+
+
+## 5. Build: the final images
+
+Each OS workflow runs the same `fips` matrix and passes two build args:
+
+| `matrix.fips` | `TOMCAT_TAG_SUFFIX` | `SEMOSS_FIPS` |
+|---------------|---------------------|---------------|
+| `false`       | (empty)             | `false`       |
+| `true`        | `-fips`             | `true`        |
+
+- `TOMCAT_TAG_SUFFIX` selects the base:
+  `FROM ...tomcat-builder:${TOMCAT_VERSION}${TOMCAT_TAG_SUFFIX}`.
+  Only the suffix crosses the workflow boundary, so `TOMCAT_VERSION` stays
+  defined in exactly one place - the Dockerfile.
+- `SEMOSS_FIPS` becomes an `ENV` that `update_latest_dev.sh` reads.
+
+Resulting tags, with `-fips` on the flavour segment so `latest` stays trailing:
+
+```
+semoss-dev:<ver>-SNAPSHOT-ubuntu22-latest
+semoss-dev:<ver>-SNAPSHOT-ubuntu22-fips-latest
+semoss:<ver>-ubuntu22
+semoss:<ver>-ubuntu22-fips
+```
+
+Same pattern for ubuntu24, ubi8, ubi9, al2023 and cuda.
+
+
+## 6. Resolve: semoss-artifacts
+
+`update_latest_dev.sh` runs inside the image build. It resolves
+`org.semoss:monolith` from Sonatype and unpacks the war and the libraries tarball
+into `$TOMCAT_HOME/webapps/Monolith`.
+
+FIPS is opt-in, off by default. You can run FIPS by either:
+
+```bash
+SEMOSS_FIPS=true update_latest_dev.sh
+update_latest_dev.sh --fips
+```
+
+Either form adds `-Dmonolith.lib.classifier=libraries-fips`, which
+`artifacts/lib/pom.xml` uses to select the tarball. The war has no classifier
+because it is shared.
+
+
+## 7. Session IDs
+
+Tomcat's `SessionIdGeneratorBase` defaults to `secureRandomAlgorithm="SHA1PRNG"`
+with no provider. **BCFIPS does not implement SHA1PRNG**, so that lookup resolves
+to SUN and JSESSIONID entropy comes from outside the validated module, with
+nothing logged.
+
+`context-*.xml` in semoss-artifacts carries a parameterised Manager:
+
+```xml
+<Manager secureRandomProvider="${SESSION_SECURE_RANDOM_PROVIDER:-}"
+         secureRandomAlgorithm="${SESSION_SECURE_RANDOM_ALGORITHM:-SHA1PRNG}" />
+```
+
+The `:-` defaults reproduce stock Tomcat exactly, so the file is safe everywhere.
+The `-fips` base defaults both variables to `BCFIPS` / `DEFAULT` in `setenv.sh`,
+and a container environment value overrides that.
+
+Env var substitution in Tomcat config needs
+`org.apache.tomcat.util.digester.PROPERTY_SOURCE=...EnvironmentPropertySource`,
+which `setenv.sh` sets for all images. Without it the `:-` defaults still apply,
+so nothing breaks on an older base.
+
+The setenv.sh is predefined in Dockerfile.tomcat inside the FIPS_ENABLED=true block.
+
+
+## 8. What approved-only mode does and does not catch
+
+`-Dorg.bouncycastle.fips.approved_only=true` constrains **BCFIPS**. It cannot
+remove algorithms from another provider.
+
+SUN has to stay registered: BCFIPS seeds its DRBG from a core `SecureRandom`, and
+without SUN that lookup recurses into BCFIPS and dies with `StackOverflowError`.
+SUN as a seed source is fine for compliance - the approved DRBG is still BCFIPS's.
+
+The consequence is that **SUN also serves MD5**, so `MessageDigest.getInstance("MD5")`
+succeeds. Non-approved algorithm use in application code will not fail at
+runtime and has to be caught by code review.
+
+Things that DO fail loudly:
+
+- Passwords under 112 bits through PBKDF2 (see section 10)
+- Any BCFIPS-mediated non-approved operation
+
+Things that fail silently:
+
+- MD5 and other SUN-provided algorithms
+- Pure-Java crypto that never touches JCA, such as bcrypt
+
+
+## 9. Verification
+
+`Monolith/local-docker-testing/fips-check.sh` exercises the primitives rather
+than reading config, and exits non-zero on failure:
+
+```bash
+./fips-check.sh                              # running container named "semoss"
+./fips-check.sh my-container
+./fips-check.sh --image local-monolith-fips
+```
+
+It checks provider order, that SecureRandom and SHA-256 come from BCFIPS,
+AES-256-GCM, PBKDF2, that a sub-112-bit password is rejected, that the BCFKS
+truststore loads, and that `context.xml` resolves session IDs to BCFIPS through
+the same `IntrospectionUtils` path the Tomcat Digester uses.
+
+It also reports which provider serves MD5, as a standing reminder of section 8.
+
+
+## 10. Operational constraints
+
+**Credentials must be at least 14 characters.** SP 800-132 puts a 112-bit floor
+on PBKDF2 password input and BC-FIPS enforces it. PostgreSQL authenticates with
+SCRAM-SHA-256, which runs the password through PBKDF2, so a shorter password
+fails before a connection is attempted:
+
+```
+FipsUnapprovedOperationError: password must be at least 112 bits
+  at org.postgresql.shaded.com.ongres.scram.common.CryptoUtil.hi
+```
+
+That reads like a database problem and is not - the driver refuses to compute the
+hash. The same floor applies to MinIO/S3 keys and to
+`PM_SEMOSS_EXECUTE_SQL_ENCRYPTION_PASSWORD`.
+
+`POSTGRES_PASSWORD` only applies at `initdb`, so an existing stack needs
+`docker compose down -v`.
+
+**Cross-mode caution:** `PBEncryptionUtility` will encrypt with a short password
+on a non-FIPS deployment, and that ciphertext cannot be decrypted on a FIPS one.
+Use 14+ characters everywhere.
+
+**SFTP is reduced under FIPS.** The `fips` profile strips sshj's non-FIPS
+BouncyCastle, so sshj falls back to its JCE-only algorithm set: it loses
+`curve25519-sha256` KEX and `ssh-ed25519` host keys, and keeps
+`ecdh-sha2-nistp256`, `diffie-hellman-group14/16-sha256`, `aes-ctr`, `aes-gcm`
+and `hmac-sha2-*`. Those are the approved ones. `SFTPStorageEngine` authenticates
+with a password and never loads a key, so no key-parsing path is affected.
+
+
+## 11. Local development
+
+```bash
+cd Monolith/local-docker-testing
+./createLocalFipsDockerScript.sh          # build + tag
+./createLocalFipsDockerScript.sh --push   # and publish
+```
+
+Builds Monolith with `-P dev,fips`, verifies no BouncyCastle in the war, then
+overlays it on a `-fips` base via `Dockerfile.fips`.
+
+This is the **only** place the Maven `fips` profile is used. CI does not use it,
+because the tarball split handles the same thing and yields both variants from
+one build. Local dev needs it because `Dockerfile.fips` consumes the raw `dev`
+war, which has no `packagingExcludes` and no tarball split.
+
+Compose stacks are in `local-docker-compose-fips/`, with project names prefixed
+so a FIPS and a non-FIPS stack can run side by side.

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,11 @@
 		<project.build.sourceEncoding>cp1252</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>cp1252</project.reporting.outputEncoding>
 		<openhtml.version>1.0.1</openhtml.version>
+		<!-- Keep in sync with BCPKIX_FIPS_VERSION in docker/Dockerfile.tomcat.
+		     Scope stays compile here: whether BouncyCastle ends up in the deployed
+		     WEB-INF/lib is decided by Monolith's libraries-fips.xml assembly, not
+		     by this pom. -->
+		<bc.fips.version>2.1.12</bc.fips.version>
 	</properties>
 	<!-- removing distributionManagement as it is no longer required
 	<distributionManagement><snapshotRepository><id>ossrh</id><url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</url></snapshotRepository><repository><id>ossrh</id><url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url></repository></distributionManagement>
@@ -625,6 +630,22 @@
 				<groupId>tools.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
 				<version>3.1.1</version>
+			</dependency>
+			<!-- sshj 0.40.0 is internally inconsistent about BouncyCastle versions -->
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcprov-jdk18on</artifactId>
+				<version>1.80.2</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcpkix-jdk18on</artifactId>
+				<version>1.80.2</version>
+			</dependency>
+			<dependency>
+				<groupId>org.bouncycastle</groupId>
+				<artifactId>bcutil-jdk18on</artifactId>
+				<version>1.80.2</version>
 			</dependency>
 			<!-- GHSA-72hv-8253-57qq: force transitive jackson 2.15.x/2.17.x up to fixed version -->
 			<dependency>
@@ -1821,11 +1842,12 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
-		<!-- Source: https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-jdk18on -->
+		<!-- Source: https://mvnrepository.com/artifact/org.bouncycastle/bcpkix-fips -->
 		<dependency>
 			<groupId>org.bouncycastle</groupId>
-			<artifactId>bcpkix-jdk18on</artifactId>
-			<version>1.78.1</version>
+			<artifactId>bcpkix-fips</artifactId>
+			<version>${bc.fips.version}</version>
+			<scope>compile</scope>
 		</dependency>
 		<!-- Source: https://mvnrepository.com/artifact/org.kohsuke/github-api -->
 		<dependency>
@@ -2629,16 +2651,6 @@
 			<artifactId>re2j</artifactId>
 			<version>1.7</version>
 		</dependency>
-		<!-- Source: https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-io -->
-		<!-- 
-		<dependency><groupId>org.eclipse.jetty</groupId><artifactId>jetty-io</artifactId><version>9.4.12.v20180830</version></dependency><dependency><groupId>com.github.ulisesbocchio</groupId><artifactId>jasypt-spring-boot-starter</artifactId><version>2.0.0</version></dependency>
-		-->
-		<!-- Source: https://mvnrepository.com/artifact/org.jasypt/jasypt -->
-		<dependency>
-			<groupId>org.jasypt</groupId>
-			<artifactId>jasypt</artifactId>
-			<version>1.9.3</version>
-		</dependency>
 		<!-- Source: https://mvnrepository.com/artifact/org.apache.commons/commons-exec -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -2817,10 +2829,12 @@
 			<version>2.7.4</version>
 		</dependency>
 		<!-- Source: https://mvnrepository.com/artifact/com.hierynomus/sshj -->
+		<!-- This is synced with Monolith/pom.xml which removes non-FIPS 
+			 bcprov/bcpkix/bcutil-jdk18on at runtime in fips profile. -->
 		<dependency>
 			<groupId>com.hierynomus</groupId>
 			<artifactId>sshj</artifactId>
-			<version>0.39.0</version>
+			<version>0.40.0</version>
 			<exclusions>
 				<exclusion>
 					<groupId>org.slf4j</groupId>

--- a/src/prerna/configure/Me.java
+++ b/src/prerna/configure/Me.java
@@ -194,9 +194,9 @@ public class Me {
 			// PrintStream(System.out)));
 			String prefix = "";
 			if (System.getenv().containsKey("PYTHONHOME")) {
-				prefix += "\"%PYTHONHOME%/\";\"%PYTHONHOME%/Scripts/\";\"%PYTHONHOME%/Lib/site-packages/jep\";";
+				prefix += "\"%PYTHONHOME%/\";\"%PYTHONHOME%/Scripts/\";";
 			} else if (System.getenv().containsKey("PYTHON_HOME")) {
-				prefix += "\"%PYTHON_HOME%/\";\"%PYTHON_HOME%/Scripts/\";\"%PYTHON_HOME%/Lib/site-packages/jep\";";
+				prefix += "\"%PYTHON_HOME%/\";\"%PYTHON_HOME%/Scripts/\";";
 			}
 			String options = "-Djava.library.path=" + prefix + "\"" + rHome + "\";\"" + jriHome + "\"";
 			// should we also set the memory here ?

--- a/src/prerna/om/ClientProcessWrapper.java
+++ b/src/prerna/om/ClientProcessWrapper.java
@@ -90,6 +90,14 @@ public class ClientProcessWrapper {
 	private static final long SOCKET_CLIENT_READY_WAIT_INTERVAL_MS = 1_000L;
 	private static final long SOCKET_CLIENT_READY_WAIT_TIMEOUT_MS = 60_000L;
 
+	// Fallback classpath entries for the spawned SocketServer worker, used when the
+	// caller does not pass an explicit cp.
+	private static final String[] DEFAULT_CP_ENTRIES = new String[] { "fst-3.0.4-jdk17.jar", "objenesis-3.3.jar",
+			"javassist-3.30.2-GA.jar", "log4j-api-2.25.4.jar", "log4j-core-2.25.4.jar", "gson-2.13.2.jar",
+			"jackson-core-2.22.0.jar", "commons-io-2.21.0.jar", "commons-lang3-3.20.0.jar",
+			"jakarta.ws.rs-api-4.0.0.jar", "netty-handler-4.1.133.Final.jar", "netty-common-4.1.133.Final.jar",
+			"netty-buffer-4.1.133.Final.jar", "netty-transport-4.1.133.Final.jar", "classes" };
+
 	private final ReentrantLock lockCreate = new ReentrantLock();
 	private final ReentrantLock lockDestroy = new ReentrantLock();
 
@@ -563,7 +571,7 @@ public class ClientProcessWrapper {
 	public static Process startTCPServer(String cp, String insightFolder, String port) {
 		Process thisProcess = null;
 		if (cp == null) {
-			cp = "fst-2.56.jar;jep-3.9.0.jar;log4j-1.2.17.jar;commons-io-2.4.jar;objenesis-2.5.1.jar;jackson-core-2.9.5.jar;javassist-3.20.0-GA.jar;netty-all-4.1.47.Final.jar;classes";
+			cp = getDefaultCP();
 		}
 		String specificPath = Utility.getCP(cp, insightFolder);
 		try {
@@ -666,7 +674,7 @@ public class ClientProcessWrapper {
 	public static Process startTCPServerChroot(String cp, String chrootDir, String insightFolder, String port) {
 		Process thisProcess = null;
 		if (cp == null) {
-			cp = "fst-2.56.jar;jep-3.9.0.jar;log4j-1.2.17.jar;commons-io-2.4.jar;objenesis-2.5.1.jar;jackson-core-2.9.5.jar;javassist-3.20.0-GA.jar;netty-all-4.1.47.Final.jar;classes";
+			cp = getDefaultCP();
 		}
 		String specificPath = Utility.getCP(cp, insightFolder);
 		try {
@@ -1323,7 +1331,6 @@ public class ClientProcessWrapper {
 			commandsStarter[5] = starter;
 
 			starter = chrootDir + dir + "/starter.sh";
-
 		}
 
 		try {
@@ -1398,5 +1405,19 @@ public class ClientProcessWrapper {
 		} catch (IOException e) {
 			classLogger.error("Failed to write the log4j2.properties file for the socket server", e);
 		}
+	}
+
+	/**
+	 * Build the fallback worker classpath from {@link #DEFAULT_CP_ENTRIES}.
+	 *
+	 * <p>
+	 * The separator is cosmetic: {@code Utility.getCP} substring-matches jar names
+	 * against this value rather than splitting it, so the same string works on
+	 * Windows and Linux.
+	 *
+	 * @return the default classpath string for the spawned SocketServer worker
+	 */
+	private static String getDefaultCP() {
+		return String.join(";", DEFAULT_CP_ENTRIES);
 	}
 }

--- a/src/prerna/reactor/frame/py/AbstractPyFrameReactor.java
+++ b/src/prerna/reactor/frame/py/AbstractPyFrameReactor.java
@@ -47,7 +47,7 @@ public abstract class AbstractPyFrameReactor extends AbstractFrameReactor implem
 
 	// the code that was executed
 	private List<String> codeExecuted = new ArrayList<>();
-	
+
 	protected ITableDataFrame recreateMetadata(PandasFrame frame, boolean override) {
 		// grab the existing metadata from the frame
 		Map<String, String> additionalDataTypes = frame.getMetaData().getHeaderToAdtlTypeMap();
@@ -55,58 +55,61 @@ public abstract class AbstractPyFrameReactor extends AbstractFrameReactor implem
 		Map<String, String[]> complexSelectors = frame.getMetaData().getComplexSelectorsMap();
 
 		String frameName = frame.getName();
-		PandasFrame newFrame = frame; 
+		PandasFrame newFrame = frame;
 		// I am just going to try to recreate the frame here
-		if(override) {
+		if (override) {
 			newFrame = new PandasFrame(frameName, insight.getPyTranslator());
 			String makeWrapper = PandasSyntaxHelper.makeWrapper(newFrame.getWrapperName(), frameName);
-			//newFrame.runScript(makeWrapper);
+			// newFrame.runScript(makeWrapper);
 			insight.getPyTranslator().runEmptyPy(makeWrapper);
 		}
 		String[] colNames = getColumns(newFrame);
 		// I bet this is being done for pixel.. I will keep the same
-		//newFrame.runScript(PandasSyntaxHelper.cleanFrameHeaders(frameName, colNames));
+		// newFrame.runScript(PandasSyntaxHelper.cleanFrameHeaders(frameName,
+		// colNames));
 		insight.getPyTranslator().runEmptyPy(PandasSyntaxHelper.cleanFrameHeaders(frameName, colNames));
 		colNames = getColumns(newFrame);
-		
+
 		String[] colTypes = getColumnTypes(newFrame);
-		if(colNames == null || colTypes == null) {
-			throw new IllegalArgumentException("Please make sure the variable " + frameName + " exists and can be a valid data.table object");
+		if (colNames == null || colTypes == null) {
+			throw new IllegalArgumentException(
+					"Please make sure the variable " + frameName + " exists and can be a valid data.table object");
 		}
-		
+
 		// create the pandas frame
 		// and set up everything else
-		ImportUtility.parseTableColumnsAndTypesToFlatTable(newFrame.getMetaData(), colNames, colTypes, frameName, additionalDataTypes, sources, complexSelectors);
+		ImportUtility.parseTableColumnsAndTypesToFlatTable(newFrame.getMetaData(), colNames, colTypes, frameName,
+				additionalDataTypes, sources, complexSelectors);
 		if (override) {
 			this.insight.setDataMaker(newFrame);
 		}
 		// update varStore
 		NounMetadata noun = new NounMetadata(newFrame, PixelDataType.FRAME);
 		this.insight.getVarStore().put(frame.getName(), noun);
-		
+
 		return newFrame;
 	}
-	
+
 	protected ITableDataFrame recreateMetadata(PandasFrame frame) {
 		return recreateMetadata(frame, true);
 	}
-	
-	public String[] getColumns(PandasFrame frame) {		
+
+	public String[] getColumns(PandasFrame frame) {
 		String wrapperName = frame.getWrapperName();
-		// get jep thread and get the names
 		List<String> val = (List) insight.getPyTranslator().getList("list(" + wrapperName + ".cache['data'])");
 		return val.toArray(new String[val.size()]);
 	}
-	
+
 	public String[] getColumnTypes(PandasFrame frame) {
 		String wrapperName = frame.getWrapperName();
-		// get jep thread and get the names
-		List<String> val = (List) insight.getPyTranslator().getList(PandasSyntaxHelper.getTypes(wrapperName + ".cache['data']"));
+		List<String> val = (List) insight.getPyTranslator()
+				.getList(PandasSyntaxHelper.getTypes(wrapperName + ".cache['data']"));
 		return val.toArray(new String[val.size()]);
 	}
-	
+
 	/**
 	 * Get the data type of a column by querying the python frame
+	 * 
 	 * @param frame
 	 * @param column
 	 * @return
@@ -117,45 +120,44 @@ public abstract class AbstractPyFrameReactor extends AbstractFrameReactor implem
 		String pythonDt = (String) insight.getPyTranslator().runScript(columnType);
 		SemossDataType smssDT = this.insight.getPyTranslator().convertDataType(pythonDt);
 		return smssDT.toString();
-	}	
-	
+	}
+
 	public boolean smartSync(PyTranslator pyt) {
 		// at this point try to see if something has changed and if so
 		// trigger smart sync
 		boolean frameChanged = false;
-		if(this.insight.getCurFrame() != null && this.insight.getCurFrame() instanceof PandasFrame)
-		{
+		if (this.insight.getCurFrame() != null && this.insight.getCurFrame() instanceof PandasFrame) {
 			StringBuffer script = new StringBuffer();
 			// source the script
 			script.append(this.insight.getCurFrame().getName() + "w.hasFrameChanged()");
 			String sync = pyt.runScript(script.toString()) + "";
 			frameChanged = sync.equalsIgnoreCase("true");
-			//changing this to always on
-			//frameChanged = true;
-			if(frameChanged) {
-				recreateMetadata((PandasFrame)insight.getCurFrame(), true);	
+			// changing this to always on
+			// frameChanged = true;
+			if (frameChanged) {
+				recreateMetadata((PandasFrame) insight.getCurFrame(), true);
 			}
-		}	
+		}
 		return frameChanged;
 	}
 
- 	/////////////////////////////////////////////////////
- 	
- 	/*
- 	 * ICodeExecution methods
- 	 */
+	/////////////////////////////////////////////////////
 
- 	public void addExecutedCode(String code) {
- 		if(this.codeExecuted.isEmpty()) {
- 			this.codeExecuted.add("###### Code executed from " + getClass().getSimpleName() + " #######");
- 		}
- 		this.codeExecuted.add(code);
- 	}
-	
+	/*
+	 * ICodeExecution methods
+	 */
+
+	public void addExecutedCode(String code) {
+		if (this.codeExecuted.isEmpty()) {
+			this.codeExecuted.add("###### Code executed from " + getClass().getSimpleName() + " #######");
+		}
+		this.codeExecuted.add(code);
+	}
+
 	@Override
 	public String getExecutedCode() {
 		StringBuffer finalScript = new StringBuffer();
-		for(String c : this.codeExecuted) {
+		for (String c : this.codeExecuted) {
 			finalScript.append(c).append("\n");
 		}
 		return finalScript.toString();
@@ -165,10 +167,10 @@ public abstract class AbstractPyFrameReactor extends AbstractFrameReactor implem
 	public LANGUAGE getLanguage() {
 		return LANGUAGE.PYTHON;
 	}
-	
+
 	@Override
 	public boolean isUserScript() {
 		return false;
 	}
-	
+
 }

--- a/src/prerna/reactor/insights/recipemanagement/AddPreDefinedParameterReactor.java
+++ b/src/prerna/reactor/insights/recipemanagement/AddPreDefinedParameterReactor.java
@@ -28,6 +28,7 @@
 package prerna.reactor.insights.recipemanagement;
 
 import java.io.IOException;
+import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -35,8 +36,6 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jasypt.encryption.pbe.StandardPBEByteEncryptor;
-import org.jasypt.exceptions.EncryptionOperationNotPossibleException;
 
 import prerna.auth.utils.SecurityEngineUtils;
 import prerna.engine.api.IDatabaseEngine;
@@ -50,6 +49,7 @@ import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.ReactorKeysEnum;
 import prerna.sablecc2.om.VarStore;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.security.PBEncryptionUtility;
 import prerna.util.Constants;
 import prerna.util.Utility;
 
@@ -168,13 +168,13 @@ public class AddPreDefinedParameterReactor extends AbstractInsightParameterReact
 							paramList.add(paramMap);
 						}
 					} catch (Exception e) {
-						classLogger.error(Constants.STACKTRACE, e);
+						classLogger.error("Failed to build pre-defined parameters for database {}", databaseId, e);
 					} finally {
 						if (wrapper != null) {
 							try {
 								wrapper.close();
 							} catch (IOException e) {
-								classLogger.error(Constants.STACKTRACE, e);
+								classLogger.error("Failed to close the query wrapper for database {}", databaseId, e);
 							}
 						}
 					}
@@ -208,14 +208,12 @@ public class AddPreDefinedParameterReactor extends AbstractInsightParameterReact
 	 * @return
 	 */
 	private String getDecryptedQuery(Map<String, Object> exportParam) {
-		StandardPBEByteEncryptor encryptor = new StandardPBEByteEncryptor();
-		encryptor.setPassword(getPassword());
 		byte[] encryptedQuery = getInputQuery(exportParam.get("list").toString());
 		if (encryptedQuery != null) {
 			try {
-				byte[] queryBytes = encryptor.decrypt(encryptedQuery);
+				byte[] queryBytes = PBEncryptionUtility.decrypt(encryptedQuery, getPassword());
 				return new String(queryBytes);
-			} catch (EncryptionOperationNotPossibleException e) {
+			} catch (GeneralSecurityException | IllegalArgumentException e) {
 				// ignore
 				// if the query is not encrypted
 				return exportParam.get("list").toString();
@@ -245,7 +243,6 @@ public class AddPreDefinedParameterReactor extends AbstractInsightParameterReact
 	 */
 	private static String getPassword() {
 		if (AddPreDefinedParameterReactor.password != null) {
-//			logger.debug("Decrypting with password >> " + AddPreDefinedParameterReactor.password);
 			return AddPreDefinedParameterReactor.password;
 		}
 
@@ -258,7 +255,6 @@ public class AddPreDefinedParameterReactor extends AbstractInsightParameterReact
 					.getDIHelperProperty(Constants.PM_SEMOSS_EXECUTE_SQL_ENCRYPTION_PASSWORD);
 		}
 
-//		logger.debug("Decrypting with password >> " + AddPreDefinedParameterReactor.password);
 		return AddPreDefinedParameterReactor.password;
 	}
 

--- a/src/prerna/reactor/security/PBEDecryptReactor.java
+++ b/src/prerna/reactor/security/PBEDecryptReactor.java
@@ -29,13 +29,13 @@ package prerna.reactor.security;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jasypt.encryption.pbe.StandardPBEByteEncryptor;
 
 import prerna.reactor.AbstractReactor;
 import prerna.sablecc2.om.GenRowStruct;
 import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.ReactorKeysEnum;
 import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.security.PBEncryptionUtility;
 import prerna.util.Constants;
 import prerna.util.Utility;
 
@@ -56,9 +56,7 @@ public final class PBEDecryptReactor extends AbstractReactor {
 		byte[] encryptedQuery = getInput();
 
 		try {
-			StandardPBEByteEncryptor encryptor = new StandardPBEByteEncryptor();
-			encryptor.setPassword(getPassword());
-			byte[] queryBytes = encryptor.decrypt(encryptedQuery);
+			byte[] queryBytes = PBEncryptionUtility.decrypt(encryptedQuery, getPassword());
 			String query = new String(queryBytes);
 
 			return new NounMetadata(query, PixelDataType.CONST_STRING);

--- a/src/prerna/security/PBEncryptionUtility.java
+++ b/src/prerna/security/PBEncryptionUtility.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.security;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+/**
+ * Password-based encryption using only FIPS 140-3 approved primitives:
+ * PBKDF2-HMAC-SHA256 for key derivation (SP 800-132) and AES-256-GCM for
+ * authenticated encryption (SP 800-38D).
+ *
+ * <p>
+ * Replaces the previous jasypt {@code StandardPBEByteEncryptor} usage, which
+ * defaulted to {@code PBEWithMD5AndDES}. Neither MD5 nor single DES is an
+ * approved algorithm, and both are unavailable once the BouncyCastle FIPS
+ * provider runs in approved-only mode.
+ *
+ * <p>
+ * Payload layout, all big-endian, no separators:
+ * 
+ * <pre>
+ *   [0]        version byte (currently 1)
+ *   [1..16]    16-byte random salt for PBKDF2
+ *   [17..28]   12-byte random IV for GCM
+ *   [29..]     AES-256-GCM ciphertext with the 128-bit tag appended
+ * </pre>
+ * 
+ * The salt and IV are generated fresh per call, so encrypting the same
+ * plaintext twice yields different payloads. GCM authenticates the ciphertext,
+ * so a wrong password or a tampered payload fails loudly rather than returning
+ * garbage - unlike the CBC/DES scheme it replaces.
+ *
+ * <p>
+ * Ciphertext produced by the old jasypt format is NOT readable here. The
+ * version byte exists so a future format change can be detected rather than
+ * silently misparsed.
+ */
+public class PBEncryptionUtility {
+
+	/** Payload format version, occupying the first byte of every payload. */
+	private static final byte FORMAT_VERSION = 1;
+
+	private static final String KDF_ALGORITHM = "PBKDF2WithHmacSHA256";
+	private static final String CIPHER_TRANSFORMATION = "AES/GCM/NoPadding";
+	private static final String KEY_ALGORITHM = "AES";
+
+	private static final int SALT_LENGTH_BYTES = 16;
+	private static final int IV_LENGTH_BYTES = 12;
+	private static final int GCM_TAG_LENGTH_BITS = 128;
+	private static final int DERIVED_KEY_LENGTH_BITS = 256;
+
+	/**
+	 * PBKDF2 iteration count. SP 800-132 sets a floor of 1000; this follows the
+	 * higher OWASP guidance for PBKDF2-HMAC-SHA256. Deriving a key costs on the
+	 * order of 100ms, which is the intended tradeoff - lower it only if a caller is
+	 * on a hot path and the password is known to be high-entropy.
+	 */
+	private static final int PBKDF2_ITERATIONS = 210_000;
+
+	private static final int HEADER_LENGTH_BYTES = 1 + SALT_LENGTH_BYTES + IV_LENGTH_BYTES;
+
+	private static final SecureRandom RANDOM = new SecureRandom();
+
+	private PBEncryptionUtility() {
+		// static utility
+	}
+
+	/**
+	 * Encrypt with a fresh random salt and IV.
+	 *
+	 * @param plaintext bytes to encrypt
+	 * @param password  password to derive the key from
+	 * @return a self-describing payload: version, salt, IV, then GCM ciphertext
+	 * @throws GeneralSecurityException if the JCE providers cannot supply
+	 *                                  PBKDF2-HMAC-SHA256 or AES/GCM
+	 */
+	public static byte[] encrypt(byte[] plaintext, String password) throws GeneralSecurityException {
+		if (plaintext == null) {
+			throw new IllegalArgumentException("Cannot encrypt null plaintext");
+		}
+		byte[] salt = new byte[SALT_LENGTH_BYTES];
+		byte[] iv = new byte[IV_LENGTH_BYTES];
+		RANDOM.nextBytes(salt);
+		RANDOM.nextBytes(iv);
+
+		Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+		cipher.init(Cipher.ENCRYPT_MODE, deriveKey(password, salt), new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+		byte[] ciphertext = cipher.doFinal(plaintext);
+
+		return ByteBuffer.allocate(HEADER_LENGTH_BYTES + ciphertext.length).put(FORMAT_VERSION).put(salt).put(iv)
+				.put(ciphertext).array();
+	}
+
+	/**
+	 * Decrypt a payload produced by {@link #encrypt(byte[], String)}.
+	 *
+	 * @param payload  the versioned payload
+	 * @param password password to derive the key from
+	 * @return the decrypted bytes
+	 * @throws IllegalArgumentException if the payload is too short or carries an
+	 *                                  unrecognized version byte
+	 * @throws GeneralSecurityException if the password is wrong, the payload was
+	 *                                  tampered with, or the required algorithms
+	 *                                  are unavailable
+	 */
+	public static byte[] decrypt(byte[] payload, String password) throws GeneralSecurityException {
+		if (payload == null || payload.length <= HEADER_LENGTH_BYTES) {
+			throw new IllegalArgumentException("Payload is too short to be a valid encrypted value");
+		}
+		ByteBuffer buffer = ByteBuffer.wrap(payload);
+		byte version = buffer.get();
+		if (version != FORMAT_VERSION) {
+			throw new IllegalArgumentException("Unsupported encrypted payload version: " + version);
+		}
+		byte[] salt = new byte[SALT_LENGTH_BYTES];
+		byte[] iv = new byte[IV_LENGTH_BYTES];
+		buffer.get(salt);
+		buffer.get(iv);
+		byte[] ciphertext = new byte[buffer.remaining()];
+		buffer.get(ciphertext);
+
+		Cipher cipher = Cipher.getInstance(CIPHER_TRANSFORMATION);
+		cipher.init(Cipher.DECRYPT_MODE, deriveKey(password, salt), new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+		// throws AEADBadTagException (a GeneralSecurityException) on a wrong
+		// password or a modified payload
+		return cipher.doFinal(ciphertext);
+	}
+
+	/**
+	 * Convenience wrapper over {@link #encrypt(byte[], String)} for callers that
+	 * need to move the payload as text. This is the transport format any external
+	 * tool producing ciphertext for SEMOSS should emit.
+	 *
+	 * @param plaintext string to encrypt, read as UTF-8
+	 * @param password  password to derive the key from
+	 * @return the base64 encoded payload
+	 * @throws GeneralSecurityException if encryption fails
+	 */
+	public static String encryptToBase64(String plaintext, String password) throws GeneralSecurityException {
+		return Base64.getEncoder().encodeToString(encrypt(plaintext.getBytes(StandardCharsets.UTF_8), password));
+	}
+
+	/**
+	 * Convenience wrapper over {@link #decrypt(byte[], String)}.
+	 *
+	 * @param base64Payload base64 encoded payload
+	 * @param password      password to derive the key from
+	 * @return the decrypted string, read as UTF-8
+	 * @throws IllegalArgumentException if the input is not valid base64
+	 * @throws GeneralSecurityException if decryption fails
+	 */
+	public static String decryptFromBase64(String base64Payload, String password) throws GeneralSecurityException {
+		return new String(decrypt(Base64.getDecoder().decode(base64Payload), password), StandardCharsets.UTF_8);
+	}
+
+	/**
+	 * Derive a 256-bit AES key from the password and salt via PBKDF2-HMAC-SHA256.
+	 *
+	 * @param password the password
+	 * @param salt     the per-payload random salt
+	 * @return the derived AES key
+	 * @throws GeneralSecurityException if the KDF is unavailable or the spec is
+	 *                                  rejected
+	 */
+	private static SecretKey deriveKey(String password, byte[] salt) throws GeneralSecurityException {
+		if (password == null || password.isEmpty()) {
+			throw new IllegalArgumentException("No encryption password is configured");
+		}
+		PBEKeySpec spec = new PBEKeySpec(password.toCharArray(), salt, PBKDF2_ITERATIONS, DERIVED_KEY_LENGTH_BITS);
+		try {
+			byte[] keyBytes = SecretKeyFactory.getInstance(KDF_ALGORITHM).generateSecret(spec).getEncoded();
+			return new SecretKeySpec(keyBytes, KEY_ALGORITHM);
+		} finally {
+			spec.clearPassword();
+		}
+	}
+
+}


### PR DESCRIPTION
## Summary

Adds FIPS 140-3 build support: a second Tomcat base image, FIPS variants of all six OS images, and the pom/application changes needed to run on a validated BouncyCastle provider.

Standard builds are unchanged. Every FIPS path is opt-in through a build argument, and with the flag off the images are byte-identical to before.

## How the image build works

Two switches, both driven from one `fips` matrix value per workflow:

| `matrix.fips` | `TOMCAT_TAG_SUFFIX` | `SEMOSS_FIPS` | Result |
|---|---|---|---|
| `false` | (empty) | `false` | standard base + standard `WEB-INF/lib` |
| `true` | `-fips` | `true` | `-fips` base + `libraries-fips` payload |

The base supplies BouncyCastle on the JVM system classloader; `SEMOSS_FIPS` tells `update_latest_dev.sh` to pull the Monolith payload that leaves BouncyCastle out of `WEB-INF/lib`. Tying both to one matrix value keeps them in step.

### Tomcat base - `docker/Dockerfile.tomcat`

One definition, two images, switched by `FIPS_ENABLED`:

```
tomcat-builder:11.0.24        FIPS_ENABLED=false
tomcat-builder:11.0.24-fips   FIPS_ENABLED=true
```

With the flag on it stages `bc-fips`, `bctls-fips`, `bcpkix-fips` and `bcutil-fips` into `$JAVA_HOME/lib/fips` against SHA-256 hashes pinned in the Dockerfile, converts `cacerts` to BCFKS, registers BCFIPS/BCJSSE in `java.security`, and appends the provider CLASSPATH plus `-Dorg.bouncycastle.fips.approved_only=true` to `setenv.sh`.

The truststore conversion runs before the provider swap, since JKS integrity checking is SHA-1 based and is no longer readable once approved-only mode is in force.

`setenv.sh` also now enables `EnvironmentPropertySource`, so `${VAR}` and `${VAR:-default}` in `server.xml` and `context.xml` resolve against container environment variables. This applies to both variants and is generally useful beyond FIPS.

### Final images - six Dockerfiles

```
FROM quay.io/semoss/tomcat-builder:${TOMCAT_VERSION}${TOMCAT_TAG_SUFFIX}
```

Only the suffix is passed in from the workflow, so `TOMCAT_VERSION` stays defined in one place. `SEMOSS_FIPS` is declared as an ARG/ENV pair so the artifact resolution script can read it.

### Workflows

`tomcat-builder.yml` crosses the existing `arch` matrix with `fips`, giving four build legs and two tagged manifest lists. Digest artifacts are namespaced per variant so the two tags cannot end up pointing at a mixed manifest. The per-arch verification step now asserts each variant is what it claims, including that the standard image carries no FIPS artifacts.

The six OS workflows compute both tag sets in `prepare` and select per variant in `build`/`merge`, with `-fips` on the flavour segment so `latest` stays trailing:

```
semoss-dev:<ver>-SNAPSHOT-ubuntu22-latest
semoss-dev:<ver>-SNAPSHOT-ubuntu22-fips-latest
semoss:<ver>-ubuntu22
semoss:<ver>-ubuntu22-fips
```

## pom changes

- `bcpkix-jdk18on:1.78.1` replaced by `bcpkix-fips` (version via a `bc.fips.version` property, kept in sync with the Dockerfile build arg)
- `jasypt:1.9.3` removed
- `sshj` 0.39.0 to 0.40.0, which adds a BCFIPS-backed `SecureRandom` factory and drops the `net.i2p.crypto:eddsa` transitive
- BouncyCastle versions converged on 1.80.2 in `dependencyManagement`. sshj 0.40.0 declares `bcprov-jdk18on 1.80` directly while its `bcpkix-jdk18on 1.80` pulls `bcutil-jdk18on 1.80.2` which pulls `bcprov-jdk18on 1.80.2`, which trips the existing enforcer rule

## Application changes

**New `prerna.security.PBEncryptionUtility`** - password-based encryption on PBKDF2-HMAC-SHA256 (SP 800-132) and AES-256-GCM (SP 800-38D), replacing the jasypt usage in `PBEDecryptReactor` and `AddPreDefinedParameterReactor`. Payload is self-describing (version byte, salt, IV, ciphertext with tag) with a fresh salt and IV per call. GCM authenticates the ciphertext, so a wrong password or tampered payload fails cleanly instead of returning garbage. Uses JCA standard names with no provider pinning, so it works on both standard and FIPS deployments.

**`ClientProcessWrapper`** - the worker classpath is now built by a single `getDefaultCP()` from a documented `DEFAULT_CP_ENTRIES` array rather than duplicated string literals in two methods, and the jar versions are refreshed to match the current dependency set.

**Dead JEP references removed** from `Me.java` and the worker classpath. JEP is not a dependency and is not installed in any image.

**Logging** - `Constants.STACKTRACE` in `AddPreDefinedParameterReactor` replaced with parameterised messages that identify the database involved.

`AbstractPyFrameReactor` is formatter-only.

## Docs

`docker/FIPS.README.md` documents the build across Semoss, semoss-artifacts and Monolith, plus verification and the operational constraints (notably that PBKDF2 enforces a 112-bit floor, so database and object-store credentials need 14+ characters).

## Companion PRs

- Monolith SEMOSS/Monolith#403 - publishes the `libraries-fips` payload and the local dev tooling
- semoss-artifacts - `--fips` / `SEMOSS_FIPS` in `update_latest_dev.sh`, classifier selection in `artifacts/lib/pom.xml`, parameterised session-ID Manager in `context-*.xml`

## Running it

1. Run `tomcat-builder.yml` to publish the `-fips` base tag
2. Deploy Monolith so both payloads exist under the version
3. Run any OS workflow to get both image variants
