### PR TITLE
fix: add serializer for sqlexception in proxied invocation logging

### DIFF
--- a/src/prerna/engine/impl/pipeline/PipelineInvocationHandler.java
+++ b/src/prerna/engine/impl/pipeline/PipelineInvocationHandler.java
@@ -77,6 +77,7 @@ import prerna.logging.LoggingSQLConnectionSerializer;
 import prerna.logging.LoggingSQLDataSourceSerializer;
 import prerna.logging.LoggingSQLResultSetSerializer;
 import prerna.logging.LoggingSQLStatementSerializer;
+import prerna.logging.LoggingThrowableSerializer;
 import prerna.logging.SemossLogUtils;
 import prerna.om.Insight;
 import prerna.om.InsightStore;
@@ -113,6 +114,7 @@ public class PipelineInvocationHandler implements InvocationHandler {
 			.registerTypeHierarchyAdapter(DataSource.class, new LoggingSQLDataSourceSerializer())
 			.registerTypeHierarchyAdapter(Statement.class, new LoggingSQLStatementSerializer())
 			.registerTypeHierarchyAdapter(ResultSet.class, new LoggingSQLResultSetSerializer())
+			.registerTypeHierarchyAdapter(Throwable.class, new LoggingThrowableSerializer())
 			.registerTypeAdapter(Room.class, new LoggingRoomAdapter())
 			.registerTypeHierarchyAdapter(ZoneId.class, new ZoneIdTypeAdapter())
 			.registerTypeAdapter(ZoneOffset.class, new ZoneOffsetTypeAdapter())

--- a/src/prerna/logging/LoggingThrowableSerializer.java
+++ b/src/prerna/logging/LoggingThrowableSerializer.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.logging;
+
+import com.google.gson.*;
+import java.lang.reflect.Type;
+import java.sql.SQLException;
+import java.util.*;
+
+public class LoggingThrowableSerializer implements JsonSerializer<Throwable> {
+    
+    private final int maxDepth;
+    private final int maxStackTraceElements;
+    private final boolean includeSuppressed;
+    
+    public LoggingThrowableSerializer() {
+        this(10, 30, true);
+    }
+    
+    public LoggingThrowableSerializer(int maxDepth, int maxStackTraceElements, boolean includeSuppressed) {
+        this.maxDepth = maxDepth;
+        this.maxStackTraceElements = maxStackTraceElements;
+        this.includeSuppressed = includeSuppressed;
+    }
+    
+    @Override
+    public JsonElement serialize(Throwable throwable, Type typeOfSrc, JsonSerializationContext context) {
+        if (throwable == null) {
+            return JsonNull.INSTANCE;
+        }
+        
+        Set<Throwable> seen = new HashSet<>();
+        return serializeThrowable(throwable, 0, seen, context);
+    }
+    
+    private JsonElement serializeThrowable(Throwable throwable, int depth, Set<Throwable> seen, JsonSerializationContext context) {
+        if (throwable == null || depth > maxDepth || seen.contains(throwable)) {
+            return JsonNull.INSTANCE;
+        }
+        
+        seen.add(throwable);
+        JsonObject obj = new JsonObject();
+        
+        // Class name
+        obj.addProperty("class", throwable.getClass().getName());
+        
+        // Message
+        obj.addProperty("message", throwable.getMessage());
+        
+        // Localized message (if different)
+        String localizedMessage = throwable.getLocalizedMessage();
+        if (localizedMessage != null && !localizedMessage.equals(throwable.getMessage())) {
+            obj.addProperty("localizedMessage", localizedMessage);
+        }
+        
+        // Stack trace
+        obj.add("stackTrace", serializeStackTrace(throwable.getStackTrace()));
+        
+        // Cause
+        if (throwable.getCause() != null && throwable.getCause() != throwable) {
+            obj.add("cause", serializeThrowable(throwable.getCause(), depth + 1, seen, context));
+        }
+        
+        // Suppressed exceptions
+        if (includeSuppressed) {
+            Throwable[] suppressed = throwable.getSuppressed();
+            if (suppressed != null && suppressed.length > 0) {
+                JsonArray suppressedArray = new JsonArray();
+                for (Throwable s : suppressed) {
+                    suppressedArray.add(serializeThrowable(s, depth + 1, seen, context));
+                }
+                obj.add("suppressed", suppressedArray);
+            }
+        }
+        
+        // SQLException specific: nextException chain
+        if (throwable instanceof SQLException sqlEx) {
+            SQLException next = sqlEx.getNextException();
+            if (next != null && next != throwable) {
+                obj.add("nextException", serializeThrowable(next, depth + 1, seen, context));
+            }
+            
+            // SQL state and error code
+            obj.addProperty("sqlState", sqlEx.getSQLState());
+            obj.addProperty("errorCode", sqlEx.getErrorCode());
+        }
+        
+        return obj;
+    }
+    
+    private JsonArray serializeStackTrace(StackTraceElement[] stackTrace) {
+        JsonArray array = new JsonArray();
+        int limit = Math.min(stackTrace.length, maxStackTraceElements);
+        
+        for (int i = 0; i < limit; i++) {
+            StackTraceElement ste = stackTrace[i];
+            JsonObject element = new JsonObject();
+            element.addProperty("className", ste.getClassName());
+            element.addProperty("methodName", ste.getMethodName());
+            element.addProperty("fileName", ste.getFileName());
+            element.addProperty("lineNumber", ste.getLineNumber());
+            array.add(element);
+        }
+        
+        if (stackTrace.length > maxStackTraceElements) {
+            JsonObject truncated = new JsonObject();
+            truncated.addProperty("truncated", true);
+            truncated.addProperty("remaining", stackTrace.length - maxStackTraceElements);
+            array.add(truncated);
+        }
+        
+        return array;
+    }
+}


### PR DESCRIPTION
## Description
It was observed that when executing a query that generates an exception, the activity logging tooling throws an error:
<img width="712" height="115" alt="image" src="https://github.com/user-attachments/assets/d1542795-9fae-413b-acf0-1937e51476b1" />

## Changes Made
Added a serializer to the pipeline for throwable type classes.

## How to Test
1. Execute a database query that would yield an error. e.g. `select nothing from non_existent`
2. You should see the actual query exception in the message instead of the accessibility one above.
<img width="708" height="91" alt="Screenshot 2026-08-12 123313" src="https://github.com/user-attachments/assets/963dcb71-7f40-4e2c-b79b-309ce4aa036e" />

3. In the activity log for the engine, you should see a truncated stacktrace json.
<img width="476" height="506" alt="image" src="https://github.com/user-attachments/assets/f925a8fb-f225-4cc6-b026-9be6d4f36112" />
