### PR TITLE
Amazon Nova tool calling fails with "Model produced invalid sequence as part of ToolUse"

### DIFF
--- a/src/prerna/engine/impl/model/Room.java
+++ b/src/prerna/engine/impl/model/Room.java
@@ -1010,7 +1010,8 @@ public class Room implements Serializable {
 	 */
 	private void appendToolsToParams(Map<String, Object> params, IModelEngine modelEngine) {
 		int maxLength = MCPUtility.getMaxToolNameLength(modelEngine);
-		List<Map<String, Object>> newTools = getAllToolsJsonForRoom(maxLength);
+		List<Map<String, Object>> newTools = getAllToolsJsonForRoom(maxLength,
+				MCPUtility.requiresLLMNameSanitization(modelEngine));
 		Object existing = params.get("tools");
 		if (existing instanceof List<?>) {
 			@SuppressWarnings("unchecked")
@@ -1065,8 +1066,19 @@ public class Room implements Serializable {
 	 *                  {@link MCPUtility#DEFAULT_MAX_TOOL_NAME_LENGTH} as default)
 	 * @return list of tool definition maps ready to pass to the LLM
 	 */
-	@SuppressWarnings("unchecked")
 	public List<Map<String, Object>> getAllToolsJsonForRoom(int maxLength) {
+		return getAllToolsJsonForRoom(maxLength, false);
+	}
+
+	/**
+	 * Same as {@link #getAllToolsJsonForRoom(int)}, additionally sanitizing the
+	 * LLM-facing tool names for providers that require it (see
+	 * {@link MCPUtility#requiresLLMNameSanitization}). The lookup map is keyed by
+	 * the exact names sent to the model, so callers must pass the same flag the
+	 * model invocation used.
+	 */
+	@SuppressWarnings("unchecked")
+	public List<Map<String, Object>> getAllToolsJsonForRoom(int maxLength, boolean sanitizeToolNamesForLLM) {
 		toolLookupByLLMName.clear();
 		List<Map<String, Object>> aggregated = new ArrayList<>();
 		Map<String, Object> o = getOptionsMap();
@@ -1079,7 +1091,7 @@ public class Room implements Serializable {
 		if (InternalMCP.hasDefinitions(getRoomFolderPath())) {
 			ensureUnique.add(MCPUtility.ROOM_MCP_ID);
 			try {
-				aggregated.addAll(getToolJson(MCPUtility.ROOM_MCP_ID, maxLength));
+				aggregated.addAll(getToolJson(MCPUtility.ROOM_MCP_ID, maxLength, sanitizeToolNamesForLLM));
 			} catch (Exception e) {
 				classLogger.error("Unable to add the room's own MCP tools", e);
 			}
@@ -1093,7 +1105,7 @@ public class Room implements Serializable {
 						if (mcpMap.containsKey("id")) {
 							String id = (String) mcpMap.get("id");
 							if (!ensureUnique.contains(id)) {
-								aggregated.addAll(getToolJson(id, maxLength));
+								aggregated.addAll(getToolJson(id, maxLength, sanitizeToolNamesForLLM));
 								ensureUnique.add(id);
 							}
 						} else {
@@ -1123,7 +1135,7 @@ public class Room implements Serializable {
 						for (Map<String, Object> tool : tools) {
 							String toolId = (String) tool.get("resource_id");
 							if (!ensureUnique.contains(toolId)) {
-								aggregated.addAll(getToolJson(toolId, maxLength));
+								aggregated.addAll(getToolJson(toolId, maxLength, sanitizeToolNamesForLLM));
 								ensureUnique.add(toolId);
 							}
 						}
@@ -1143,7 +1155,7 @@ public class Room implements Serializable {
 								}
 								String toolId = mcp.optString("id", null);
 								if (toolId != null && !toolId.isEmpty() && !ensureUnique.contains(toolId)) {
-									aggregated.addAll(getToolJson(toolId, maxLength));
+									aggregated.addAll(getToolJson(toolId, maxLength, sanitizeToolNamesForLLM));
 									ensureUnique.add(toolId);
 								}
 							}
@@ -1167,12 +1179,14 @@ public class Room implements Serializable {
 	 * {@link #updateToolResponseMeta(ResponseMessage)} can reverse-resolve
 	 * LLM-facing names.
 	 *
-	 * @param engineId  the engine/project UUID
-	 * @param maxLength maximum allowed tool name length
+	 * @param engineId                the engine/project UUID
+	 * @param maxLength               maximum allowed tool name length
+	 * @param sanitizeToolNamesForLLM whether the injected engine-id prefix must be
+	 *                                restricted to [a-zA-Z0-9_] (Bedrock/Nova)
 	 * @return list of non-disabled tool definition maps
 	 */
 	@SuppressWarnings("unchecked")
-	private List<Map<String, Object>> getToolJson(String engineId, int maxLength) {
+	private List<Map<String, Object>> getToolJson(String engineId, int maxLength, boolean sanitizeToolNamesForLLM) {
 		// room level MCPs
 		if (MCPUtility.ROOM_MCP_ID.equals(engineId)) {
 			InternalMCP roomMcp = InternalMCP.genFromRoomFolder(this.getRoomFolderPath());
@@ -1193,7 +1207,7 @@ public class Room implements Serializable {
 				}
 			}
 			JSONObject updatedToolMap = MCPUtility.appendEngineIdToToolsMethodName(MCPUtility.ROOM_MCP_ID, toolMap,
-					maxLength);
+					maxLength, sanitizeToolNamesForLLM);
 			if (updatedToolMap == null || !updatedToolMap.has("tools")) {
 				return new ArrayList<>();
 			}
@@ -1269,7 +1283,8 @@ public class Room implements Serializable {
 			engineMeta = toolMap.getJSONObject("_meta").toMap();
 		}
 
-		JSONObject updatedToolMap = MCPUtility.appendEngineIdToToolsMethodName(engineId, toolMap, maxLength);
+		JSONObject updatedToolMap = MCPUtility.appendEngineIdToToolsMethodName(engineId, toolMap, maxLength,
+				sanitizeToolNamesForLLM);
 		if (updatedToolMap != null && updatedToolMap.has("tools")) {
 			JSONArray arr = updatedToolMap.getJSONArray("tools");
 			List<Map<String, Object>> result = new ArrayList<>();

--- a/src/prerna/engine/impl/model/RoomUtils.java
+++ b/src/prerna/engine/impl/model/RoomUtils.java
@@ -610,7 +610,8 @@ public final class RoomUtils {
 				// Tool metadata enrichment still supports legacy UUID-prefixed names.
 			}
 		}
-		room.getAllToolsJsonForRoom(MCPUtility.getMaxToolNameLength(roomModelEngine));
+		room.getAllToolsJsonForRoom(MCPUtility.getMaxToolNameLength(roomModelEngine),
+				MCPUtility.requiresLLMNameSanitization(roomModelEngine));
 
 		Map<String, JSONObject> toolCache = new HashMap<>();
 		for (AbstractMessage message : messages) {

--- a/src/prerna/reactor/agent/mcp/MCPUtility.java
+++ b/src/prerna/reactor/agent/mcp/MCPUtility.java
@@ -645,15 +645,29 @@ public final class MCPUtility {
 	 * skip truncation.
 	 */
 	public static JSONObject appendEngineIdToToolsMethodName(String engineId, JSONObject jsonToolsMap, int maxLength) {
+		return appendEngineIdToToolsMethodName(engineId, jsonToolsMap, maxLength, false);
+	}
+
+	/**
+	 * Appends engine ID prefix to each tool name, truncating to maxLength. When
+	 * sanitizeForLLM is true the injected prefix is restricted to [a-zA-Z0-9_]
+	 * (see {@link #requiresLLMNameSanitization}); other providers keep the raw
+	 * engine id so existing LLM-facing names are unchanged.
+	 */
+	public static JSONObject appendEngineIdToToolsMethodName(String engineId, JSONObject jsonToolsMap, int maxLength,
+			boolean sanitizeForLLM) {
 		if (jsonToolsMap == null || !jsonToolsMap.has("tools")) {
 			return jsonToolsMap;
 		}
 
 		JSONArray toolsArray = jsonToolsMap.getJSONArray("tools");
+		String idForPrefix = sanitizeForLLM ? sanitizeEngineIdForLLMName(engineId) : engineId;
+		String shortIdForPrefix = sanitizeForLLM ? sanitizeEngineIdForLLMName(computeShortEngineId(engineId))
+				: computeShortEngineId(engineId);
 
 		if (maxLength == Integer.MAX_VALUE) {
 			// No length limit: use the full UUID prefix (preserves existing behavior)
-			String fullPrefix = "a" + sanitizeEngineIdForLLMName(engineId) + "_";
+			String fullPrefix = "a" + idForPrefix + "_";
 			for (int i = 0; i < toolsArray.length(); i++) {
 				JSONObject toolMap = toolsArray.getJSONObject(i);
 				String currentName = toolMap.getString("name");
@@ -664,8 +678,8 @@ public final class MCPUtility {
 
 		// Length-limited provider: prefer full UUID prefix when it fits, otherwise
 		// fall back to short 8-hex prefix and truncate if still needed.
-		String fullPrefix = "a" + sanitizeEngineIdForLLMName(engineId) + "_";
-		String shortPrefix = "a" + sanitizeEngineIdForLLMName(computeShortEngineId(engineId)) + "_";
+		String fullPrefix = "a" + idForPrefix + "_";
+		String shortPrefix = "a" + shortIdForPrefix + "_";
 
 		for (int i = 0; i < toolsArray.length(); i++) {
 			JSONObject toolMap = toolsArray.getJSONObject(i);
@@ -697,6 +711,16 @@ public final class MCPUtility {
 	 */
 	public static String sanitizeEngineIdForLLMName(String engineId) {
 		return engineId == null ? null : engineId.replaceAll("[^a-zA-Z0-9_]", "_");
+	}
+
+	/**
+	 * Whether LLM-facing tool names must be sanitized for the given model engine.
+	 * Only Bedrock engines opt in: Amazon Nova is the model family that rejects
+	 * hyphenated tool names, and scoping the rename here keeps every other
+	 * provider's tool names byte-identical to their historical form.
+	 */
+	public static boolean requiresLLMNameSanitization(IModelEngine modelEngine) {
+		return modelEngine != null && ModelTypeEnum.BEDROCK == modelEngine.getModelType();
 	}
 
 	/**

--- a/src/prerna/reactor/agent/mcp/MCPUtility.java
+++ b/src/prerna/reactor/agent/mcp/MCPUtility.java
@@ -162,9 +162,10 @@ public final class MCPUtility {
 	public static final String LEGACY_MCP_NOTEBOOK_NAME = "smss_driver";
 
 	// Regex pattern for "a" + UUID + "_"
-	// UUID format: 8-4-4-4-12 hexadecimal digits
-	private static final Pattern UUID_PREFIX_PATTERN = Pattern
-			.compile("^a[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}_");
+	// UUID format: 8-4-4-4-12 hexadecimal digits. Separators may be "-" (legacy
+	// names persisted before LLM-name sanitization) or "_" (sanitized names).
+	private static final Pattern UUID_PREFIX_PATTERN = Pattern.compile(
+			"^a([0-9a-fA-F]{8})[-_]([0-9a-fA-F]{4})[-_]([0-9a-fA-F]{4})[-_]([0-9a-fA-F]{4})[-_]([0-9a-fA-F]{12})_");
 
 	// Default maximum tool name length (matches OpenAI's 64-char limit)
 	public static final int DEFAULT_MAX_TOOL_NAME_LENGTH = 64;
@@ -652,18 +653,19 @@ public final class MCPUtility {
 
 		if (maxLength == Integer.MAX_VALUE) {
 			// No length limit: use the full UUID prefix (preserves existing behavior)
+			String fullPrefix = "a" + sanitizeEngineIdForLLMName(engineId) + "_";
 			for (int i = 0; i < toolsArray.length(); i++) {
 				JSONObject toolMap = toolsArray.getJSONObject(i);
 				String currentName = toolMap.getString("name");
-				toolMap.put("name", "a" + engineId + "_" + currentName);
+				toolMap.put("name", fullPrefix + currentName);
 			}
 			return jsonToolsMap;
 		}
 
 		// Length-limited provider: prefer full UUID prefix when it fits, otherwise
 		// fall back to short 8-hex prefix and truncate if still needed.
-		String fullPrefix = "a" + engineId + "_";
-		String shortPrefix = "a" + computeShortEngineId(engineId) + "_";
+		String fullPrefix = "a" + sanitizeEngineIdForLLMName(engineId) + "_";
+		String shortPrefix = "a" + sanitizeEngineIdForLLMName(computeShortEngineId(engineId)) + "_";
 
 		for (int i = 0; i < toolsArray.length(); i++) {
 			JSONObject toolMap = toolsArray.getJSONObject(i);
@@ -686,13 +688,30 @@ public final class MCPUtility {
 	}
 
 	/**
+	 * LLM-facing tool names must stay within [a-zA-Z0-9_]. Amazon Nova (Bedrock)
+	 * deterministically fails with "Model produced invalid sequence as part of
+	 * ToolUse" whenever a tool name contains a hyphen (e.g. from a hyphenated
+	 * engine id), and underscores are accepted by every provider. Only the
+	 * SEMOSS-injected prefix is sanitized; the author's tool name is appended
+	 * untouched.
+	 */
+	public static String sanitizeEngineIdForLLMName(String engineId) {
+		return engineId == null ? null : engineId.replaceAll("[^a-zA-Z0-9_]", "_");
+	}
+
+	/**
 	 * Strips the engine ID prefix from a tool function name. Tries the short prefix
-	 * (a{8hex}_) first, then falls back to the legacy full-UUID prefix.
+	 * (a{8hex}_) first, then the sanitized full prefix, then falls back to the
+	 * legacy raw full prefix (names persisted before LLM-name sanitization).
 	 */
 	public static String removeEngineIdFromToolsMethodName(String engineId, String functionName) {
-		String shortPrefix = "a" + computeShortEngineId(engineId) + "_";
+		String shortPrefix = "a" + sanitizeEngineIdForLLMName(computeShortEngineId(engineId)) + "_";
 		if (functionName.startsWith(shortPrefix)) {
 			return functionName.substring(shortPrefix.length());
+		}
+		String sanitizedFullPrefix = "a" + sanitizeEngineIdForLLMName(engineId) + "_";
+		if (functionName.startsWith(sanitizedFullPrefix)) {
+			return functionName.substring(sanitizedFullPrefix.length());
 		}
 		String fullPrefix = "a" + engineId + "_";
 		if (functionName.startsWith(fullPrefix)) {
@@ -712,9 +731,10 @@ public final class MCPUtility {
 
 		Matcher matcher = UUID_PREFIX_PATTERN.matcher(input);
 		if (matcher.find()) {
-			String prefix = matcher.group();
-			// remove the "a" and the "_" after the project id
-			prefix = prefix.substring(1, prefix.length() - 1);
+			// rebuild the canonical hyphenated UUID regardless of which separator
+			// ("-" legacy, "_" sanitized) appeared in the LLM-facing name
+			String prefix = matcher.group(1) + "-" + matcher.group(2) + "-" + matcher.group(3) + "-"
+					+ matcher.group(4) + "-" + matcher.group(5);
 			String remaining = input.substring(matcher.end());
 			return new String[] { prefix, remaining };
 		}


### PR DESCRIPTION
### Problem

Any Bedrock Converse request routed through a room with engine-backed tools fails on
Amazon Nova models (`amazon.nova-pro-v1:0`, etc.) as soon as the model attempts a tool
call:

```
ModelErrorException: Model produced invalid sequence as part of ToolUse.
Please refer to the model tool use troubleshooting guide.
```

The same room/tools work fine on Claude and OpenAI models.

### Root cause

Room tool names are sent to the LLM prefixed with their source engine id:
`a<engineId>_<toolName>` (e.g. `areactor-help_runPixel`). When the engine id contains a
hyphen (hyphenated ids, or any UUID engine id, since Bedrock is not a length-limited
provider and always gets the full-UUID prefix), the LLM-facing tool name contains `-`.

Amazon Nova deterministically fails to emit a valid ToolUse sequence for any tool whose
name contains a hyphen. Verified by direct `bedrock-runtime converse` calls against
`amazon.nova-pro-v1:0`:

| Tool name                                            | Result                        |
| ---------------------------------------------------- | ----------------------------- |
| `get_weather`                                        | OK                            |
| `a__room___get_weather`                              | OK                            |
| `afa1c15a9_df1b_4097_b19a_77e69c201650_get_weather` (49 chars, underscores) | OK    |
| `get-weather`                                        | ModelErrorException (2/2)     |
| `afa1c15a9-df1b-4097-b19a-77e69c201650_get_weather`  | ModelErrorException (2/2)     |

Failures are 100% reproducible whenever the model tries to call the tool, and are NOT
fixed by AWS's documented greedy-decoding mitigation (`temperature: 0`,
`additionalModelRequestFields.inferenceConfig.topK: 1`) - this is a name-format issue,
not a sampling issue.

### Fix - scoped to Bedrock engines only

Non-Bedrock providers produce byte-identical tool names to before this change; the
rename is opted into per model engine.

**`MCPUtility.java`**
- `sanitizeEngineIdForLLMName(String)`: replaces every character outside `[a-zA-Z0-9_]`
  with `_`.
- `requiresLLMNameSanitization(IModelEngine)`: true only when the model engine's type is
  `ModelTypeEnum.BEDROCK`.
- `appendEngineIdToToolsMethodName(...)` gains a 4-arg overload with a `sanitizeForLLM`
  flag that sanitizes the injected engine-id prefix (both the unlimited and
  length-limited branches). The author's own tool name is appended untouched. The
  existing 3-arg signature delegates with `false`, preserving current behavior for all
  other callers. Example on Bedrock: `areactor-help_runPixel` -> `areactor_help_runPixel`.
- `removeEngineIdFromToolsMethodName(...)` strips, in order: the short prefix, the
  sanitized full prefix, and the legacy raw full prefix. `UUID_PREFIX_PATTERN` /
  `parseEngineIdFromFunctionName(...)` accept both `-` and `_` as UUID separators and
  rebuild the canonical hyphenated engine id (used by the `HarnessToolExecutor` fallback
  when `_meta` is absent). These accept both forms unconditionally so a Bedrock room's
  sanitized names always resolve.

**`Room.java`**
- `appendToolsToParams(...)` computes the flag from the invoking model engine via
  `MCPUtility.requiresLLMNameSanitization(modelEngine)`.
- New `getAllToolsJsonForRoom(int, boolean)` overload threads the flag through the
  private `getToolJson(...)` helper to both rename sites (room MCP tools and
  engine/project tools). The existing 1-arg signature delegates with `false`.

**`RoomUtils.java`**
- `getMessagesForClient(...)` passes the same flag when rebuilding the lookup map for
  tool metadata enrichment, so the map is keyed by the exact names the LLM saw.

### Why routing is unaffected

Tool-call resolution primarily goes through `Room.toolLookupByLLMName`, an exact-string
map keyed by the LLM-facing name and populated at the same time the names are renamed,
with the original tool name carried in `_meta` (`SMSS_ORIGINAL_TOOL_NAME`). Since the map
records the sanitized name that is actually sent to the model, lookups round-trip
unchanged. The structural strip/parse helpers are only cold-map fallbacks and now accept
both name forms.

### Notes / limitations

- Tool names authored with hyphens in the tool itself (not the prefix) will still break
  Nova; only the SEMOSS-injected prefix is sanitized.
- Rooms that alternate between Bedrock and non-Bedrock models will have historical
  messages recorded under the other provider's name form; the strip/parse fallbacks
  accept both forms, so metadata enrichment of old messages still resolves.
- Reference: AWS Nova troubleshooting guide recommends greedy decoding for this error
  (https://docs.aws.amazon.com/nova/latest/userguide/prompting-tool-troubleshooting.html),
  which does not resolve this case.
