### PR TITLE
Provider Built-in Tools: catalog, reactor, storage, and runtime plumbing

### DIFF
--- a/meta/builtin-tools.json
+++ b/meta/builtin-tools.json
@@ -1,0 +1,376 @@
+{
+  "openai": {
+    "web_search": {
+      "alias": "web_search",
+      "display_name": "Web Search",
+      "params": [
+        {
+          "alias": "search_content_types",
+          "display_name": "Search Content Types",
+          "type": "optional",
+          "input": "list",
+          "options": ["text", "image"],
+          "default": ["text"],
+          "show_in_ui": true
+        },
+        {
+          "alias": "search_context_size",
+          "display_name": "Search Context Size",
+          "type": "optional",
+          "input": "string",
+          "options": ["low", "medium", "high"],
+          "default": "medium",
+          "show_in_ui": true
+        },
+        {
+          "alias": "filters",
+          "display_name": "Domain Filters",
+          "type": "optional",
+          "input": "map",
+          "options": [],
+          "default": {},
+          "show_in_ui": true
+        },
+        {
+          "alias": "external_web_access",
+          "display_name": "Allow External Web Access",
+          "type": "optional",
+          "input": "boolean",
+          "options": [],
+          "default": true,
+          "show_in_ui": true
+        }
+      ],
+      "description": "This tool searches the web for relevant results to use in a response. Domain filters are nested under filters.allowed_domains and filters.blocked_domains, each capped at 100 domains."
+    },
+    "image_generation": {
+      "alias": "image_generation",
+      "display_name": "Image Generation",
+      "description": "A tool that generates images using the GPT image models.",
+      "params": [
+        {
+          "alias": "action",
+          "display_name": "Action",
+          "type": "optional",
+          "input": "string",
+          "options": ["generate", "edit", "auto"],
+          "default": "auto",
+          "show_in_ui": true
+        },
+        {
+          "alias": "background",
+          "display_name": "Background",
+          "type": "optional",
+          "input": "string",
+          "options": ["transparent", "opaque", "auto"],
+          "default": "auto",
+          "show_in_ui": true
+        },
+        {
+          "alias": "model",
+          "display_name": "Model",
+          "type": "optional",
+          "input": "string",
+          "options": [
+            "gpt-image-1",
+            "gpt-image-1-mini",
+            "gpt-image-1.5",
+            "gpt-image-2"
+          ],
+          "default": "gpt-image-2",
+          "show_in_ui": true
+        },
+        {
+          "alias": "size",
+          "display_name": "Size",
+          "type": "optional",
+          "input": "string",
+          "options": ["1024x1024", "1024x1536", "1536x1024", "auto"],
+          "default": "auto",
+          "show_in_ui": true
+        },
+        {
+          "alias": "quality",
+          "display_name": "Quality",
+          "type": "optional",
+          "input": "string",
+          "options": ["high", "medium", "low", "auto"],
+          "default": "auto",
+          "show_in_ui": true
+        },
+        {
+          "alias": "output_format",
+          "display_name": "Output Format",
+          "type": "optional",
+          "input": "string",
+          "options": ["png", "jpeg", "webp", "auto"],
+          "default": "auto",
+          "show_in_ui": true
+        }
+      ]
+    }
+  },
+  "anthropic": {
+    "web_search": {
+      "alias": "web_search_20260318",
+      "display_name": "Web Search",
+      "params": [
+        {
+          "alias": "name",
+          "display_name": "Name",
+          "type": "required",
+          "input": "string",
+          "options": ["web_search"],
+          "default": "web_search",
+          "show_in_ui": false
+        },
+        {
+          "alias": "type",
+          "display_name": "Type",
+          "type": "required",
+          "input": "string",
+          "options": ["web_search_20260318"],
+          "default": "web_search_20260318",
+          "show_in_ui": false
+        },
+        {
+          "alias": "max_uses",
+          "display_name": "Maximum Uses",
+          "type": "optional",
+          "input": "number",
+          "options": [],
+          "default": 5,
+          "show_in_ui": true
+        },
+        {
+          "alias": "allowed_domains",
+          "display_name": "Allowed Domains",
+          "type": "optional",
+          "input": "list",
+          "options": [],
+          "default": [],
+          "show_in_ui": true
+        },
+        {
+          "alias": "blocked_domains",
+          "display_name": "Blocked Domains",
+          "type": "optional",
+          "input": "list",
+          "options": [],
+          "default": [],
+          "show_in_ui": true
+        },
+        {
+          "alias": "allowed_callers",
+          "display_name": "Allowed Callers",
+          "type": "optional",
+          "input": "list",
+          "options": ["direct", "code_execution_20260120"],
+          "default": ["code_execution_20260120"],
+          "show_in_ui": true
+        },
+        {
+          "alias": "response_inclusion",
+          "display_name": "Response Inclusion",
+          "type": "optional",
+          "input": "string",
+          "options": ["full", "excluded"],
+          "default": "full",
+          "show_in_ui": true
+        }
+      ],
+      "description": "This tool searches the web for relevant results to use in a response. Never set both allowed domains and blocked domains. If you set both, the tool will not work. On this tool version allowed_callers defaults to code_execution_20260120, which runs the search inside code execution so results are filtered before they reach the context window. Models that do not support programmatic tool calling require allowed_callers to be set to direct, otherwise the request fails with a 400."
+    },
+    "web_fetch": {
+      "alias": "web_fetch_20260318",
+      "display_name": "Web Fetch",
+      "params": [
+        {
+          "alias": "name",
+          "display_name": "Name",
+          "type": "required",
+          "input": "string",
+          "options": ["web_fetch"],
+          "default": "web_fetch",
+          "show_in_ui": false
+        },
+        {
+          "alias": "type",
+          "display_name": "Type",
+          "type": "required",
+          "input": "string",
+          "options": ["web_fetch_20260318"],
+          "default": "web_fetch_20260318",
+          "show_in_ui": false
+        },
+        {
+          "alias": "max_uses",
+          "display_name": "Maximum Uses",
+          "type": "optional",
+          "input": "number",
+          "options": [],
+          "default": 5,
+          "show_in_ui": true
+        },
+        {
+          "alias": "allowed_domains",
+          "display_name": "Allowed Domains",
+          "type": "optional",
+          "input": "list",
+          "options": [],
+          "default": [],
+          "show_in_ui": true
+        },
+        {
+          "alias": "blocked_domains",
+          "display_name": "Blocked Domains",
+          "type": "optional",
+          "input": "list",
+          "options": [],
+          "default": [],
+          "show_in_ui": true
+        },
+        {
+          "alias": "citations",
+          "display_name": "Citations",
+          "type": "optional",
+          "input": "map",
+          "options": [],
+          "default": {
+            "enabled": false
+          },
+          "show_in_ui": true
+        },
+        {
+          "alias": "max_content_tokens",
+          "display_name": "Maximum Content Tokens",
+          "type": "optional",
+          "input": "number",
+          "options": [],
+          "default": 100000,
+          "show_in_ui": true
+        },
+        {
+          "alias": "use_cache",
+          "display_name": "Use Cache",
+          "type": "optional",
+          "input": "boolean",
+          "options": [],
+          "default": true,
+          "show_in_ui": true
+        },
+        {
+          "alias": "allowed_callers",
+          "display_name": "Allowed Callers",
+          "type": "optional",
+          "input": "list",
+          "options": ["direct", "code_execution_20260120"],
+          "default": ["code_execution_20260120"],
+          "show_in_ui": true
+        },
+        {
+          "alias": "response_inclusion",
+          "display_name": "Response Inclusion",
+          "type": "optional",
+          "input": "string",
+          "options": ["full", "excluded"],
+          "default": "full",
+          "show_in_ui": true
+        }
+      ],
+      "description": "This tool fetches full content from specific web pages and PDF documents. It uses dynamic filtering to keep only relevant content before it reaches the context window. Never set both allowed domains and blocked domains. If you set both, the tool will not work. Claude can only fetch URLs that already appeared in the conversation, so this tool cannot browse from a bare prompt. Models that do not support programmatic tool calling require allowed_callers to be set to direct."
+    }
+  },
+  "google": {
+    "web_search": {
+      "alias": "google_search",
+      "display_name": "Web Search",
+      "params": [
+        {
+          "alias": "google_search",
+          "display_name": "Google Search",
+          "type": "required",
+          "input": "map",
+          "options": [],
+          "default": {},
+          "show_in_ui": false
+        }
+      ],
+      "description": "This tool searches the web with Google Search to ground responses in current information and provide citations to verifiable sources."
+    },
+    "google_maps": {
+      "alias": "google_maps",
+      "display_name": "Google Maps",
+      "params": [
+        {
+          "alias": "google_maps",
+          "display_name": "Google Maps",
+          "type": "required",
+          "input": "map",
+          "options": [],
+          "default": {},
+          "show_in_ui": false
+        }
+      ],
+      "description": "This tool grounds location-aware responses in current Google Maps data and provides citations to Google Maps sources. Optional user coordinates must be supplied separately through toolConfig.retrievalConfig.latLng. The tool currently supports English-language prompts and responses."
+    },
+    "web_fetch": {
+      "alias": "url_context",
+      "display_name": "URL Context",
+      "params": [
+        {
+          "alias": "url_context",
+          "display_name": "URL Context",
+          "type": "required",
+          "input": "map",
+          "options": [],
+          "default": {},
+          "show_in_ui": false
+        }
+      ],
+      "description": "This tool retrieves content from specific public URLs to provide additional context for a response. It supports up to 20 URLs per request and can process supported text, image, and PDF content."
+    },
+    "code_execution": {
+      "alias": "code_execution",
+      "display_name": "Code Execution",
+      "params": [
+        {
+          "alias": "code_execution",
+          "display_name": "Code Execution",
+          "type": "required",
+          "input": "map",
+          "options": [],
+          "default": {},
+          "show_in_ui": false
+        }
+      ],
+      "description": "This tool lets the model write and run Python in a sandbox managed by Google, iterating on the code until it succeeds, and returns the generated code alongside its output."
+    }
+  },
+  "bedrock": {
+    "openai": {
+      "web_search": {
+        "alias": "web_search",
+        "display_name": "Web Search",
+        "params": [
+          {
+            "alias": "external_web_access",
+            "display_name": "Allow External Web Access",
+            "type": "optional",
+            "input": "boolean",
+            "options": [],
+            "default": false,
+            "show_in_ui": true
+          }
+        ],
+        "constraints": {
+          "api": "responses",
+          "models": ["openai.gpt-5.4", "openai.gpt-5.5", "openai.gpt-5.6"],
+          "regions": ["us-east-1", "us-east-2", "us-west-2"]
+        },
+        "description": "This tool searches the web for relevant results to use in a response. Search and fetch are hosted by AWS and served from the Amazon Bedrock web index and cache, so request data stays inside the AWS boundary. Only available on the OpenAI-compatible Responses API at the bedrock-mantle endpoint. Only external_web_access is documented as configurable here; the other OpenAI web search params are unverified on this endpoint. Allowing external web access requires the bedrock-websearch:ExternalWebAccess IAM permission, which AmazonBedrockFullAccess does not grant, so this defaults to false rather than to the API default of true; leaving it on without that permission returns a 403 on the authorization check and the model answers from the index alone."
+      }
+    },
+    "anthropic": {}
+  }
+}

