### PR TITLE
Updating ability to clone project to editors and admins

### DIFF
--- a/src/prerna/auth/utils/SecurityProjectUtils.java
+++ b/src/prerna/auth/utils/SecurityProjectUtils.java
@@ -1159,14 +1159,21 @@ public class SecurityProjectUtils extends AbstractSecurityUtils {
 	}
 
 	/**
-	 * Determine whether a user may clone a project. The user must be able to view
-	 * the project and the owner must have explicitly enabled it as a template.
+	 * Determine whether a user may clone a project. Admins, owners, and editors
+	 * may always clone. Viewers may only clone when the owner has explicitly
+	 * enabled the project as a template.
 	 *
 	 * @param user      current user
 	 * @param projectId project identifier
 	 * @return whether the user may clone the project
 	 */
 	public static boolean userCanCloneProject(User user, String projectId) {
+		if (SecurityAdminUtils.userIsAdmin(user)) {
+			return true;
+		}
+		if (userCanEditProject(user, projectId)) {
+			return true;
+		}
 		return userCanViewProject(user, projectId) && projectIsTemplate(projectId);
 	}
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Fixing a bug that prevented apps from being cloned even if you were editor or admin. If you are an editor or admin, this does not require you to have the app set with `IS_TEMPLATE` to true.

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->