### PR TITLE
fix: honor rclone exit codes in the storage engines

### DIFF
--- a/src/prerna/engine/impl/storage/AbstractRCloneStorageEngine.java
+++ b/src/prerna/engine/impl/storage/AbstractRCloneStorageEngine.java
@@ -798,32 +798,6 @@ public abstract class AbstractRCloneStorageEngine extends AbstractStorageEngine 
 
 	/**
 	 * 
-	 * @param command
-	 * @return
-	 * @throws IOException          if rclone exited with a non-zero code
-	 * @throws InterruptedException
-	 */
-	protected static Map<String, Object> runProcessJsonOutput(String... command)
-			throws IOException, InterruptedException {
-		ProcessResult result = runProcess(command);
-		result.verify(Collections.emptySet(), command);
-		return parseJsonOutput(result.getOutput());
-	}
-
-	/**
-	 * 
-	 * @param command
-	 * @return
-	 * @throws IOException          if rclone exited with a non-zero code
-	 * @throws InterruptedException
-	 */
-	protected static List<Map<String, Object>> runProcessListJsonOutput(String... command)
-			throws IOException, InterruptedException {
-		return runProcessListJsonOutput(Collections.emptySet(), command);
-	}
-
-	/**
-	 * 
 	 * @param toleratedExitCodes non-zero rclone exit codes to accept instead of failing
 	 * @param command
 	 * @return
@@ -901,21 +875,6 @@ public abstract class AbstractRCloneStorageEngine extends AbstractStorageEngine 
 	 */
 	private static boolean isConfigCommand(String... command) {
 		return command != null && command.length > 1 && "config".equals(command[1]);
-	}
-
-	/**
-	 * 
-	 * @param lines
-	 * @return
-	 */
-	protected static Map<String, Object> parseJsonOutput(List<String> lines) {
-		String json = String.join("", lines);
-		if (json.trim().isEmpty()) {
-			return Collections.emptyMap();
-		}
-		Map<String, Object> parsed = GSON.fromJson(json, new TypeToken<Map<String, Object>>() {
-		}.getType());
-		return parsed == null ? Collections.emptyMap() : parsed;
 	}
 
 	/**

--- a/src/prerna/engine/impl/storage/AbstractRCloneStorageEngine.java
+++ b/src/prerna/engine/impl/storage/AbstractRCloneStorageEngine.java
@@ -41,6 +41,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
@@ -77,6 +78,15 @@ public abstract class AbstractRCloneStorageEngine extends AbstractStorageEngine 
 
 	// optional additional keys
 	protected String ADDITIONAL_RCLONE_PARAMETERS = null;
+
+	/**
+	 * rclone exit codes that report a missing target - 3 is directory not found and
+	 * 4 is file not found. Tolerated on the read and delete operations, where an
+	 * absent path is an empty result or an already finished delete rather than a
+	 * failure. Every other non-zero exit means rclone gave up after its retries and
+	 * the operation did not happen.
+	 */
+	private static final Set<Integer> NOT_FOUND_EXIT_CODES = Set.of(3, 4);
 
 	/**
 	 * Init the general storage values
@@ -177,6 +187,11 @@ public abstract class AbstractRCloneStorageEngine extends AbstractStorageEngine 
 		String configPath = getConfigPath(rCloneConfig);
 		try {
 			runRcloneDeleteFileProcess(rCloneConfig, RCLONE, "config", "delete", rCloneConfig);
+		} catch (IOException e) {
+			// every caller runs this from a finally block, so throwing here would replace
+			// the failure they are already unwinding. the config file itself is removed
+			// below either way, which is the part that matters
+			classLogger.warn("Unable to remove the temporary rclone config", e);
 		} finally {
 			configPath = Utility.normalizePath(configPath);
 			new File(configPath).delete();
@@ -656,7 +671,8 @@ public abstract class AbstractRCloneStorageEngine extends AbstractStorageEngine 
 		commandList.add(configPath);
 		commandList.add("--fast-list");
 		String[] newCommand = commandList.toArray(new String[] {});
-		return runAnyProcess(newCommand);
+		// listing a path that is not there is an empty result, not an error
+		return runAnyProcess(NOT_FOUND_EXIT_CODES, newCommand);
 	}
 
 	/**
@@ -708,7 +724,8 @@ public abstract class AbstractRCloneStorageEngine extends AbstractStorageEngine 
 		commandList.add("--config");
 		commandList.add(configPath);
 		String[] newCommand = commandList.toArray(new String[] {});
-		return runAnyProcess(newCommand);
+		// removing something that is already gone is a finished delete, not a failure
+		return runAnyProcess(NOT_FOUND_EXIT_CODES, newCommand);
 	}
 
 	/**
@@ -727,7 +744,8 @@ public abstract class AbstractRCloneStorageEngine extends AbstractStorageEngine 
 		commandList.add("--config");
 		commandList.add(configPath);
 		String[] newCommand = commandList.toArray(new String[] {});
-		return runProcessListJsonOutput(newCommand);
+		// listing a path that is not there is an empty result, not an error
+		return runProcessListJsonOutput(NOT_FOUND_EXIT_CODES, newCommand);
 	}
 
 	/**
@@ -751,47 +769,83 @@ public abstract class AbstractRCloneStorageEngine extends AbstractStorageEngine 
 	}
 
 	/**
+	 * Run the command and return what it wrote to stdout.
 	 * 
 	 * @param command
 	 * @return
-	 * @throws IOException
+	 * @throws IOException          if rclone exited with a non-zero code
 	 * @throws InterruptedException
 	 */
 	protected static List<String> runAnyProcess(String... command) throws IOException, InterruptedException {
-		// Need to allow this process to execute the below commands
-//		SecurityManager priorManager = System.getSecurityManager();
-//		System.setSecurityManager(null);
-		try {
-			Process p = null;
-			try {
-				ProcessBuilder pb = new ProcessBuilder(command);
-				pb.directory(new File(Utility.normalizePath(System.getProperty("user.home"))));
-				pb.redirectOutput(Redirect.PIPE);
-				pb.redirectError(Redirect.PIPE);
-				p = pb.start();
-				p.waitFor();
-				List<String> results = streamOutput(p.getInputStream());
-				streamError(p.getErrorStream());
-				return results;
-			} finally {
-				if (p != null) {
-					p.destroyForcibly();
-				}
-			}
-		} finally {
-//			System.setSecurityManager(priorManager);
-		}
+		return runAnyProcess(Collections.emptySet(), command);
+	}
+
+	/**
+	 * Run the command and return what it wrote to stdout.
+	 * 
+	 * @param toleratedExitCodes non-zero rclone exit codes to accept instead of failing
+	 * @param command
+	 * @return
+	 * @throws IOException          if rclone exited with a code outside toleratedExitCodes
+	 * @throws InterruptedException
+	 */
+	protected static List<String> runAnyProcess(Set<Integer> toleratedExitCodes, String... command)
+			throws IOException, InterruptedException {
+		ProcessResult result = runProcess(command);
+		result.verify(toleratedExitCodes, command);
+		return result.getOutput();
 	}
 
 	/**
 	 * 
 	 * @param command
 	 * @return
-	 * @throws IOException
+	 * @throws IOException          if rclone exited with a non-zero code
 	 * @throws InterruptedException
 	 */
 	protected static Map<String, Object> runProcessJsonOutput(String... command)
 			throws IOException, InterruptedException {
+		ProcessResult result = runProcess(command);
+		result.verify(Collections.emptySet(), command);
+		return parseJsonOutput(result.getOutput());
+	}
+
+	/**
+	 * 
+	 * @param command
+	 * @return
+	 * @throws IOException          if rclone exited with a non-zero code
+	 * @throws InterruptedException
+	 */
+	protected static List<Map<String, Object>> runProcessListJsonOutput(String... command)
+			throws IOException, InterruptedException {
+		return runProcessListJsonOutput(Collections.emptySet(), command);
+	}
+
+	/**
+	 * 
+	 * @param toleratedExitCodes non-zero rclone exit codes to accept instead of failing
+	 * @param command
+	 * @return
+	 * @throws IOException          if rclone exited with a code outside toleratedExitCodes
+	 * @throws InterruptedException
+	 */
+	protected static List<Map<String, Object>> runProcessListJsonOutput(Set<Integer> toleratedExitCodes,
+			String... command) throws IOException, InterruptedException {
+		ProcessResult result = runProcess(command);
+		result.verify(toleratedExitCodes, command);
+		return parseListJsonOutput(result.getOutput());
+	}
+
+	/**
+	 * Start the command, drain both of its pipes, and wait for it to finish.
+	 * 
+	 * @param command
+	 * @return the exit code together with everything written to stdout and stderr
+	 * @throws IOException
+	 * @throws InterruptedException
+	 */
+	private static ProcessResult runProcess(String... command) throws IOException, InterruptedException {
 		Process p = null;
 		try {
 			ProcessBuilder pb = new ProcessBuilder(command);
@@ -799,10 +853,19 @@ public abstract class AbstractRCloneStorageEngine extends AbstractStorageEngine 
 			pb.redirectOutput(Redirect.PIPE);
 			pb.redirectError(Redirect.PIPE);
 			p = pb.start();
-			p.waitFor();
-			Map<String, Object> results = streamJsonOutput(p.getInputStream());
-			streamError(p.getErrorStream());
-			return results;
+
+			// both pipes have to be drained while the process is still running - a child
+			// that fills the OS pipe buffer blocks on write, and waitFor() would then never
+			// return. stderr gets its own thread so neither stream can stall the other.
+			StreamDrainer errorDrainer = new StreamDrainer(p.getErrorStream(), true);
+			Thread errorThread = new Thread(errorDrainer, "rclone-stderr-" + p.pid());
+			errorThread.setDaemon(true);
+			errorThread.start();
+
+			List<String> output = streamOutput(p.getInputStream());
+			errorThread.join();
+
+			return new ProcessResult(p.waitFor(), output, errorDrainer.getLines());
 		} finally {
 			if (p != null) {
 				p.destroyForcibly();
@@ -811,30 +874,63 @@ public abstract class AbstractRCloneStorageEngine extends AbstractStorageEngine 
 	}
 
 	/**
+	 * Describe the rclone operation without exposing the rest of the command. The
+	 * argument list carries credentials on a config create, so it must never reach
+	 * a log line or an error message.
 	 * 
 	 * @param command
 	 * @return
-	 * @throws IOException
-	 * @throws InterruptedException
 	 */
-	protected static List<Map<String, Object>> runProcessListJsonOutput(String... command)
-			throws IOException, InterruptedException {
-		Process p = null;
-		try {
-			ProcessBuilder pb = new ProcessBuilder(command);
-			pb.directory(new File(Utility.normalizePath(System.getProperty("user.home"))));
-			pb.redirectOutput(Redirect.PIPE);
-			pb.redirectError(Redirect.PIPE);
-			p = pb.start();
-			p.waitFor();
-			List<Map<String, Object>> results = streamListJsonOutput(p.getInputStream());
-			streamError(p.getErrorStream());
-			return results;
-		} finally {
-			if (p != null) {
-				p.destroyForcibly();
-			}
+	private static String describeCommand(String... command) {
+		if (command == null || command.length < 2) {
+			return "rclone";
 		}
+		// "config" takes a sub-command of its own, everything else is a single verb
+		if (isConfigCommand(command) && command.length > 2) {
+			return "rclone " + command[1] + " " + command[2];
+		}
+		return "rclone " + command[1];
+	}
+
+	/**
+	 * Whether the command is an rclone config call, which is the only one that
+	 * carries the storage credentials in its arguments.
+	 * 
+	 * @param command
+	 * @return
+	 */
+	private static boolean isConfigCommand(String... command) {
+		return command != null && command.length > 1 && "config".equals(command[1]);
+	}
+
+	/**
+	 * 
+	 * @param lines
+	 * @return
+	 */
+	protected static Map<String, Object> parseJsonOutput(List<String> lines) {
+		String json = String.join("", lines);
+		if (json.trim().isEmpty()) {
+			return Collections.emptyMap();
+		}
+		Map<String, Object> parsed = GSON.fromJson(json, new TypeToken<Map<String, Object>>() {
+		}.getType());
+		return parsed == null ? Collections.emptyMap() : parsed;
+	}
+
+	/**
+	 * 
+	 * @param lines
+	 * @return
+	 */
+	protected static List<Map<String, Object>> parseListJsonOutput(List<String> lines) {
+		String json = String.join("", lines);
+		if (json.trim().isEmpty()) {
+			return Collections.emptyList();
+		}
+		List<Map<String, Object>> parsed = GSON.fromJson(json, new TypeToken<List<Map<String, Object>>>() {
+		}.getType());
+		return parsed == null ? Collections.emptyList() : parsed;
 	}
 
 	/**
@@ -845,16 +941,6 @@ public abstract class AbstractRCloneStorageEngine extends AbstractStorageEngine 
 	 */
 	protected static List<String> streamOutput(InputStream stream) throws IOException {
 		return stream(stream, false);
-	}
-
-	/**
-	 * 
-	 * @param stream
-	 * @return
-	 * @throws IOException
-	 */
-	protected static List<String> streamError(InputStream stream) throws IOException {
-		return stream(stream, true);
 	}
 
 	/**
@@ -885,35 +971,81 @@ public abstract class AbstractRCloneStorageEngine extends AbstractStorageEngine 
 	}
 
 	/**
-	 * 
-	 * @param stream
-	 * @return
-	 * @throws IOException
+	 * Reads one of the process pipes on its own thread so the child can never block
+	 * writing into a full buffer.
 	 */
-	protected static Map<String, Object> streamJsonOutput(InputStream stream) throws IOException {
-		try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
-			StringBuilder builder = new StringBuilder();
-			reader.lines().forEach(line -> builder.append(line));
-			classLogger.info(builder.toString());
-			return GSON.fromJson(builder.toString(), new TypeToken<Map<String, Object>>() {
-			}.getType());
+	private static class StreamDrainer implements Runnable {
+
+		private final InputStream stream;
+		private final boolean error;
+		private volatile List<String> lines = Collections.emptyList();
+
+		StreamDrainer(InputStream stream, boolean error) {
+			this.stream = stream;
+			this.error = error;
 		}
+
+		@Override
+		public void run() {
+			try {
+				this.lines = stream(this.stream, this.error);
+			} catch (IOException e) {
+				// losing the captured text must not fail the operation itself
+				classLogger.warn("Unable to read the rclone process {} stream", this.error ? "error" : "output", e);
+			}
+		}
+
+		List<String> getLines() {
+			return this.lines;
+		}
+
 	}
 
 	/**
-	 * 
-	 * @param stream
-	 * @return
-	 * @throws IOException
+	 * The outcome of a finished rclone invocation.
 	 */
-	protected static List<Map<String, Object>> streamListJsonOutput(InputStream stream) throws IOException {
-		try (BufferedReader reader = new BufferedReader(new InputStreamReader(stream, StandardCharsets.UTF_8))) {
-			StringBuilder builder = new StringBuilder();
-			reader.lines().forEach(line -> builder.append(line));
-			classLogger.info(builder.toString());
-			return GSON.fromJson(builder.toString(), new TypeToken<List<Map<String, Object>>>() {
-			}.getType());
+	private static class ProcessResult {
+
+		// keep an error message to a sane size - stderr can run to thousands of lines
+		private static final int MAX_ERROR_LINES = 5;
+
+		private final int exitCode;
+		private final List<String> output;
+		private final List<String> error;
+
+		ProcessResult(int exitCode, List<String> output, List<String> error) {
+			this.exitCode = exitCode;
+			this.output = output;
+			this.error = error;
 		}
+
+		List<String> getOutput() {
+			return this.output;
+		}
+
+		/**
+		 * rclone only exits non-zero once it has given up retrying, so any code we do
+		 * not explicitly tolerate means the operation did not happen.
+		 * 
+		 * @param toleratedExitCodes
+		 * @param command
+		 * @throws IOException
+		 */
+		void verify(Set<Integer> toleratedExitCodes, String... command) throws IOException {
+			if (this.exitCode == 0 || toleratedExitCodes.contains(this.exitCode)) {
+				return;
+			}
+			StringBuilder message = new StringBuilder(describeCommand(command)).append(" failed with exit code ")
+					.append(this.exitCode);
+			// a failing config create can echo the credentials it was handed, and this
+			// message travels back to the caller. the full text stays in the log only
+			if (!this.error.isEmpty() && !isConfigCommand(command)) {
+				message.append(" - ").append(String.join("; ",
+						this.error.subList(0, Math.min(this.error.size(), MAX_ERROR_LINES))));
+			}
+			throw new IOException(message.toString());
+		}
+
 	}
 
 }

--- a/src/prerna/reactor/storage/DeleteFromStorageReactor.java
+++ b/src/prerna/reactor/storage/DeleteFromStorageReactor.java
@@ -69,7 +69,7 @@ public class DeleteFromStorageReactor extends AbstractReactor {
 			return new NounMetadata(true, PixelDataType.BOOLEAN);
 		} catch (Exception e) {
 			classLogger.error(Constants.STACKTRACE, e);
-			throw new IllegalArgumentException("Error occurred delete file from storage");
+			throw new IllegalArgumentException("Error occurred delete file from storage. Detailed message = " + e.getMessage());
 		}
 	}
 

--- a/src/prerna/reactor/storage/GetStorageFileAsBase64Reactor.java
+++ b/src/prerna/reactor/storage/GetStorageFileAsBase64Reactor.java
@@ -126,7 +126,7 @@ public class GetStorageFileAsBase64Reactor extends AbstractReactor {
 			throw new IllegalArgumentException("In-memory blob reading is not supported by this storage engine");
 		} catch (Exception e) {
 			classLogger.error("Failed to read storage file content as base64: {}", e.getMessage(), e);
-			throw new IllegalArgumentException("Error reading blob from storage: " + storagePath);
+			throw new IllegalArgumentException("Error reading blob from storage: " + storagePath + ". Detailed message = " + e.getMessage());
 		}
 	}
 

--- a/src/prerna/reactor/storage/ListStoragePathDetailsReactor.java
+++ b/src/prerna/reactor/storage/ListStoragePathDetailsReactor.java
@@ -61,7 +61,7 @@ public class ListStoragePathDetailsReactor extends AbstractReactor {
 			return new NounMetadata(storageList, PixelDataType.VECTOR);
 		} catch (Exception e) {
 			classLogger.error("Error listing storage path details for path {}", path, e);
-			throw new IllegalArgumentException("Error listing storage details at path " + path);
+			throw new IllegalArgumentException("Error listing storage details at path " + path + ". Detailed message = " + e.getMessage());
 		}
 	}
 

--- a/src/prerna/reactor/storage/ListStoragePathReactor.java
+++ b/src/prerna/reactor/storage/ListStoragePathReactor.java
@@ -61,7 +61,7 @@ public class ListStoragePathReactor extends AbstractReactor {
 			return new NounMetadata(storageList, PixelDataType.CONST_STRING);
 		} catch (Exception e) {
 			classLogger.error(Constants.STACKTRACE, e);
-			throw new IllegalArgumentException("Error listing storage details at path " + path);
+			throw new IllegalArgumentException("Error listing storage details at path " + path + ". Detailed message = " + e.getMessage());
 		}
 	}
 

--- a/src/prerna/reactor/storage/PullFromStorageReactor.java
+++ b/src/prerna/reactor/storage/PullFromStorageReactor.java
@@ -69,7 +69,7 @@ public class PullFromStorageReactor extends AbstractReactor {
 			return new NounMetadata(true, PixelDataType.BOOLEAN);
 		} catch (Exception e) {
 			classLogger.error(Constants.STACKTRACE, e);
-			throw new IllegalArgumentException("Error occurred downloading storage file to local");
+			throw new IllegalArgumentException("Error occurred downloading storage file to local. Detailed message = " + e.getMessage());
 		}
 	}
 

--- a/src/prerna/reactor/storage/PushToStorageReactor.java
+++ b/src/prerna/reactor/storage/PushToStorageReactor.java
@@ -75,7 +75,7 @@ public class PushToStorageReactor extends AbstractReactor {
 			return new NounMetadata(true, PixelDataType.BOOLEAN);
 		} catch (Exception e) {
 			classLogger.error(Constants.STACKTRACE, e);
-			throw new IllegalArgumentException("Error occurred uploading local file to storage");
+			throw new IllegalArgumentException("Error occurred uploading local file to storage. Detailed message = " + e.getMessage());
 		}
 	}
 