--- a/meta/builtin-tools.json
+++ b/meta/builtin-tools.json
@@ -282,69 +282,125 @@
     }
   },
   "google": {
-    "web_search": {
-      "alias": "google_search",
-      "display_name": "Web Search",
-      "params": [
-        {
-          "alias": "google_search",
-          "display_name": "Google Search",
-          "type": "required",
-          "input": "map",
-          "options": [],
-          "default": {},
-          "show_in_ui": false
-        }
-      ],
-      "description": "This tool searches the web with Google Search to ground responses in current information and provide citations to verifiable sources."
+    "google": {
+      "web_search": {
+        "alias": "google_search",
+        "display_name": "Web Search",
+        "params": [
+          {
+            "alias": "google_search",
+            "display_name": "Google Search",
+            "type": "required",
+            "input": "map",
+            "options": [],
+            "default": {},
+            "show_in_ui": false
+          }
+        ],
+        "description": "This tool searches the web with Google Search to ground responses in current information and provide citations to verifiable sources."
+      },
+      "google_maps": {
+        "alias": "google_maps",
+        "display_name": "Google Maps",
+        "params": [
+          {
+            "alias": "google_maps",
+            "display_name": "Google Maps",
+            "type": "required",
+            "input": "map",
+            "options": [],
+            "default": {},
+            "show_in_ui": false
+          }
+        ],
+        "description": "This tool grounds location-aware responses in current Google Maps data and provides citations to Google Maps sources. Optional user coordinates must be supplied separately through toolConfig.retrievalConfig.latLng. The tool currently supports English-language prompts and responses."
+      },
+      "web_fetch": {
+        "alias": "url_context",
+        "display_name": "URL Context",
+        "params": [
+          {
+            "alias": "url_context",
+            "display_name": "URL Context",
+            "type": "required",
+            "input": "map",
+            "options": [],
+            "default": {},
+            "show_in_ui": false
+          }
+        ],
+        "description": "This tool retrieves content from specific public URLs to provide additional context for a response. It supports up to 20 URLs per request and can process supported text, image, and PDF content."
+      },
+      "code_execution": {
+        "alias": "code_execution",
+        "display_name": "Code Execution",
+        "params": [
+          {
+            "alias": "code_execution",
+            "display_name": "Code Execution",
+            "type": "required",
+            "input": "map",
+            "options": [],
+            "default": {},
+            "show_in_ui": false
+          }
+        ],
+        "description": "This tool lets the model write and run Python in a sandbox managed by Google, iterating on the code until it succeeds, and returns the generated code alongside its output."
+      }
     },
-    "google_maps": {
-      "alias": "google_maps",
-      "display_name": "Google Maps",
-      "params": [
-        {
-          "alias": "google_maps",
-          "display_name": "Google Maps",
-          "type": "required",
-          "input": "map",
-          "options": [],
-          "default": {},
-          "show_in_ui": false
-        }
-      ],
-      "description": "This tool grounds location-aware responses in current Google Maps data and provides citations to Google Maps sources. Optional user coordinates must be supplied separately through toolConfig.retrievalConfig.latLng. The tool currently supports English-language prompts and responses."
-    },
-    "web_fetch": {
-      "alias": "url_context",
-      "display_name": "URL Context",
-      "params": [
-        {
-          "alias": "url_context",
-          "display_name": "URL Context",
-          "type": "required",
-          "input": "map",
-          "options": [],
-          "default": {},
-          "show_in_ui": false
-        }
-      ],
-      "description": "This tool retrieves content from specific public URLs to provide additional context for a response. It supports up to 20 URLs per request and can process supported text, image, and PDF content."
-    },
-    "code_execution": {
-      "alias": "code_execution",
-      "display_name": "Code Execution",
-      "params": [
-        {
-          "alias": "code_execution",
-          "display_name": "Code Execution",
-          "type": "required",
-          "input": "map",
-          "options": [],
-          "default": {},
-          "show_in_ui": false
-        }
-      ],
-      "description": "This tool lets the model write and run Python in a sandbox managed by Google, iterating on the code until it succeeds, and returns the generated code alongside its output."
+    "anthropic": {
+      "web_search": {
+        "alias": "web_search_20250305",
+        "display_name": "Web Search",
+        "params": [
+          {
+            "alias": "name",
+            "display_name": "Name",
+            "type": "required",
+            "input": "string",
+            "options": ["web_search"],
+            "default": "web_search",
+            "show_in_ui": false
+          },
+          {
+            "alias": "type",
+            "display_name": "Type",
+            "type": "required",
+            "input": "string",
+            "options": ["web_search_20250305"],
+            "default": "web_search_20250305",
+            "show_in_ui": false
+          },
+          {
+            "alias": "max_uses",
+            "display_name": "Maximum Uses",
+            "type": "optional",
+            "input": "number",
+            "options": [],
+            "default": 5,
+            "show_in_ui": true
+          },
+          {
+            "alias": "allowed_domains",
+            "display_name": "Allowed Domains",
+            "type": "optional",
+            "input": "list",
+            "options": [],
+            "default": [],
+            "show_in_ui": true
+          },
+          {
+            "alias": "blocked_domains",
+            "display_name": "Blocked Domains",
+            "type": "optional",
+            "input": "list",
+            "options": [],
+            "default": [],
+            "show_in_ui": true
+          }
+        ],
+        "description": "This tool searches the web for relevant results to use in a response. Google Cloud serves only this basic tool version for Claude models - dynamic filtering, web fetch, and code execution are not available on Vertex AI. Never set both allowed domains and blocked domains; a request with both fails with a 400."
+      }
     }
   },
   "bedrock": {

--- a/py/genai_client/__init__.py
+++ b/py/genai_client/__init__.py
@@ -117,7 +117,7 @@ def get_text_gen_client(client_type, **kwargs):
 
             return OpenAiClient(**kwargs)
     elif client_type == "BEDROCK":
-        from .text_generation.bedrock_client import BedrockClient
+        from .text_generation.bedrock_clients.bedrock_client import BedrockClient
 
         return BedrockClient(**kwargs)
     elif client_type == "VERTEX":

--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -26,6 +26,10 @@ from ..semoss_base.semoss_models import (
     ModelSettings,
 )
 from ...utils import string_to_bool
+from ..semoss_base.builtin_tools import (
+    built_in_tool_request_fields,
+    normalize_built_in_tools,
+)
 from ..semoss_base.reasoning import normalize_reasoning
 
 MODEL_MAX_OUTPUT_TOKENS = {
@@ -450,17 +454,13 @@ class AnthropicMessageBuilder:
             has_structured_input=has_schema,
         )
 
-    def _build_built_in_tools(self, built_in_tools: List[str]) -> List[Dict[str, Any]]:
+    def _build_built_in_tools(self, built_in_tools: Any) -> List[Dict[str, Any]]:
         anthropic_built_in_tools: List[Dict[str, Any]] = []
-        for tool in built_in_tools:
-            if tool.lower() == "web_search":
-                anthropic_built_in_tools.append(
-                    {"type": "web_search_20250305", "name": "web_search", "max_uses": 5}
-                )
-            elif tool.lower() == "code_execution":
-                anthropic_built_in_tools.append(
-                    {"type": "code_execution_20250825", "name": "code_execution"}
-                )
+        for selection in normalize_built_in_tools(built_in_tools):
+            spec = built_in_tool_request_fields(selection)
+            spec.setdefault("type", selection["alias"])
+            spec.setdefault("name", selection["name"])
+            anthropic_built_in_tools.append(spec)
         return anthropic_built_in_tools
 
     def _build_tool_choice(

--- a/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
+++ b/py/genai_client/message_builders/anthropic/anthropic_message_builder.py
@@ -801,6 +801,7 @@ class AnthropicMessageBuilder:
             kwargs.pop("max_tokens", None)
             or kwargs.pop("max_completion_tokens", None)
             or self.model_settings.max_tokens
+            or self._get_model_max_output_tokens(self.model_name)
         )
 
         # MAX TOKENS MUST BE STRICTLY GREATER THAN THINKING BUDGET (legacy only)

--- a/py/genai_client/message_builders/bedrock/bedrock_message_builder.py
+++ b/py/genai_client/message_builders/bedrock/bedrock_message_builder.py
@@ -5,6 +5,7 @@ from ...utils import (
     get_image_extension,
     fetch_and_encode_image,
 )
+from ..semoss_base.builtin_tools import built_in_tool_names
 from ..semoss_base.reasoning import normalize_reasoning
 from ..semoss_base.semoss_models import (
     SEMOSSMessage,
@@ -483,9 +484,15 @@ class BedrockMessageBuilder:
 
         return None
 
-    def _build_built_in_tools(self, built_in_tools: List[str]) -> List[Dict[str, Any]]:
-        """Convert generic built-in tool names to Bedrock systemTool format."""
-        return [{"systemTool": {"name": tool}} for tool in built_in_tools]
+    def _build_built_in_tools(self, built_in_tools: Any) -> List[Dict[str, Any]]:
+        """Convert built-in tool selections to Bedrock systemTool format.
+        Converse systemTools carry only a name - the catalog's Bedrock-hosted
+        OpenAI web search (which does take params) runs through the OpenAI
+        Responses client instead, so params are intentionally unused here."""
+        return [
+            {"systemTool": {"name": tool}}
+            for tool in built_in_tool_names(built_in_tools)
+        ]
 
     def _convert_mcp_to_bedrock_tools(self, mcp_tools: List[Dict]) -> Dict[str, Any]:
         """Convert MCP-formatted tools to Bedrock tool configuration."""

--- a/py/genai_client/message_builders/google_genai/google_genai_builder.py
+++ b/py/genai_client/message_builders/google_genai/google_genai_builder.py
@@ -17,31 +17,11 @@ from ..semoss_base.semoss_models import (
 from .google_genai_models import GoogleRoles
 from google.genai import types
 from ...utils import string_to_bool
+from ..semoss_base.builtin_tools import normalize_built_in_tools
 from ..semoss_base.reasoning import normalize_reasoning
 
 
 class GoogleGenAIMessageBuilder:
-
-    def _normalize_web_search_tool(self, value: Any) -> str:
-        """
-        Controls which Google built-in web search tool is used when `built_in_tools`
-        includes `web_search`.
-
-        Supported values:
-        - "enterprise" | "enterprise_web_search" (default)
-        - "google" | "google_search"
-        """
-        if value is None:
-            return "enterprise"
-        if isinstance(value, str):
-            normalized = value.strip().lower()
-            if normalized in {"enterprise", "enterprise_web_search"}:
-                return "enterprise"
-            if normalized in {"google", "google_search"}:
-                return "google"
-        raise ValueError(
-            f"Unsupported web search tool: {value!r}. Use 'enterprise' or 'google'."
-        )
 
     def build_messages(
         self,
@@ -504,31 +484,19 @@ class GoogleGenAIMessageBuilder:
 
         return function_declarations
 
-    def _build_built_in_tools(
-        self, built_in_tools: List[str], web_search_tool: str = "enterprise"
-    ) -> List[types.Tool]:
-        """Add built-in Google GenAI tools based on names."""
+    def _build_built_in_tools(self, built_in_tools: Any) -> List[types.Tool]:
+        """Add built-in Google GenAI tools.
+
+        A selection's params name the Tool field directly (google_search={},
+        url_context={}, ...) - pydantic coerces the dict values onto the
+        field types, the same way function_declarations already accepts
+        dicts. A selection without params has nothing to enable and is
+        skipped.
+        """
         google_built_in_tools: List[types.Tool] = []
-        for tool in built_in_tools:
-            if tool.lower() == "web_search":
-                if web_search_tool == "google":
-                    google_built_in_tools.append(
-                        types.Tool(google_search=types.GoogleSearch())
-                    )
-                else:
-                    google_built_in_tools.append(
-                        types.Tool(enterprise_web_search=types.EnterpriseWebSearch())
-                    )
-            if tool.lower() == "websearch_retrieval":
-                google_built_in_tools.append(
-                    types.Tool(google_search_retrieval=types.GoogleSearchRetrieval())
-                )
-            if tool.lower() == "google_maps":
-                google_built_in_tools.append(types.Tool(google_maps=types.GoogleMaps()))
-            if tool.lower() == "code_execution":
-                google_built_in_tools.append(
-                    types.Tool(code_execution=types.ToolCodeExecution())
-                )
+        for selection in normalize_built_in_tools(built_in_tools):
+            if selection["params"]:
+                google_built_in_tools.append(types.Tool(**selection["params"]))
         return google_built_in_tools
 
     def build_tools(
@@ -538,24 +506,13 @@ class GoogleGenAIMessageBuilder:
         tools = param_map.get("tools", [])
         built_in_tools = param_map.get("built_in_tools", [])
         tool_choice = param_map.get("tool_choice", {})
-        web_search_tool = "enterprise"
-        if any(
-            isinstance(t, str) and t.lower() == "web_search"
-            for t in (built_in_tools or [])
-        ):
-            web_search_tool = self._normalize_web_search_tool(
-                param_map.get("web_search_tool", param_map.get("web_search_type"))
-            )
 
         if tools:
             func_declarations = self.convert_mcp_to_google_tools(tools)
             tools = [types.Tool(function_declarations=func_declarations)]
 
         if built_in_tools:
-            google_built_in_tools = self._build_built_in_tools(
-                built_in_tools, web_search_tool=web_search_tool
-            )
-            tools.extend(google_built_in_tools)
+            tools.extend(self._build_built_in_tools(built_in_tools))
 
         tool_config = self._create_tool_config(tool_choice, tools) if (tools) else None
 

--- a/py/genai_client/message_builders/openai/openai_message_builder.py
+++ b/py/genai_client/message_builders/openai/openai_message_builder.py
@@ -2,6 +2,10 @@ from typing import List, Dict, Any, Optional, Tuple, Union
 import json
 from pydantic import BaseModel
 from ...utils import get_image_extension, string_to_bool
+from ..semoss_base.builtin_tools import (
+    built_in_tool_request_fields,
+    normalize_built_in_tools,
+)
 from ..semoss_base.reasoning import normalize_reasoning
 from .openai_models import (
     OpenAIResponsesToolCall,
@@ -63,8 +67,11 @@ class OpenAIMessageBuilder:
             request.update(self.model_settings.global_param_override)
 
         if "built_in_tools" in request:
-            built_in_tools = request.pop("built_in_tools")
-            openai_built_in = [{"type": tool} for tool in built_in_tools]
+            openai_built_in = []
+            for selection in normalize_built_in_tools(request.pop("built_in_tools")):
+                spec = built_in_tool_request_fields(selection)
+                spec.setdefault("type", selection["alias"])
+                openai_built_in.append(spec)
             if openai_built_in:
                 existing_tools = request.get("tools", [])
                 existing_tools.extend(openai_built_in)

--- a/py/genai_client/message_builders/semoss_base/builtin_tools.py
+++ b/py/genai_client/message_builders/semoss_base/builtin_tools.py
@@ -1,0 +1,112 @@
+"""Shared normalization for the ``built_in_tools`` param across providers.
+
+Java rides the engine's saved built-in tool selection along on every ask call.
+There is exactly one shape, originating in the MODELMETADATA.BUILTINTOOLS
+column: a dict keyed by canonical tool name whose values are the
+meta/builtin-tools.json catalog definition for the tool, with a ``value``
+added beside ``default`` on any parameter the user changed::
+
+    {"web_search": {
+        "alias": "web_search_20260318",
+        "display_name": "Web Search",
+        "params": [{"alias": "max_uses", "default": 5,
+                    "value": 3, "show_in_ui": True}, ...]}}
+
+A hand-written override can be as small as
+``{"web_search": {"alias": "web_search_20260318"}}`` - the alias is what the
+providers key their tool type on, so it must be present and versioned where
+the provider versions its tools.
+
+Every consumer should go through ``normalize_built_in_tools`` (or the small
+helpers on top of it) rather than iterating the raw value; anything that is
+not the dict shape normalizes to no tools.
+
+The catalog is written so that a tool's parameters ARE the provider request
+fields (anthropic carries its ``name``/``type`` as hidden required params,
+google's single param names the Tool field, openai's params are the tool
+object's fields). Builders therefore construct their provider-native specs
+from ``built_in_tool_request_fields`` plus the ``alias`` - there are no
+name tables to keep in sync with the catalog.
+"""
+
+from typing import Any, Dict, List
+
+
+def normalize_built_in_tools(built_in_tools: Any) -> List[Dict[str, Any]]:
+    """Collapse the ``built_in_tools`` dict into a list of
+    ``{"name": str, "alias": str, "params": {alias: value}}`` selections.
+
+    ``params`` holds the effective value per parameter: the user's ``value``
+    when one was set, the catalog ``default`` otherwise. Anything that is not
+    the dict shape normalizes to no tools rather than raising - a malformed
+    selection should degrade the same way an unknown tool name does
+    downstream.
+    """
+    if not isinstance(built_in_tools, dict):
+        return []
+
+    selections = []
+    for name, config in built_in_tools.items():
+        config = config if isinstance(config, dict) else {}
+        selections.append(_to_selection(str(name), config))
+    return selections
+
+
+def built_in_tool_names(built_in_tools: Any) -> List[str]:
+    """Just the canonical tool names, in selection order."""
+    return [
+        selection["name"] for selection in normalize_built_in_tools(built_in_tools)
+    ]
+
+
+def has_built_in_tool(built_in_tools: Any, tool_name: str) -> bool:
+    """Whether the selection includes the given canonical tool name."""
+    target = tool_name.lower()
+    return any(
+        name.lower() == target for name in built_in_tool_names(built_in_tools)
+    )
+
+
+def built_in_tool_request_fields(selection: Dict[str, Any]) -> Dict[str, Any]:
+    """The selection's resolved parameter values as provider request fields,
+    with unset optional values (None, empty list, empty dict) omitted - a
+    web_search with no domain filters must not send ``allowed_domains=[]``.
+    ``False`` and ``0`` are meaningful values and are kept.
+
+    Note google's tool-field params default to ``{}`` where the empty dict
+    means "enabled with provider defaults" - the google builder reads the
+    raw ``params`` instead of going through this pruning.
+    """
+    fields: Dict[str, Any] = {}
+    for alias, value in selection.get("params", {}).items():
+        if value is None:
+            continue
+        if isinstance(value, (list, dict)) and len(value) == 0:
+            continue
+        fields[alias] = value
+    return fields
+
+
+def _to_selection(name: str, config: Dict[str, Any]) -> Dict[str, Any]:
+    alias = config.get("alias")
+    return {
+        "name": name,
+        "alias": str(alias) if alias else name,
+        "params": _selected_params(config.get("params")),
+    }
+
+
+def _selected_params(params: Any) -> Dict[str, Any]:
+    """Effective value per parameter alias from a catalog-shaped params list."""
+    selected: Dict[str, Any] = {}
+    if isinstance(params, (list, tuple)):
+        for param in params:
+            if not isinstance(param, dict):
+                continue
+            alias = param.get("alias")
+            if not alias:
+                continue
+            value = param.get("value", param.get("default"))
+            if value is not None:
+                selected[str(alias)] = value
+    return selected

--- a/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
+++ b/py/genai_client/text_generation/anthropic_client/anthropic_text_client.py
@@ -24,6 +24,7 @@ from ..abstract_text_generation_client import AbstractTextGenerationClient
 from ...message_builders.anthropic.anthropic_message_builder import (
     AnthropicMessageBuilder,
 )
+from ...message_builders.semoss_base.builtin_tools import has_built_in_tool
 from ...message_builders.semoss_base.semoss_streaming_util import StreamUtil
 from ..model_engine_exception import (
     ModelEngineException,
@@ -305,10 +306,8 @@ class AnthropicTextClient(AbstractTextGenerationClient):
             if self.model_settings.global_param_override:
                 kwargs.update(self.model_settings.global_param_override)
 
-            built_in_tools = kwargs.get("built_in_tools", []) or []
-            web_search_enabled = any(
-                isinstance(tool, str) and tool.lower() == "web_search"
-                for tool in built_in_tools
+            web_search_enabled = has_built_in_tool(
+                kwargs.get("built_in_tools"), "web_search"
             )
             inline_citations = kwargs.get("inline_citations", None)
             if inline_citations is None:

--- a/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
+++ b/py/genai_client/text_generation/google_genai_clients/google_genai_client.py
@@ -15,6 +15,7 @@ from ...constants import (
     TEMPLATE_NAME,
 )
 from ..abstract_text_generation_client import AbstractTextGenerationClient
+from ...message_builders.semoss_base.builtin_tools import has_built_in_tool
 from ...message_builders.google_genai.google_genai_builder import (
     GoogleGenAIMessageBuilder,
 )
@@ -40,7 +41,7 @@ class StreamingResponse(BaseModel):
 
 
 class GoogleGenAiTextClient(AbstractTextGenerationClient):
-    client: GoogleGenAIClient
+    google_client: GoogleGenAIClient
 
     def __init__(
         self,
@@ -89,10 +90,8 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
         ):
             kwargs.update(self.model_settings.global_param_override)
 
-        built_in_tools = kwargs.get("built_in_tools", []) or []
-        web_search_enabled = any(
-            isinstance(tool, str) and tool.lower() == "web_search"
-            for tool in built_in_tools
+        web_search_enabled = has_built_in_tool(
+            kwargs.get("built_in_tools"), "web_search"
         )
         inline_citations = kwargs.get("inline_citations", None)
         if inline_citations is None:
@@ -135,7 +134,7 @@ class GoogleGenAiTextClient(AbstractTextGenerationClient):
                 return self.generate_with_retry(streaming_call)
 
             def call_generate_content():
-                return self.client.models.generate_content(
+                return self.google_client.models.generate_content(
                     model=self.model_name,
                     contents=google_messages,
                     config=provider_config,

--- a/src/prerna/auth/utils/SecurityModelMetadataUtils.java
+++ b/src/prerna/auth/utils/SecurityModelMetadataUtils.java
@@ -51,10 +51,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.ToNumberPolicy;
 
 import prerna.engine.api.IEngine;
 import prerna.engine.api.IRDBMSEngine;
@@ -75,6 +77,8 @@ public final class SecurityModelMetadataUtils extends AbstractSecurityUtils {
 
 	private static final Logger classLogger = LogManager.getLogger(SecurityModelMetadataUtils.class);
 	private static final Gson GSON = new Gson();
+	private static final Gson LONG_OR_DOUBLE_GSON = new GsonBuilder()
+			.setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE).create();
 
 	private static final Set<String> CAPABILITIES = Set.of("TEXT_GENERATION", "IMAGE_GENERATION", "VIDEO_GENERATION",
 			"EMBEDDING", "TRANSCRIPTION", "SPEECH_SYNTHESIS", "RERANKING", "MODERATION");
@@ -596,7 +600,7 @@ public final class SecurityModelMetadataUtils extends AbstractSecurityUtils {
 		capabilities.put("outputModalities", emptyListIfNull(modelMetadata.get("outputModalities")));
 		capabilities.put("contextWindow", emptyStringIfNull(modelMetadata.get("contextWindow")));
 		capabilities.put("maxOutputTokens", emptyStringIfNull(modelMetadata.get("maxOutputTokens")));
-		capabilities.put("builtinTools", emptyListIfNull(modelMetadata.get("builtinTools")));
+		capabilities.put("builtinTools", emptyMapIfNull(modelMetadata.get("builtinTools")));
 		capabilities.put("attachment", modelMetadata.get("attachment"));
 		capabilities.put("reasoning", modelMetadata.get("reasoning"));
 		capabilities.put("toolCall", modelMetadata.get("toolCall"));
@@ -786,11 +790,9 @@ public final class SecurityModelMetadataUtils extends AbstractSecurityUtils {
 	}
 
 	/**
-	 * Built-in tools started as a flat list of canonical tool names and now
-	 * also accept a JSON object keyed by tool name that holds the selected
-	 * configuration for each tool. An object is stored as-is after its keys
-	 * are normalized; anything else falls back to the legacy list handling so
-	 * rows and SMSS values written before configurations existed stay valid.
+	 * Built-in tools are stored as a JSON object keyed by tool name holding
+	 * the selected catalog definition for each tool. An empty selection is
+	 * stored as SQL NULL; anything that is not a JSON object is rejected.
 	 */
 	private static void normalizeBuiltinToolsProperty(Map<String, Object> details) {
 		String key = Constants.BUILTIN_TOOLS;
@@ -803,15 +805,14 @@ public final class SecurityModelMetadataUtils extends AbstractSecurityUtils {
 			return;
 		}
 
-		JsonElement json = null;
+		JsonElement json;
 		try {
 			json = value instanceof String ? JsonParser.parseString(value.toString()) : GSON.toJsonTree(value);
 		} catch (RuntimeException e) {
-			// not JSON - the legacy comma-separated list of tool names
+			throw new IllegalArgumentException(key + " must be a JSON object keyed by tool name", e);
 		}
-		if (json == null || !json.isJsonObject()) {
-			normalizeListProperty(details, key, false);
-			return;
+		if (!json.isJsonObject()) {
+			throw new IllegalArgumentException(key + " must be a JSON object keyed by tool name");
 		}
 
 		JsonObject selection = json.getAsJsonObject();
@@ -828,17 +829,16 @@ public final class SecurityModelMetadataUtils extends AbstractSecurityUtils {
 	}
 
 	/**
-	 * Stored built-in tools are either the legacy JSON array of tool names or
-	 * a JSON object keyed by tool name. Return whichever shape was stored.
+	 * Stored built-in tools are a JSON object keyed by tool name; anything
+	 * else in the column reads as unset. Whole numbers parse as longs rather
+	 * than gson's default doubles, since the selection is forwarded to the
+	 * python clients where a max_uses of 5.0 is not the same request as 5.
 	 */
-	private static Object parseStoredBuiltinTools(String json) {
-		if (json == null) {
+	private static Map<?, ?> parseStoredBuiltinTools(String json) {
+		if (json == null || !json.trim().startsWith("{")) {
 			return null;
 		}
-		if (json.trim().startsWith("{")) {
-			return GSON.fromJson(json, Map.class);
-		}
-		return parseStoredList(json);
+		return LONG_OR_DOUBLE_GSON.fromJson(json, Map.class);
 	}
 
 	private static void normalizeBooleanProperty(Map<String, Object> details, String key) {

--- a/src/prerna/auth/utils/SecurityModelMetadataUtils.java
+++ b/src/prerna/auth/utils/SecurityModelMetadataUtils.java
@@ -53,6 +53,7 @@ import org.apache.logging.log4j.Logger;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 import prerna.engine.api.IEngine;
@@ -118,7 +119,7 @@ public final class SecurityModelMetadataUtils extends AbstractSecurityUtils {
 		normalizeCapabilityProperty(normalized);
 		normalizeListProperty(normalized, Constants.INPUT_MODALITIES, true);
 		normalizeListProperty(normalized, Constants.OUTPUT_MODALITIES, true);
-		normalizeListProperty(normalized, Constants.BUILTIN_TOOLS, false);
+		normalizeBuiltinToolsProperty(normalized);
 		normalizeBooleanProperty(normalized, Constants.ATTACHMENT);
 		normalizeBooleanProperty(normalized, Constants.REASONING);
 		normalizeBooleanProperty(normalized, Constants.TOOL_CALL);
@@ -784,6 +785,62 @@ public final class SecurityModelMetadataUtils extends AbstractSecurityUtils {
 		return json == null ? null : parseList(json);
 	}
 
+	/**
+	 * Built-in tools started as a flat list of canonical tool names and now
+	 * also accept a JSON object keyed by tool name that holds the selected
+	 * configuration for each tool. An object is stored as-is after its keys
+	 * are normalized; anything else falls back to the legacy list handling so
+	 * rows and SMSS values written before configurations existed stay valid.
+	 */
+	private static void normalizeBuiltinToolsProperty(Map<String, Object> details) {
+		String key = Constants.BUILTIN_TOOLS;
+		if (!details.containsKey(key)) {
+			return;
+		}
+		Object value = details.get(key);
+		if (value == null || value.toString().trim().isEmpty()) {
+			details.put(key, null);
+			return;
+		}
+
+		JsonElement json = null;
+		try {
+			json = value instanceof String ? JsonParser.parseString(value.toString()) : GSON.toJsonTree(value);
+		} catch (RuntimeException e) {
+			// not JSON - the legacy comma-separated list of tool names
+		}
+		if (json == null || !json.isJsonObject()) {
+			normalizeListProperty(details, key, false);
+			return;
+		}
+
+		JsonObject selection = json.getAsJsonObject();
+		JsonObject normalized = new JsonObject();
+		for (Map.Entry<String, JsonElement> entry : selection.entrySet()) {
+			String toolName = entry.getKey().trim().toLowerCase(Locale.ROOT).replace('-', '_').replace(' ', '_');
+			if (!LOWER_SNAKE_CASE_PATTERN.matcher(toolName).matches()) {
+				throw new IllegalArgumentException("Invalid " + key + " tool name " + entry.getKey());
+			}
+			normalized.add(toolName, entry.getValue());
+		}
+		// store an unset selection as SQL NULL rather than an empty JSON object
+		details.put(key, normalized.size() == 0 ? null : GSON.toJson(normalized));
+	}
+
+	/**
+	 * Stored built-in tools are either the legacy JSON array of tool names or
+	 * a JSON object keyed by tool name. Return whichever shape was stored.
+	 */
+	private static Object parseStoredBuiltinTools(String json) {
+		if (json == null) {
+			return null;
+		}
+		if (json.trim().startsWith("{")) {
+			return GSON.fromJson(json, Map.class);
+		}
+		return parseStoredList(json);
+	}
+
 	private static void normalizeBooleanProperty(Map<String, Object> details, String key) {
 		if (!details.containsKey(key)) {
 			return;
@@ -876,7 +933,7 @@ public final class SecurityModelMetadataUtils extends AbstractSecurityUtils {
 		metadata.put("outputModalities", parseStoredList(rs.getString("OUTPUTMODALITIES")));
 		metadata.put("contextWindow", getNullableLong(rs, "CONTEXTWINDOW"));
 		metadata.put("maxOutputTokens", getNullableLong(rs, "MAXOUTPUTTOKENS"));
-		metadata.put("builtinTools", parseStoredList(rs.getString("BUILTINTOOLS")));
+		metadata.put("builtinTools", parseStoredBuiltinTools(rs.getString("BUILTINTOOLS")));
 		metadata.put("attachment", getNullableBoolean(rs, "ATTACHMENT"));
 		metadata.put("reasoning", getNullableBoolean(rs, "REASONING"));
 		metadata.put("toolCall", getNullableBoolean(rs, "TOOLCALL"));

--- a/src/prerna/engine/impl/model/AbstractModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractModelEngine.java
@@ -78,6 +78,7 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	public static final String FULL_PROMPT = "full_prompt";
 	public static final String APPEND_FULL_PROMPT = "append_full_prompt";
 	public static final String CONTEXT_WINDOW = "context_window";
+	public static final String BUILT_IN_TOOLS = "built_in_tools";
 
 	// the init script loading tells us the provider we are using
 	// but we also want to know what the model brand actually is
@@ -86,6 +87,15 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	protected boolean keepConversationHistory = false;
 	protected int contextWindow = 0;
 	protected boolean inferenceLogsEnbaled = Utility.isModelInferenceLogsEnabled();
+
+	/**
+	 * The engine's saved built-in tool selection from MODELMETADATA - a JSON
+	 * object keyed by tool name. The security database is its only source of
+	 * truth (the value is deliberately kept out of the smss), and it rides
+	 * along on ask calls as the built_in_tools param unless the caller
+	 * supplies their own.
+	 */
+	protected Object builtinTools = null;
 
 	@Override
 	public void open(Properties smssProp) throws Exception {
@@ -128,6 +138,7 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 
 		fillIfMissing("context_window", metadata.get("contextWindow"));
 		fillIfMissing("max_tokens", metadata.get("maxOutputTokens"));
+		this.builtinTools = metadata.get("builtinTools");
 	}
 
 	/**

--- a/src/prerna/engine/impl/model/AbstractModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractModelEngine.java
@@ -79,6 +79,7 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	public static final String APPEND_FULL_PROMPT = "append_full_prompt";
 	public static final String CONTEXT_WINDOW = "context_window";
 	public static final String BUILT_IN_TOOLS = "built_in_tools";
+	public static final String MAX_TOKENS = "max_tokens";
 
 	// the init script loading tells us the provider we are using
 	// but we also want to know what the model brand actually is
@@ -97,6 +98,14 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	 */
 	protected Object builtinTools = null;
 
+	/**
+	 * The max output tokens to request when the caller does not name one -
+	 * the smss value when defined, otherwise the MODELMETADATA row's
+	 * maxOutputTokens. Null when neither names one, in which case the python
+	 * clients fall back to the model's own output cap.
+	 */
+	protected Long maxTokens = null;
+
 	@Override
 	public void open(Properties smssProp) throws Exception {
 		super.open(smssProp);
@@ -111,6 +120,29 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 		this.contextWindow = contextWindowStr != null && !contextWindowStr.trim().isEmpty()
 				? Integer.parseInt(contextWindowStr.trim())
 				: 0;
+		this.maxTokens = resolveMaxTokens();
+	}
+
+	/**
+	 * The effective max output tokens after the metadata merge: the smss file
+	 * wins under either key casing, then the metadata backfill placed under
+	 * the lowercase param key. A value that does not parse reads as unset
+	 * rather than failing engine open.
+	 */
+	private Long resolveMaxTokens() {
+		String value = this.smssProp.getProperty(Constants.MAX_TOKENS);
+		if (value == null || value.trim().isEmpty()) {
+			value = this.smssProp.getProperty(MAX_TOKENS);
+		}
+		if (value == null || value.trim().isEmpty()) {
+			return null;
+		}
+		try {
+			return Long.parseLong(value.trim());
+		} catch (NumberFormatException e) {
+			classLogger.warn("Model {} has an invalid max tokens value '{}' - ignoring it", this.engineId, value);
+			return null;
+		}
 	}
 
 	/**

--- a/src/prerna/engine/impl/model/AbstractPythonModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractPythonModelEngine.java
@@ -277,6 +277,15 @@ public abstract class AbstractPythonModelEngine extends AbstractModelEngine {
 		}
 		checkSocketStatus();
 
+		if (this.builtinTools != null) {
+			if (parameters == null) {
+				parameters = new HashMap<>();
+			}
+			if (!parameters.containsKey(BUILT_IN_TOOLS)) {
+				parameters.put(BUILT_IN_TOOLS, this.builtinTools);
+			}
+		}
+
 		final String TRIPLE_QUOTE = "\"\"\"";
 		StringBuilder callMaker = new StringBuilder(varName + ".ask(");
 

--- a/src/prerna/engine/impl/model/AbstractPythonModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractPythonModelEngine.java
@@ -249,6 +249,15 @@ public abstract class AbstractPythonModelEngine extends AbstractModelEngine {
 	}
 
 	/**
+	 * Whether the caller already named an output token limit under any of the
+	 * aliases the python message builders accept.
+	 */
+	private static boolean hasMaxTokensParam(Map<String, Object> parameters) {
+		return parameters.containsKey(MAX_TOKENS) || parameters.containsKey("max_completion_tokens")
+				|| parameters.containsKey("max_output_tokens") || parameters.containsKey("max_new_tokens");
+	}
+
+	/**
 	 * This method checks whether the socket client is instantiated and connected.
 	 */
 	protected void checkSocketStatus() {
@@ -277,12 +286,17 @@ public abstract class AbstractPythonModelEngine extends AbstractModelEngine {
 		}
 		checkSocketStatus();
 
-		if (this.builtinTools != null) {
+		// ride the engine's saved built-in tool selection and max output
+		// tokens along on the request unless the caller supplied their own
+		if (this.builtinTools != null || this.maxTokens != null) {
 			if (parameters == null) {
 				parameters = new HashMap<>();
 			}
-			if (!parameters.containsKey(BUILT_IN_TOOLS)) {
+			if (this.builtinTools != null && !parameters.containsKey(BUILT_IN_TOOLS)) {
 				parameters.put(BUILT_IN_TOOLS, this.builtinTools);
+			}
+			if (this.maxTokens != null && !hasMaxTokensParam(parameters)) {
+				parameters.put(MAX_TOKENS, this.maxTokens);
 			}
 		}
 

--- a/src/prerna/reactor/model/GetModelBuiltinToolsReactor.java
+++ b/src/prerna/reactor/model/GetModelBuiltinToolsReactor.java
@@ -1,0 +1,240 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.model;
+
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.auth.User;
+import prerna.auth.utils.SecurityEngineUtils;
+import prerna.auth.utils.SecurityModelMetadataUtils;
+import prerna.auth.utils.SecurityQueryUtils;
+import prerna.engine.api.IEngine;
+import prerna.engine.api.IModelEngine;
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.ReactorKeysEnum;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.util.Constants;
+import prerna.util.DIHelper;
+import prerna.util.StaticBuiltinToolsCatalog;
+import prerna.util.StaticModelMetadataCatalog;
+import prerna.util.Utility;
+
+/**
+ * Offer the provider-hosted built-in tools a model engine can use, resolved
+ * from meta/builtin-tools.json by the engine's serving provider and model
+ * provider. The same vendor's models do not share capabilities across hosts -
+ * an OpenAI model on Bedrock is not offered the OpenAI-hosted tools - which is
+ * why both providers participate in the lookup.
+ */
+public class GetModelBuiltinToolsReactor extends AbstractReactor {
+
+	private static final Logger classLogger = LogManager.getLogger(GetModelBuiltinToolsReactor.class);
+
+	/**
+	 * A dotted qualifier ahead of the model name, as in "us.anthropic.claude-*".
+	 * Digits end the qualifiers so version dots ("gpt-5.4") are left alone.
+	 */
+	private static final Pattern QUALIFIER_PREFIX_PATTERN = Pattern.compile("^([a-z][a-z-]*)\\.(?=.)");
+
+	/**
+	 * The SMSS variable some engines use to name who actually hosts the model,
+	 * as in the Anthropic-on-Vertex engines. There is no shared constant for it.
+	 */
+	private static final String SMSS_PROVIDER = "PROVIDER";
+
+	public GetModelBuiltinToolsReactor() {
+		this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey() };
+		this.keyRequired = new int[] { 1 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+		String engineId = this.keyValue.get(ReactorKeysEnum.ENGINE.getKey());
+		if (engineId == null || engineId.trim().isEmpty()) {
+			throw new IllegalArgumentException("Must input a model engine id");
+		}
+
+		User user = this.insight.getUser();
+		engineId = SecurityQueryUtils.testUserEngineIdForAlias(user, engineId);
+		if (!SecurityEngineUtils.userCanViewEngine(user, engineId)) {
+			throw new IllegalArgumentException("Model engine does not exist or user does not have access to view it");
+		}
+		if (SecurityEngineUtils.getEngineType(engineId) != IEngine.CATALOG_TYPE.MODEL) {
+			throw new IllegalArgumentException("Engine is not a model engine");
+		}
+
+		Map<String, Object> metadata = SecurityModelMetadataUtils.getModelMetadata(engineId);
+		Properties smssProp = loadSmssProperties(engineId);
+
+		String modelId = resolveModelId(metadata, smssProp);
+		String servingProvider = resolveServingProvider(metadata, smssProp);
+		String modelProvider = resolveModelProvider(metadata, modelId);
+
+		Map<String, Object> tools = getTools(servingProvider, modelProvider, modelId);
+
+		Map<String, Object> response = new LinkedHashMap<>();
+		response.put("engineId", engineId);
+		response.put("modelId", modelId == null ? "" : modelId);
+		response.put("modelProvider", modelProvider == null ? "" : modelProvider);
+		response.put("servingProvider", servingProvider == null ? "" : servingProvider);
+		response.put("tools", tools);
+		Object selected = metadata == null ? null : metadata.get("builtinTools");
+		response.put("selected", selected == null ? new LinkedHashMap<>() : selected);
+		return new NounMetadata(response, PixelDataType.MAP);
+	}
+
+	Map<String, Object> getTools(String servingProvider, String modelProvider, String modelId) {
+		return StaticBuiltinToolsCatalog.getTools(StaticBuiltinToolsCatalog.getCatalogFile(), servingProvider,
+				modelProvider, modelId);
+	}
+
+	/**
+	 * The provider model id, preferring the saved metadata row over the smss.
+	 */
+	private static String resolveModelId(Map<String, Object> metadata, Properties smssProp) {
+		String modelId = metadata == null ? null : trimToNull(metadata.get("modelId"));
+		if (modelId == null && smssProp != null) {
+			modelId = trimToNull(smssProp.getProperty(Constants.MODEL));
+		}
+		return modelId;
+	}
+
+	/**
+	 * Who hosts the model, as a lowercase catalog key. The saved metadata wins
+	 * when set; otherwise the smss PROVIDER variable, then the engine's smss
+	 * MODEL_TYPE, which names the client implementation and so tracks the host.
+	 */
+	private static String resolveServingProvider(Map<String, Object> metadata, Properties smssProp) {
+		String servingProvider = metadata == null ? null
+				: StaticBuiltinToolsCatalog.normalizeProviderKey(trimToNull(metadata.get("servingProvider")));
+		if (servingProvider == null && smssProp != null) {
+			servingProvider = StaticBuiltinToolsCatalog
+					.normalizeProviderKey(trimToNull(smssProp.getProperty(SMSS_PROVIDER)));
+		}
+		if (servingProvider == null && smssProp != null) {
+			servingProvider = StaticBuiltinToolsCatalog
+					.normalizeProviderKey(trimToNull(smssProp.getProperty(IModelEngine.MODEL_TYPE)));
+		}
+		return servingProvider;
+	}
+
+	/**
+	 * Who made the model, as a lowercase catalog key. The saved metadata wins
+	 * when set; otherwise the model catalog's provider field, then the vendor
+	 * qualifier that aggregator hosts prefix onto their model ids.
+	 */
+	private static String resolveModelProvider(Map<String, Object> metadata, String modelId) {
+		String modelProvider = metadata == null ? null
+				: StaticBuiltinToolsCatalog.normalizeProviderKey(trimToNull(metadata.get("modelProvider")));
+		if (modelProvider == null && modelId != null) {
+			try {
+				Map<String, Object> catalogEntry = StaticModelMetadataCatalog
+						.getFlattenedMetadata(StaticModelMetadataCatalog.getMetadataFile(), modelId);
+				modelProvider = StaticBuiltinToolsCatalog.normalizeProviderKey(trimToNull(catalogEntry.get("provider")));
+			} catch (RuntimeException e) {
+				classLogger.warn("Unable to read the static model catalog while resolving the provider for model {}",
+						Utility.cleanLogString(modelId), e);
+			}
+		}
+		if (modelProvider == null) {
+			modelProvider = parseProviderQualifier(modelId);
+		}
+		return modelProvider;
+	}
+
+	/**
+	 * The last dotted qualifier ahead of the model name - "us.anthropic.claude-*"
+	 * carries its maker behind the region. Returns null when there is none.
+	 */
+	static String parseProviderQualifier(String modelId) {
+		if (modelId == null || modelId.trim().isEmpty()) {
+			return null;
+		}
+		String remainder = modelId.trim().toLowerCase(Locale.ROOT);
+		int providerSeparator = remainder.indexOf('/');
+		if (providerSeparator >= 0 && providerSeparator < remainder.length() - 1) {
+			remainder = remainder.substring(providerSeparator + 1);
+		}
+		String qualifier = null;
+		Matcher matcher = QUALIFIER_PREFIX_PATTERN.matcher(remainder);
+		while (matcher.find()) {
+			qualifier = matcher.group(1);
+			remainder = remainder.substring(matcher.end());
+			matcher = QUALIFIER_PREFIX_PATTERN.matcher(remainder);
+		}
+		return qualifier;
+	}
+
+	/**
+	 * The engine's smss properties, or null when they cannot be read - the
+	 * saved metadata row still drives the lookup in that case.
+	 */
+	private static Properties loadSmssProperties(String engineId) {
+		Object smssFile = DIHelper.getInstance().getEngineProperty(engineId + "_" + Constants.STORE);
+		if (smssFile == null) {
+			return null;
+		}
+		try {
+			return Utility.loadProperties(smssFile.toString());
+		} catch (Exception e) {
+			classLogger.warn("Unable to read the smss file for engine {}", engineId, e);
+			return null;
+		}
+	}
+
+	private static String trimToNull(Object value) {
+		if (value == null) {
+			return null;
+		}
+		String stringValue = value.toString().trim();
+		return stringValue.isEmpty() ? null : stringValue;
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Returns the provider-hosted built-in tools available to a model engine from meta/builtin-tools.json, resolved by its serving provider and model provider, alongside the engine's saved tool selection";
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (key.equals(ReactorKeysEnum.ENGINE.getKey())) {
+			return "The id or name of the model engine";
+		}
+		return super.getDescriptionForKey(key);
+	}
+}

--- a/src/prerna/reactor/model/GetModelBuiltinToolsReactor.java
+++ b/src/prerna/reactor/model/GetModelBuiltinToolsReactor.java
@@ -76,39 +76,57 @@ public class GetModelBuiltinToolsReactor extends AbstractReactor {
 	 */
 	private static final String SMSS_PROVIDER = "PROVIDER";
 
+	static final String SERVING_PROVIDER_KEY = "servingProvider";
+	static final String MODEL_PROVIDER_KEY = "modelProvider";
+	static final String MODEL_ID_KEY = "modelId";
+
 	public GetModelBuiltinToolsReactor() {
-		this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey() };
-		this.keyRequired = new int[] { 1 };
+		this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey(), SERVING_PROVIDER_KEY, MODEL_PROVIDER_KEY,
+				MODEL_ID_KEY };
+		this.keyRequired = new int[] { 0, 0, 0, 0 };
 	}
 
 	@Override
 	public NounMetadata execute() {
 		organizeKeys();
-		String engineId = this.keyValue.get(ReactorKeysEnum.ENGINE.getKey());
-		if (engineId == null || engineId.trim().isEmpty()) {
-			throw new IllegalArgumentException("Must input a model engine id");
+		String engineId = trimToNull(this.keyValue.get(ReactorKeysEnum.ENGINE.getKey()));
+		String servingProviderInput = trimToNull(this.keyValue.get(SERVING_PROVIDER_KEY));
+		String modelProviderInput = trimToNull(this.keyValue.get(MODEL_PROVIDER_KEY));
+		String modelIdInput = trimToNull(this.keyValue.get(MODEL_ID_KEY));
+
+		// an existing engine resolves everything itself; the explicit inputs
+		// serve the import flow, where the engine does not exist yet
+		Map<String, Object> metadata = null;
+		Properties smssProp = null;
+		if (engineId != null) {
+			User user = this.insight.getUser();
+			engineId = SecurityQueryUtils.testUserEngineIdForAlias(user, engineId);
+			if (!SecurityEngineUtils.userCanViewEngine(user, engineId)) {
+				throw new IllegalArgumentException(
+						"Model engine does not exist or user does not have access to view it");
+			}
+			if (SecurityEngineUtils.getEngineType(engineId) != IEngine.CATALOG_TYPE.MODEL) {
+				throw new IllegalArgumentException("Engine is not a model engine");
+			}
+			metadata = SecurityModelMetadataUtils.getModelMetadata(engineId);
+			smssProp = loadSmssProperties(engineId);
+		} else if (servingProviderInput == null && modelProviderInput == null && modelIdInput == null) {
+			throw new IllegalArgumentException(
+					"Must input a model engine id, or a serving provider, model provider, or model id");
 		}
 
-		User user = this.insight.getUser();
-		engineId = SecurityQueryUtils.testUserEngineIdForAlias(user, engineId);
-		if (!SecurityEngineUtils.userCanViewEngine(user, engineId)) {
-			throw new IllegalArgumentException("Model engine does not exist or user does not have access to view it");
-		}
-		if (SecurityEngineUtils.getEngineType(engineId) != IEngine.CATALOG_TYPE.MODEL) {
-			throw new IllegalArgumentException("Engine is not a model engine");
-		}
-
-		Map<String, Object> metadata = SecurityModelMetadataUtils.getModelMetadata(engineId);
-		Properties smssProp = loadSmssProperties(engineId);
-
-		String modelId = resolveModelId(metadata, smssProp);
-		String servingProvider = resolveServingProvider(metadata, smssProp);
-		String modelProvider = resolveModelProvider(metadata, modelId);
+		String modelId = modelIdInput != null ? modelIdInput : resolveModelId(metadata, smssProp);
+		String servingProvider = servingProviderInput != null
+				? StaticBuiltinToolsCatalog.normalizeProviderKey(servingProviderInput)
+				: resolveServingProvider(metadata, smssProp);
+		String modelProvider = modelProviderInput != null
+				? StaticBuiltinToolsCatalog.normalizeProviderKey(modelProviderInput)
+				: resolveModelProvider(metadata, modelId);
 
 		Map<String, Object> tools = getTools(servingProvider, modelProvider, modelId);
 
 		Map<String, Object> response = new LinkedHashMap<>();
-		response.put("engineId", engineId);
+		response.put("engineId", engineId == null ? "" : engineId);
 		response.put("modelId", modelId == null ? "" : modelId);
 		response.put("modelProvider", modelProvider == null ? "" : modelProvider);
 		response.put("servingProvider", servingProvider == null ? "" : servingProvider);
@@ -227,13 +245,22 @@ public class GetModelBuiltinToolsReactor extends AbstractReactor {
 
 	@Override
 	public String getReactorDescription() {
-		return "Returns the provider-hosted built-in tools available to a model engine from meta/builtin-tools.json, resolved by its serving provider and model provider, alongside the engine's saved tool selection";
+		return "Returns the provider-hosted built-in tools available to a model from meta/builtin-tools.json, resolved by serving provider and model provider. Pass an existing engine to resolve both from it (alongside its saved tool selection), or pass the providers and model id directly when the engine does not exist yet";
 	}
 
 	@Override
 	protected String getDescriptionForKey(String key) {
 		if (key.equals(ReactorKeysEnum.ENGINE.getKey())) {
-			return "The id or name of the model engine";
+			return "The id or name of an existing model engine; optional when the providers are passed directly";
+		}
+		if (key.equals(SERVING_PROVIDER_KEY)) {
+			return "Who hosts the model (openai, anthropic, google, bedrock, azure); the SMSS MODEL_TYPE values are also accepted";
+		}
+		if (key.equals(MODEL_PROVIDER_KEY)) {
+			return "Who made the model (openai, anthropic, google); inferred from the model id when omitted";
+		}
+		if (key.equals(MODEL_ID_KEY)) {
+			return "The provider model id, used to infer the model provider and evaluate per-tool model constraints";
 		}
 		return super.getDescriptionForKey(key);
 	}

--- a/src/prerna/util/StaticBuiltinToolsCatalog.java
+++ b/src/prerna/util/StaticBuiltinToolsCatalog.java
@@ -176,6 +176,7 @@ public final class StaticBuiltinToolsCatalog {
 		case "open_ai", "openai" -> "openai";
 		case "azure_open_ai", "azure_openai" -> "azure";
 		case "vertex", "vertex_ai", "google_vertex" -> "google";
+		case "aws_bedrock", "amazon_bedrock" -> "bedrock";
 		default -> value;
 		};
 	}

--- a/src/prerna/util/StaticBuiltinToolsCatalog.java
+++ b/src/prerna/util/StaticBuiltinToolsCatalog.java
@@ -1,0 +1,283 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.util;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonParser;
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * Read-only view over the curated provider built-in tool catalog stored in
+ * meta/builtin-tools.json.
+ * <p>
+ * The catalog is keyed by serving provider. A serving provider node holds
+ * either tool definitions directly (openai, anthropic, google - each value
+ * carries an "alias") or, for aggregators that host other vendors' models
+ * (bedrock), a second level keyed by model provider. Mixing the two shapes
+ * within one node is not supported.
+ * <p>
+ * A tool definition may carry a "constraints" object whose "models" list
+ * restricts the tool to specific model ids. The catalog is hand-maintained
+ * and optional, so a missing file or an unknown provider yields no tools
+ * rather than an error.
+ */
+public final class StaticBuiltinToolsCatalog {
+
+	private static final Logger classLogger = LogManager.getLogger(StaticBuiltinToolsCatalog.class);
+	private static final Gson GSON = new Gson();
+
+	private static final String META_DIRECTORY = "meta";
+	private static final String BUILTIN_TOOLS_FILE = "builtin-tools.json";
+	private static final String TOOL_ALIAS = "alias";
+	private static final Type TOOL_DEFINITION_TYPE = new TypeToken<LinkedHashMap<String, Object>>() {
+	}.getType();
+	private static final Object CACHE_LOCK = new Object();
+
+	private static volatile CatalogCache catalogCache;
+
+	private StaticBuiltinToolsCatalog() {
+	}
+
+	/**
+	 * Location of the catalog file within the SEMOSS base folder.
+	 */
+	public static Path getCatalogFile() {
+		String baseFolder = Utility.getBaseFolder();
+		if (baseFolder == null || baseFolder.trim().isEmpty()) {
+			throw new IllegalStateException("SEMOSS base folder is not configured");
+		}
+		return Paths.get(baseFolder, META_DIRECTORY, BUILTIN_TOOLS_FILE);
+	}
+
+	/**
+	 * The built-in tools a model can use, keyed by canonical tool name. Returns
+	 * an empty map when the install has no catalog file, the providers are
+	 * unknown to the catalog, or every tool is ruled out by its model
+	 * constraints.
+	 *
+	 * @param servingProvider lowercase catalog key for who hosts the model
+	 *                        (openai, anthropic, google, bedrock, ...)
+	 * @param modelProvider   lowercase catalog key for who made the model
+	 * @param modelId         provider model id used to evaluate per-tool model
+	 *                        constraints; null skips that filter
+	 */
+	public static Map<String, Object> getTools(Path catalogFile, String servingProvider, String modelProvider,
+			String modelId) {
+		Map<String, Object> tools = new LinkedHashMap<>();
+		if (!Files.isRegularFile(catalogFile)) {
+			// the catalog is optional - installs without one simply offer no tools
+			return tools;
+		}
+
+		// a direct provider serves its own models, so either provider can stand
+		// in for a missing counterpart
+		String serving = servingProvider != null ? servingProvider : modelProvider;
+		String model = modelProvider != null ? modelProvider : servingProvider;
+		if (serving == null) {
+			return tools;
+		}
+
+		JsonObject catalog = loadCatalog(catalogFile);
+		JsonElement providerElement = catalog.get(serving);
+		if (providerElement == null || !providerElement.isJsonObject()) {
+			return tools;
+		}
+		JsonObject providerNode = providerElement.getAsJsonObject();
+
+		JsonObject toolDefinitions;
+		if (isToolMap(providerNode)) {
+			// tools listed directly on the serving provider only apply to that
+			// provider's own models - an anthropic model served through vertex
+			// cannot use the google tools
+			if (!serving.equals(model)) {
+				return tools;
+			}
+			toolDefinitions = providerNode;
+		} else {
+			JsonElement nested = model == null ? null : providerNode.get(model);
+			if (nested == null || !nested.isJsonObject()) {
+				return tools;
+			}
+			toolDefinitions = nested.getAsJsonObject();
+		}
+
+		for (Map.Entry<String, JsonElement> entry : toolDefinitions.entrySet()) {
+			if (!entry.getValue().isJsonObject()) {
+				continue;
+			}
+			JsonObject definition = entry.getValue().getAsJsonObject();
+			if (!modelSatisfiesConstraints(definition, modelId)) {
+				continue;
+			}
+			tools.put(entry.getKey(), GSON.fromJson(definition, TOOL_DEFINITION_TYPE));
+		}
+		return tools;
+	}
+
+	/**
+	 * Reduce a provider name from any of the shapes the platform records - the
+	 * MODELPROVIDER / SERVINGPROVIDER columns (OPENAI, BEDROCK), the SMSS
+	 * MODEL_TYPE (OPEN_AI, AZURE_OPEN_AI, VERTEX), or the SMSS PROVIDER
+	 * variable (google, bedrock) - to the lowercase key the catalog uses.
+	 * Returns null for a blank input.
+	 */
+	public static String normalizeProviderKey(String provider) {
+		if (provider == null || provider.trim().isEmpty()) {
+			return null;
+		}
+		String value = provider.trim().toLowerCase(Locale.ROOT).replaceAll("[\\s-]+", "_");
+		return switch (value) {
+		case "open_ai", "openai" -> "openai";
+		case "azure_open_ai", "azure_openai" -> "azure";
+		case "vertex", "vertex_ai", "google_vertex" -> "google";
+		default -> value;
+		};
+	}
+
+	/**
+	 * A node holds tool definitions when its values carry an alias; otherwise
+	 * it is a second level keyed by model provider. An empty node reads as
+	 * nested, which yields no tools either way.
+	 */
+	private static boolean isToolMap(JsonObject providerNode) {
+		for (Map.Entry<String, JsonElement> entry : providerNode.entrySet()) {
+			if (entry.getValue().isJsonObject() && entry.getValue().getAsJsonObject().has(TOOL_ALIAS)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Whether the model id passes the tool's constraints.models list. A tool
+	 * without model constraints - or a call without a model id to check -
+	 * passes. Both sides are compared through the same qualifier peeling the
+	 * model catalog uses, so "us.openai.gpt-5.4" matches a constraint entry of
+	 * "openai.gpt-5.4".
+	 */
+	private static boolean modelSatisfiesConstraints(JsonObject definition, String modelId) {
+		JsonElement constraintsElement = definition.get("constraints");
+		if (constraintsElement == null || !constraintsElement.isJsonObject()) {
+			return true;
+		}
+		JsonElement modelsElement = constraintsElement.getAsJsonObject().get("models");
+		if (modelsElement == null || !modelsElement.isJsonArray() || modelsElement.getAsJsonArray().size() == 0) {
+			return true;
+		}
+		if (modelId == null || modelId.trim().isEmpty()) {
+			return true;
+		}
+
+		Set<String> lookupIds = StaticModelMetadataCatalog.getLookupIds(modelId.trim().toLowerCase(Locale.ROOT));
+		JsonArray models = modelsElement.getAsJsonArray();
+		for (JsonElement model : models) {
+			if (model == null || !model.isJsonPrimitive()) {
+				continue;
+			}
+			String constraintModel = model.getAsString().trim().toLowerCase(Locale.ROOT);
+			if (constraintModel.isEmpty()) {
+				continue;
+			}
+			for (String constraintLookupId : StaticModelMetadataCatalog.getLookupIds(constraintModel)) {
+				if (lookupIds.contains(constraintLookupId)) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
+
+	private static JsonObject loadCatalog(Path catalogFile) {
+		Path normalizedPath = catalogFile.toAbsolutePath().normalize();
+		try {
+			BasicFileAttributes attributes = Files.readAttributes(normalizedPath, BasicFileAttributes.class);
+			if (!attributes.isRegularFile()) {
+				throw new IllegalStateException("Built-in tools catalog path is not a file: " + normalizedPath);
+			}
+
+			CatalogCache currentCache = catalogCache;
+			if (currentCache != null && currentCache.matches(normalizedPath, attributes)) {
+				return currentCache.catalog();
+			}
+
+			synchronized (CACHE_LOCK) {
+				attributes = Files.readAttributes(normalizedPath, BasicFileAttributes.class);
+				currentCache = catalogCache;
+				if (currentCache != null && currentCache.matches(normalizedPath, attributes)) {
+					return currentCache.catalog();
+				}
+
+				JsonElement parsed;
+				try (Reader reader = Files.newBufferedReader(normalizedPath, StandardCharsets.UTF_8)) {
+					parsed = JsonParser.parseReader(reader);
+				}
+				if (!parsed.isJsonObject()) {
+					throw new IllegalStateException(
+							"Built-in tools catalog file must contain a JSON object: " + normalizedPath);
+				}
+
+				JsonObject catalog = parsed.getAsJsonObject();
+				catalogCache = new CatalogCache(normalizedPath, attributes.lastModifiedTime(), attributes.size(),
+						catalog);
+				return catalog;
+			}
+		} catch (IOException | JsonParseException e) {
+			classLogger.error("Unable to read the built-in tools catalog from {}", normalizedPath, e);
+			throw new IllegalStateException("Unable to read the built-in tools catalog from " + normalizedPath, e);
+		}
+	}
+
+	private record CatalogCache(Path path, FileTime lastModifiedTime, long size, JsonObject catalog) {
+
+		private boolean matches(Path catalogPath, BasicFileAttributes attributes) {
+			return this.path.equals(catalogPath) && this.lastModifiedTime.equals(attributes.lastModifiedTime())
+					&& this.size == attributes.size();
+		}
+	}
+}


### PR DESCRIPTION
Adds first-class support for provider-hosted built-in tools (web search, web fetch, image generation, code execution, ...) on model engines. Admins can now see which built-in tools a model's provider actually offers, select and configure them per engine, and have the selection automatically ride along on every inference call.

The core problem this solves: a vendor's models do **not** keep their capabilities across hosts. OpenAI models on Bedrock don't get the OpenAI-hosted tools, Claude on Vertex only gets a subset of what Claude on Anthropic gets, and Azure gets almost nothing. Tool availability is therefore resolved by **serving provider + model provider**, not by model alone.

> **Note:** the UI for selecting tools (engine settings page + model import page) is in a separate SemossWeb PR. This PR is the catalog, reactor, storage, and runtime side.

---

## 1. Tool catalog — `meta/builtin-tools.json` (new)

A curated catalog of provider-hosted tools, sibling to `meta/model.json`.

**Structure rules:**
- Top-level keys are **serving providers**. Direct providers (`openai`, `anthropic`) hold tool definitions directly (each has an `alias`).
- Multi-vendor hosts (`bedrock`, `google`) nest one more level by **model provider** (`bedrock.openai`, `google.google` for Gemini, `google.anthropic` for Claude-on-Vertex). A node is one shape or the other, never mixed.
- Each tool definition carries `alias` (the provider's tool type identifier), `display_name`, `description`, and a `params` array (`alias`, `input` kind, `options`, `default`, `show_in_ui`, required/optional). **The params are written to be the provider request fields themselves**, so no per-provider mapping tables are needed downstream.
- Optional per-tool `constraints.models` restricts a tool to specific model ids (e.g. Bedrock-hosted OpenAI web search is only on gpt-5.4/5.5/5.6).

**Current coverage** (verified against provider docs):

| Serving / model provider | Tools |
|---|---|
| `openai` | web_search, image_generation |
| `anthropic` | web_search (20260318), web_fetch (20260318) |
| `google.google` (Gemini) | web_search, google_maps, web_fetch (url_context), code_execution |
| `google.anthropic` (Claude on Vertex) | web_search (basic 20250305 only — Vertex has no web fetch / code execution / dynamic filtering) |
| `bedrock.openai` | web_search (Responses/mantle only, model-constrained, `external_web_access` defaults off — needs `bedrock-websearch:ExternalWebAccess` IAM to enable) |
| `bedrock.anthropic` | none (intentionally empty — Anthropic server tools are not available on Bedrock) |

## 2. Offering tools — `StaticBuiltinToolsCatalog` + `GetModelBuiltinTools` (new)

- `prerna.util.StaticBuiltinToolsCatalog` reads the catalog with the same mtime+size cache pattern as `StaticModelMetadataCatalog` (file edits picked up without restart). Handles the direct-vs-nested node shapes, evaluates model constraints via the existing catalog id-peeling (`us.openai.gpt-5.4` matches `openai.gpt-5.4`), and normalizes provider spellings (`OPEN_AI`→`openai`, `VERTEX`/`GOOGLE_VERTEX`→`google`, `AWS_BEDROCK`→`bedrock`, `AZURE_OPEN_AI`→`azure`).
- `GetModelBuiltinTools` pixel resolves what a model can use, two modes:
  - `GetModelBuiltinTools(engine=["<id>"])` — for existing engines (view-permission checked). Serving provider resolves from MODELMETADATA → SMSS `PROVIDER` → SMSS `MODEL_TYPE`; model provider from MODELMETADATA → `model.json` → the dotted vendor qualifier in the model id.
  - `GetModelBuiltinTools(servingProvider=[...], modelProvider=[...], modelId=[...])` — for the import flow, where the engine doesn't exist yet.
  - Returns `{engineId, modelId, modelProvider, servingProvider, tools, selected}`. A vendor's model on another host gets **no** direct-provider tools (Claude-on-Vertex is not offered the Gemini tools).

## 3. Storing selections — `MODELMETADATA.BUILTINTOOLS`

The existing CLOB column now stores exactly **one shape**: a JSON object keyed by canonical tool name, whose values are the catalog definition copied verbatim, with a `value` added beside `default` on any parameter the user changed:

```json
{
  "web_search": {
    "alias": "web_search_20260318",
    "display_name": "Web Search",
    "params": [
      { "alias": "max_uses", "default": 5, "value": 3, "show_in_ui": true }
    ]
  }
}
```

Stored catalog-shaped (not request-shaped) on purpose: any consumer reading model metadata can render the tool's options without a second catalog lookup. Effective param value = `value ?? default`.

- Writes of any other shape (arrays, comma strings) are rejected with a clear error; reads of non-object column data return unset. No legacy support — the feature is pre-release.
- Whole numbers parse as longs (`ToNumberPolicy.LONG_OR_DOUBLE`) so python receives `max_uses=5`, not `5.0`.
- No schema change: the column and its auto-ALTER already existed; `Constants.BUILTIN_TOOLS` was already in the editable keys, so `UpdateModelMetadata` / `CreateModelEngine(modelDetails=...)` persist it as-is.

## 4. Runtime plumbing — Java → Python

- `AbstractModelEngine.fillModelSettingsFromMetadata` (runs once at engine open) now also captures the row's `builtinTools`, and `open()` resolves an effective `maxTokens` (SMSS wins under either key casing, blanks ignored, then the row's `maxOutputTokens`).
- `AbstractPythonModelEngine.askCall` injects both onto every ask unless the caller supplied their own:
  - `built_in_tools=<selection dict>` (skipped if the caller passed one)
  - `max_tokens=<value>` (skipped if the caller passed any of `max_tokens` / `max_completion_tokens` / `max_output_tokens` / `max_new_tokens`)
  - Precedence everywhere: **request > SMSS > MODELMETADATA row**.
  - Injection is deliberately scoped to python engines — REST engines forward raw hyperparams into request bodies.

## 5. Python conversions — catalog-driven, no name tables

New shared module `genai_client/message_builders/semoss_base/builtin_tools.py` normalizes the selection dict into `{name, alias, params: {alias: value-or-default}}` entries; anything that isn't the dict shape normalizes to no tools rather than crashing. All consumers route through it:

| Provider | Emitted tool spec |
|---|---|
| OpenAI (incl. Bedrock mantle) | `{**params, "type": alias}` — e.g. `{"type": "web_search", "external_web_access": false}` |
| Anthropic (incl. Vertex) | `{**params}` with `name`/`type` defaulted from the selection (the catalog's hidden required params carry the versioned type) |
| Google GenAI | `types.Tool(**params)` — the param alias names the Tool field (`google_search={}`, `url_context={}`) |
| Bedrock Converse | `{"systemTool": {"name": name}}` (Converse systemTools carry no params) |

Unset optional values (`None`, `[]`, `{}`) are pruned so we never send `allowed_domains: []`; meaningful `false`/`0` values are kept. The web-search citation gates in the Anthropic and Google clients use the same normalizer.

## 6. Fixes picked up along the way

- **Anthropic `max_tokens` crash** (regression from #2857): the `ModelLimits` removal left `model_settings.max_tokens` as the only fallback, so engines whose INIT script doesn't pass `max_tokens` failed **every** request client-side with `Missing required arguments; Expected either ('max_tokens', 'messages' and 'model')...` (Anthropic requires `max_tokens`, and `model_dump(exclude_none=True)` silently drops a `None`). The builder now falls back to the model's own output cap as a last resort — though with the metadata injection above, that fallback should rarely fire.
- **Bedrock client factory import**: `get_text_gen_client("BEDROCK")` pointed at the pre-refactor module path (`text_generation.bedrock_client`) and raised `ModuleNotFoundError`; fixed to `text_generation.bedrock_clients.bedrock_client`.
