### PR TITLE
Fix stale system prompt shown in Agent UI for system agents

### DIFF
--- a/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
+++ b/src/prerna/engine/impl/model/inferencetracking/ModelInferenceLogsUtils.java
@@ -2717,6 +2717,58 @@ public class ModelInferenceLogsUtils {
 	}
 
 	/**
+	 * Updates only the core {@code WORKSPACE} display columns (NAME, DESCRIPTION,
+	 * SYSTEM_PROMPT) plus DATE_UPDATED. Leaves IS_ACTIVE, CONFIG_JSON, and the
+	 * WORKSPACE_RESOURCE rows untouched - unlike
+	 * {@link #updateWorkspaceEntry(String, String, String, String, boolean, List)},
+	 * which replaces the full resource set.
+	 *
+	 * <p>
+	 * Used by {@code SystemAgentSeeder} to self-heal the legacy display columns on
+	 * every boot the same way {@link #updateWorkspaceConfigJson(String, JSONObject)}
+	 * self-heals the config mirror. The legacy SYSTEM_PROMPT column is what
+	 * GetWorkspace/ListWorkspaces surface to the FE, so it must track the seeded
+	 * prompt or the UI shows a stale value after the constant changes.
+	 *
+	 * @param workspaceId  workspace identifier
+	 * @param name         workspace display name
+	 * @param description  workspace description payload
+	 * @param systemPrompt workspace system prompt payload
+	 * @throws SQLException if the update fails
+	 */
+	public static void updateWorkspaceCoreFields(String workspaceId, String name, String description,
+			String systemPrompt) throws SQLException {
+		if (workspaceId == null || workspaceId.isEmpty()) {
+			throw new IllegalArgumentException("workspaceId is required");
+		}
+		IRDBMSEngine modelInferenceLogsDb = SystemEngineRegistry.getModelInferenceLogsDb();
+		Timestamp now = Utility.getCurrentSqlTimestampUTC();
+
+		Connection con = null;
+		try {
+			con = modelInferenceLogsDb.getConnection();
+			try (PreparedStatement ps = con.prepareStatement(
+					"UPDATE WORKSPACE SET NAME = ?, DESCRIPTION = ?, SYSTEM_PROMPT = ?, DATE_UPDATED = ? WHERE WORKSPACE_ID = ?")) {
+				int index = 1;
+				ps.setString(index++, name);
+				modelInferenceLogsDb.getQueryUtil().handleInsertionOfClob(con, ps, description, index++, GSON);
+				modelInferenceLogsDb.getQueryUtil().handleInsertionOfClob(con, ps, systemPrompt, index++, GSON);
+				ps.setTimestamp(index++, now);
+				ps.setString(index++, workspaceId);
+				ps.execute();
+				if (!con.getAutoCommit()) {
+					con.commit();
+				}
+			}
+		} catch (Exception e) {
+			classLogger.error("Failed to update core fields for workspaceId '{}'.", workspaceId, e);
+			throw new SQLException("Failed to update workspace core fields: " + e.getMessage(), e);
+		} finally {
+			ConnectionUtils.closeAllConnectionsIfPooling(modelInferenceLogsDb, con, null, null);
+		}
+	}
+
+	/**
 	 * Adds a skill reference to {@code WORKSPACE.CONFIG_JSON.skills[]}, mirroring
 	 * the authoritative {@code WORKSPACE_RESOURCE} row so the two stores stay in
 	 * sync - the same dual-write pattern MCPs use

--- a/src/prerna/util/SystemAgentSeeder.java
+++ b/src/prerna/util/SystemAgentSeeder.java
@@ -146,10 +146,6 @@ public class SystemAgentSeeder {
 				}
 			}
 
-			// Self-heal both stores every boot: the legacy display columns (what
-			// GetWorkspace/ListWorkspaces surface to the Agent UI) and CONFIG_JSON
-			// (what AgentConfigLoader prefers at run time). Rewriting only one of
-			// them lets the UI show a prompt the agent no longer runs on.
 			ModelInferenceLogsUtils.updateWorkspaceCoreFields(agentId, displayName(agentId), description(agentId),
 					systemPrompt(agentId));
 			ModelInferenceLogsUtils.updateWorkspaceConfigJson(agentId, buildConfigJson(agentId, tools, skills));

--- a/src/prerna/util/SystemAgentSeeder.java
+++ b/src/prerna/util/SystemAgentSeeder.java
@@ -57,8 +57,12 @@ import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
  * <p>
  * {@link #seed(String)} is idempotent and self-healing: it is safe to run on
  * every boot. It creates the {@code WORKSPACE} row once, back-fills any missing
- * resource rows on subsequent boots, and always rewrites {@code CONFIG_JSON} so
- * a drifted mirror is repaired. If the ModelInferenceLogsDatabase feature is
+ * resource rows on subsequent boots, and always rewrites both {@code CONFIG_JSON}
+ * (the runtime source read by {@code AgentConfigLoader}) and the legacy
+ * NAME/DESCRIPTION/SYSTEM_PROMPT columns (the display source surfaced to the
+ * Agent UI by GetWorkspace/ListWorkspaces) so a drifted mirror on either side is
+ * repaired. Hand-edits to a system agent's prompt are therefore intentionally
+ * clobbered on the next boot. If the ModelInferenceLogsDatabase feature is
  * disabled it no-ops (the project itself still catalogs).
  *
  * <p>
@@ -142,6 +146,12 @@ public class SystemAgentSeeder {
 				}
 			}
 
+			// Self-heal both stores every boot: the legacy display columns (what
+			// GetWorkspace/ListWorkspaces surface to the Agent UI) and CONFIG_JSON
+			// (what AgentConfigLoader prefers at run time). Rewriting only one of
+			// them lets the UI show a prompt the agent no longer runs on.
+			ModelInferenceLogsUtils.updateWorkspaceCoreFields(agentId, displayName(agentId), description(agentId),
+					systemPrompt(agentId));
 			ModelInferenceLogsUtils.updateWorkspaceConfigJson(agentId, buildConfigJson(agentId, tools, skills));
 		} catch (Exception e) {
 			classLogger.error("Failed to seed system agent workspace '{}'", agentId, e);


### PR DESCRIPTION
### Problem
On every boot, `SystemAgentSeeder.seed()` rewrites `WORKSPACE.CONFIG_JSON` (what the
agent runtime reads) but never touches the legacy `SYSTEM_PROMPT` column (what
GetWorkspace/ListWorkspaces return and the Agent UI displays). So whenever the
`APP_BUILDER_SYSTEM_PROMPT` constant changes between releases, the agent runs on the
new prompt while the UI keeps showing the old one indefinitely. The reverse also
happened: a UI edit to the system agent survived in the column (still displayed) but
was clobbered out of CONFIG_JSON on the next reboot (never used).

### Fix
- Added `ModelInferenceLogsUtils.updateWorkspaceCoreFields()` - updates only NAME,
  DESCRIPTION, SYSTEM_PROMPT, and DATE_UPDATED. Intentionally not reusing
  `updateWorkspaceEntry`, which would delete and replace all WORKSPACE_RESOURCE rows.
- `SystemAgentSeeder.seed()` now calls it on every boot alongside the existing
  `updateWorkspaceConfigJson` call, so both stores self-heal together.

### Behavior change
Hand-edits to a system agent's prompt/name/description via the UI are now fully
reverted on reboot (previously only the runtime side was reverted, leaving the UI
showing an edit the agent ignored).