--- a/src/prerna/reactor/storage/SyncLocalToStorageReactor.java
+++ b/src/prerna/reactor/storage/SyncLocalToStorageReactor.java
@@ -75,7 +75,7 @@ public class SyncLocalToStorageReactor extends AbstractReactor {
 			return new NounMetadata(true, PixelDataType.BOOLEAN);
 		} catch (Exception e) {
 			classLogger.error(Constants.STACKTRACE, e);
-			throw new IllegalArgumentException("Error occurred uploading local file to storage");
+			throw new IllegalArgumentException("Error occurred uploading local file to storage. Detailed message = " + e.getMessage());
 		}
 	}
 

--- a/src/prerna/reactor/storage/SyncStorageToLocalReactor.java
+++ b/src/prerna/reactor/storage/SyncStorageToLocalReactor.java
@@ -69,7 +69,7 @@ public class SyncStorageToLocalReactor extends AbstractReactor {
 			return new NounMetadata(true, PixelDataType.BOOLEAN);
 		} catch (Exception e) {
 			classLogger.error(Constants.STACKTRACE, e);
-			throw new IllegalArgumentException("Error occurred downloading storage file to local");
+			throw new IllegalArgumentException("Error occurred downloading storage file to local. Detailed message = " + e.getMessage());
 		}
 	}
 

--- a/src/prerna/reactor/storage/UpdateStorageFileMetadataReactor.java
+++ b/src/prerna/reactor/storage/UpdateStorageFileMetadataReactor.java
@@ -78,7 +78,7 @@ public class UpdateStorageFileMetadataReactor extends AbstractReactor {
         	return new NounMetadata(true, PixelDataType.BOOLEAN);
         } catch (Exception e) {
 			classLogger.error(Constants.STACKTRACE, e);
-			throw new IllegalArgumentException("Error occurred applying metadata");
+			throw new IllegalArgumentException("Error occurred applying metadata. Detailed message = " + e.getMessage());
         }
         
 	}

--- a/test/prerna/engine/impl/storage/AbstractRCloneStorageEngineUnitTests.java
+++ b/test/prerna/engine/impl/storage/AbstractRCloneStorageEngineUnitTests.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.engine.impl.storage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Covers the guarantees the rclone process runner makes to every storage engine
+ * built on it. Uses a shell rather than rclone itself so the exit code and the
+ * output volume are both fully controlled.
+ */
+@EnabledOnOs({ OS.LINUX, OS.MAC })
+public class AbstractRCloneStorageEngineUnitTests {
+
+	@Test
+	void testNonZeroExitFails() {
+		IOException e = assertThrows(IOException.class,
+				() -> AbstractRCloneStorageEngine.runAnyProcess("sh", "-c", "echo 'copy failed' >&2; exit 7"));
+		assertTrue(e.getMessage().contains("exit code 7"), e.getMessage());
+		assertTrue(e.getMessage().contains("copy failed"), e.getMessage());
+	}
+
+	@Test
+	void testToleratedExitCodeReturnsEmpty() throws Exception {
+		List<String> results = AbstractRCloneStorageEngine.runAnyProcess(Set.of(3, 4), "sh", "-c", "exit 3");
+		assertTrue(results.isEmpty());
+	}
+
+	@Test
+	void testToleratedExitCodeStillFailsOnOtherCodes() {
+		assertThrows(IOException.class,
+				() -> AbstractRCloneStorageEngine.runAnyProcess(Set.of(3, 4), "sh", "-c", "exit 5"));
+	}
+
+	/**
+	 * Both pipes together hold far more than the OS pipe buffer. Draining them only
+	 * after the process has been waited on deadlocks instead of returning.
+	 */
+	@Test
+	// a separate thread so a regression aborts the build instead of hanging it
+	@Timeout(value = 60, threadMode = Timeout.ThreadMode.SEPARATE_THREAD)
+	void testLargeOutputOnBothPipesDoesNotBlock() throws Exception {
+		List<String> results = AbstractRCloneStorageEngine.runAnyProcess("awk",
+				"BEGIN { line = sprintf(\"%400s\", \"x\"); for (i = 0; i < 1000; i++) { print line; print line > \"/dev/stderr\" } }");
+		assertEquals(1000, results.size());
+	}
+
+	/**
+	 * A config create carries the storage credentials in its arguments, so neither
+	 * the arguments nor the process error output may reach the caller.
+	 */
+	@Test
+	void testConfigFailureDoesNotLeakCredentials(@TempDir Path tempDir) throws Exception {
+		Path script = tempDir.resolve("fake-rclone.sh");
+		Files.writeString(script, "#!/bin/sh\necho \"secret_access_key = $7\" >&2\nexit 1\n");
+		assertTrue(script.toFile().setExecutable(true));
+
+		IOException e = assertThrows(IOException.class,
+				() -> AbstractRCloneStorageEngine.runAnyProcess(script.toString(), "config", "create", "myremote",
+						"s3", "access_key_id", "AKIAEXAMPLE", "secret_access_key", "s3cr3t-value"));
+		assertTrue(e.getMessage().contains("rclone config create"), e.getMessage());
+		assertFalse(e.getMessage().contains("s3cr3t-value"), e.getMessage());
+		assertFalse(e.getMessage().contains("AKIAEXAMPLE"), e.getMessage());
+	}
+
+	/**
+	 * Drives the real public API against a stub rclone whose copy fails, the way a
+	 * denied or unreachable transfer does. Guards the wiring, not just the runner:
+	 * transfers must go through the strict exit-code policy.
+	 */
+	@Test
+	void testCopyToStorageFailsWhenRcloneCopyFails(@TempDir Path tempDir) throws Exception {
+		Path stub = tempDir.resolve("rclone");
+		Files.writeString(stub, "#!/bin/sh\n"
+				+ "if [ \"$1\" = \"copy\" ]; then\n"
+				+ "  echo 'Failed to copy: AccessDenied: Access Denied' >&2\n"
+				+ "  exit 1\n"
+				+ "fi\n"
+				+ "exit 0\n");
+		assertTrue(stub.toFile().setExecutable(true));
+
+		Path localFile = tempDir.resolve("payload.txt");
+		Files.writeString(localFile, "hello");
+		Files.writeString(tempDir.resolve("myconf.conf"), "[myconf]\ntype = s3\n");
+
+		S3StorageEngine engine = new S3StorageEngine();
+		engine.RCLONE = stub.toString();
+		engine.setRCloneConfigFolder(tempDir.toString());
+
+		IOException e = assertThrows(IOException.class,
+				() -> engine.copyToStorage(localFile.toString(), "somefolder", "myconf", null));
+		assertTrue(e.getMessage().contains("rclone copy failed"), e.getMessage());
+	}
+
+}


### PR DESCRIPTION
## Description
Every rclone invocation in the storage engines ran through three process helpers in `AbstractRCloneStorageEngine` that called `p.waitFor()` and discarded the exit code. A failed transfer returned normally, so `PushToStorage` answered `true` after a copy that never happened. Listings against the same engine succeed, which makes the false success look like a working pipeline.

The same lines held a second defect: `waitFor()` ran before either pipe was drained, with stdout and stderr both on `Redirect.PIPE`. Once a child filled the OS pipe buffer (~64KB) it blocked on write and `waitFor()` never returned, leaking the calling thread. `lsjson --metadata` on a large container reaches this.

## Changes Made
- Capture the exit code on every rclone invocation and throw `IOException` on failure (`IOException` was already declared on every signature, so no caller changes).
- Policy: transfers and config create fail on any non-zero exit. `lsf`/`lsjson` and the deletes (`delete` and `purge`) tolerate 3 (directory not found) and 4 (file not found), where a missing path is an empty result / no-op rather than an error.
- Drain both pipes concurrently while the process runs (stderr on its own thread), then `waitFor()` - removes the pipe-buffer deadlock.
- Failure messages name only the rclone sub-command plus capped stderr, and drop stderr entirely for `config` commands - the config argv carries storage credentials and the message travels back to the caller.
- `deleteRcloneConfig` logs instead of throwing: every caller runs it from a `finally` block, so a cleanup failure was replacing the real transfer failure being unwound.
- All nine storage reactors (`PushToStorage`, `PullFromStorage`, both syncs, `DeleteFromStorage`, both lists, `GetStorageFileAsBase64`, `UpdateStorageFileMetadata`) append the exception message to their thrown error instead of a fixed string, matching the idiom used elsewhere. The metadata one also stops hiding the `UnsupportedOperationException` that every non-native engine throws.
- Unit tests for the runner (exit-code enforcement, tolerated codes, deadlock regression with a preemptive timeout, credential-redaction) plus an end-to-end test driving `S3StorageEngine.copyToStorage()` against a stub rclone whose copy fails.

## How to Test
1. `mvn test -Dtest=AbstractRCloneStorageEngineUnitTests` - all six pass; against the previous code the exit-code test fails ("Expected IOException... nothing was thrown") and the deadlock test times out.
2. Manual: point any rclone-backed storage engine at a bucket the credentials cannot write to and run `PushToStorage(...)`. Before: returns `true`, file absent. After: pixel errors with `rclone copy failed with exit code N - <reason>`.
3. Browse a storage path that does not exist (`ListStoragePath`) - still returns an empty list, unchanged.

## Notes
- Behavior change: operations that silently swallowed failures now throw. Flows built on `CentralCloudStorage` (engine push/pull, image push) will surface rclone failures instead of continuing with missing files - that is the intent, but reviewers should confirm no flow depends on the old silent behavior.
- rclone's contract (https://rclone.org/docs/#exit-code): non-zero only after its own retries are exhausted; 3/4 are the not-found codes tolerated on reads and deletes.
- Known limitation, unchanged from before: there is still no overall process timeout, so a network-stalled rclone blocks the caller. Separate concern if wanted.
- `streamJsonOutput`/`streamListJsonOutput`/`streamError` (protected statics orphaned by the rework) were removed, along with `runProcessJsonOutput` and the no-tolerance `runProcessListJsonOutput` overload, which had no callers even before this change; no references exist in this repo or Monolith.
