### PR TITLE
Moving selected engines from RunAgent flow to System Prompt

### DIFF
--- a/project/platform__agent-run/app_root/version/assets/public/SKILL.md
+++ b/project/platform__agent-run/app_root/version/assets/public/SKILL.md
@@ -57,7 +57,7 @@ runAgent(
     agentId?: string,       // the agent whose tools/config the run should use
     maxTurns?: number,      // cap on model round-trips before the run stops itself
     maxReflections?: number,
-    images?: string[],
+    media?: string[],       // file locations or base64 image/PDF data URIs; any file type the model accepts (image, pdf, document, spreadsheet, audio, video)
     urls?: string[],
   },
   insightId,

--- a/project/platform__database/app_root/version/assets/public/SKILL.md
+++ b/project/platform__database/app_root/version/assets/public/SKILL.md
@@ -139,7 +139,9 @@ For the full response schema, see `references/response-schema.md`.
 
 ## Listing available databases
 
-Before running a query, you often need to let the user pick a database — or find one programmatically. Use the `MyEngines` pixel with `engineTypes=["DATABASE"]` to list databases the current user has access to.
+This listing pattern is for app-runtime features where the app's end user picks a database. When *you* are deciding which database the app should use, do not enumerate accessible databases: use the project's selected database engine (see the Selected Engines section of your system prompt), and only ask the user to choose or attach one when none is selected.
+
+For the app-runtime case, use the `MyEngines` pixel with `engineTypes=["DATABASE"]` to list databases the current user has access to.
 
 ```typescript
 import { runPixel } from "@semoss/sdk";

--- a/project/platform__functions/app_root/version/assets/public/SKILL.md
+++ b/project/platform__functions/app_root/version/assets/public/SKILL.md
@@ -97,7 +97,7 @@ const { pixelReturn } = await runPixel(
 
 Same for `["GUARDRAIL"]`. `MyEngines` supports `filterWord`, `sort`, `limit`, `offset` as described in the database skill.
 
-Never hardcode or guess an engine ID. Use the project's selected engines (see the selected-engines skill); if none fits, ask the user to choose or attach one.
+Never hardcode or guess an engine ID. Use the project's selected engines (see the Selected Engines section of your system prompt); if none fits, ask the user to choose or attach one.
 
 ## Self-documenting fallback: GetEngineUsage
 

--- a/project/platform__model/app_root/version/assets/public/SKILL.md
+++ b/project/platform__model/app_root/version/assets/public/SKILL.md
@@ -145,7 +145,9 @@ For the full response schema, see `references/response-schema.md`.
 
 ## Listing available models
 
-Before calling a model, you often need to let the user pick one, or find one programmatically. Use the `MyEngines` pixel with `engineTypes=["MODEL"]` to list models the current user has access to.
+This listing pattern is for app-runtime features where the app's end user picks a model. When *you* are deciding which model the app should call, do not enumerate accessible models: use the project's selected model engine (see the Selected Engines section of your system prompt), and only ask the user to choose or attach one when none is selected.
+
+For the app-runtime case, use the `MyEngines` pixel with `engineTypes=["MODEL"]` to list models the current user has access to.
 
 ```typescript
 import { runPixel } from "@semoss/sdk";

--- a/project/platform__storage/app_root/version/assets/public/SKILL.md
+++ b/project/platform__storage/app_root/version/assets/public/SKILL.md
@@ -147,4 +147,4 @@ const storages = pixelReturn[0].output as Array<{
 
 `MyEngines` supports the same `filterWord`, `onlyFavorites`, `sort`, `limit`, and `offset` arguments described in the database skill.
 
-Never hardcode or guess a storage engine ID. Use the project's selected storage engine (see the selected-engines skill); if none is selected, ask the user to choose or attach one.
+Never hardcode or guess a storage engine ID. Use the project's selected storage engine (see the Selected Engines section of your system prompt); if none is selected, ask the user to choose or attach one.

--- a/project/platform__vector/app_root/version/assets/public/SKILL.md
+++ b/project/platform__vector/app_root/version/assets/public/SKILL.md
@@ -205,7 +205,9 @@ Keep the prompt explicit about citing `Source` and `Part`/`Divider` so the model
 
 ## Listing available vector engines
 
-Before querying, you often need to let the user pick a vector database — or find one programmatically. Use `MyEngines` with `engineTypes=["VECTOR"]`.
+This listing pattern is for app-runtime features where the app's end user picks a vector database. When *you* are deciding which vector engine the app should use, do not enumerate accessible engines: use the project's selected vector engine (see the Selected Engines section of your system prompt), and only ask the user to choose or attach one when none is selected.
+
+For the app-runtime case, use `MyEngines` with `engineTypes=["VECTOR"]`.
 
 ```typescript
 import { runPixel } from "@semoss/sdk";

--- a/src/prerna/reactor/agent/AppBuilderHarnessConfiguration.java
+++ b/src/prerna/reactor/agent/AppBuilderHarnessConfiguration.java
@@ -42,12 +42,14 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 
+import prerna.auth.utils.SecurityProjectUtils;
 import prerna.project.api.IProject;
 import prerna.util.EngineUtility;
 import prerna.util.Utility;
 
 /**
- * App-builder helpers for {@code .agents/AGENT_CONFIG.json} and app-local skills.
+ * App-builder helpers for {@code .agents/AGENT_CONFIG.json} and the
+ * "Selected Engines" system prompt block.
  *
  * <p>This is a static utility used by the SemossWeb app-builder flow, not a
  * runtime harness class.
@@ -59,12 +61,6 @@ public class AppBuilderHarnessConfiguration {
     // Path constants
     /** Subdirectory of a project's assets folder where the agent operates. */
     public static final String CLIENT_DIR = "client";
-    /** {@code .claude/} directory under {@link #CLIENT_DIR}. */
-    public static final String CLAUDE_DIR = ".claude";
-    /** {@code skills/} subdirectory under {@link #CLAUDE_DIR}. */
-    public static final String SKILLS_DIR = "skills";
-    /** Filename inside each skill folder. */
-    public static final String SKILL_FILE = "SKILL.md";
 
     // AGENT_CONFIG.json constants
     public static final String AGENTS_DIR        = ".agents";
@@ -78,13 +74,6 @@ public class AppBuilderHarnessConfiguration {
 
     public static final String ENGINE_NAME = "name";
     public static final String ENGINE_ID   = "id";
-
-    private static final String SELECTED_ENGINES_SKILL_NAME = "selected-engines";
-    private static final String SELECTED_ENGINES_SKILL_DESCRIPTION =
-            "Consult this skill when introducing a new engine call or adding a new LLM() invocation, "
-          + "a new database query against a not-yet-used engine, or a new vector store integration. "
-          + "Do not consult it for edits to existing engine calls (the engine ID is already in the code; preserve it). "
-          + "Do not consult it for unrelated work (UI, styling, non-engine logic).";
 
     private static final List<String> ENGINE_TYPES = Arrays.asList(
             MODEL_ENGINES, VECTOR_ENGINES, STORAGE_ENGINES, DATABASE_ENGINES);
@@ -146,51 +135,42 @@ public class AppBuilderHarnessConfiguration {
     }
 
     /**
-     * Regenerates {@code .claude/skills/selected-engines/SKILL.md} from the
-     * project's current dependency list. Call this from any reactor that
-     * mutates project dependencies so the agent-facing skill file always
-     * reflects the canonical store.
+     * Builds the "Selected Engines" system prompt block for a project. Reads
+     * the dependency list fresh from the canonical store
+     * ({@link prerna.auth.utils.SecurityProjectUtils#getProjectDependencyDetails})
+     * so workbench selections are always current at run time, regardless of
+     * which reactor last mutated them.
      *
-     * <p>{@code dependencyList} entries are expected to carry at minimum
-     * {@code engine_id}, {@code engine_type}, and {@code engine_name} keys
-     * (the shape returned by
-     * {@link prerna.auth.utils.SecurityProjectUtils#getProjectDependencyDetails}).
-     * Non-engine dependency types (e.g. {@code PROJECT}) are ignored.
+     * <p>Non-engine dependency types (e.g. {@code PROJECT}) are ignored.
      *
-     * <p>Failures are logged, never thrown — a skill-write failure must not
-     * break the dependency-write transaction the caller is wrapping.
+     * @return prompt block, or {@code null} when {@code projectId} is blank or
+     *         the dependency lookup fails (logged, never thrown)
      */
-    public static void regenerateSelectedEnginesSkillFromDependencies(
-            String projectId,
-            List<Map<String, Object>> dependencyList) {
-        int depCount = dependencyList == null ? 0 : dependencyList.size();
-        logger.debug("regenerateSelectedEnginesSkillFromDependencies invoked: project={} depCount={}",
-                projectId, depCount);
-
+    public static String buildSelectedEnginesPrompt(String projectId) {
         if (projectId == null || projectId.trim().isEmpty()) {
-            logger.debug("  skipping: blank projectId");
-            return;
+            return null;
         }
-
-        Path clientPath;
+        List<Map<String, Object>> dependencyList;
         try {
-            clientPath = Paths.get(resolveProjectClientPath(projectId));
-        } catch (RuntimeException e) {
-            logger.error("  failed to resolve client path for project: {}", projectId, e);
-            return;
+            dependencyList = SecurityProjectUtils.getProjectDependencyDetails(projectId);
+        } catch (Exception e) {
+            logger.warn("Failed to load dependency details for selected-engines prompt, project: {}",
+                    projectId, e);
+            return null;
         }
-        Path claudePath = clientPath.resolve(CLAUDE_DIR);
-        if (!Files.isDirectory(claudePath)) {
-            logger.debug("  skipping: no .claude/ at {}", claudePath);
-            return;
-        }
-        logger.debug("  proceeding: clientPath={} claude exists", clientPath);
+        return buildSelectedEnginesPromptBody(bucketEnginesByType(dependencyList));
+    }
 
+    /**
+     * Buckets dependency rows into engineTypeKey -> [{name,id},...] for the
+     * four prompt-visible engine types.
+     */
+    private static Map<String, List<Map<String, String>>> bucketEnginesByType(
+            List<Map<String, Object>> dependencyList) {
         Map<String, List<Map<String, String>>> enginesByType = new LinkedHashMap<>();
         for (String type : ENGINE_TYPES) {
             enginesByType.put(type, new ArrayList<>());
         }
-
         if (dependencyList != null) {
             for (Map<String, Object> dep : dependencyList) {
                 if (dep == null) continue;
@@ -208,8 +188,7 @@ public class AppBuilderHarnessConfiguration {
                 enginesByType.get(typeKey).add(entry);
             }
         }
-
-        writeSelectedEnginesSkill(clientPath, enginesByType);
+        return enginesByType;
     }
 
     // Internals
@@ -217,43 +196,24 @@ public class AppBuilderHarnessConfiguration {
         Files.write(configFile, root.toString(4).getBytes(StandardCharsets.UTF_8));
     }
 
-    /**
-     * Writes (or overwrites) {@code .claude/skills/selected-engines/SKILL.md}
-     * from a map of engineType -> [{name,id},...]. Errors are logged, not thrown.
-     */
-    private static void writeSelectedEnginesSkill(
-            Path clientPath,
-            Map<String, List<Map<String, String>>> enginesByType) {
-        Path skillDir = clientPath
-                .resolve(CLAUDE_DIR)
-                .resolve(SKILLS_DIR)
-                .resolve(SELECTED_ENGINES_SKILL_NAME);
-        Path skillFile = skillDir.resolve(SKILL_FILE);
-        try {
-            Files.createDirectories(skillDir);
-            String content = buildSelectedEnginesSkill(enginesByType);
-            Files.write(skillFile, content.getBytes(StandardCharsets.UTF_8));
-        } catch (IOException e) {
-            logger.error("Failed to write selected-engines skill at: {}", skillFile, e);
-        }
-    }
-
-    private static String buildSelectedEnginesSkill(
+    private static String buildSelectedEnginesPromptBody(
             Map<String, List<Map<String, String>>> enginesByType) {
         StringBuilder sb = new StringBuilder();
-        sb.append("---\n");
-        sb.append("name: ").append(SELECTED_ENGINES_SKILL_NAME).append('\n');
-        sb.append("description: '").append(SELECTED_ENGINES_SKILL_DESCRIPTION).append("'\n");
-        sb.append("---\n\n");
         sb.append("# Selected Engines\n\n");
-        sb.append("These are the engines currently selected for this project. ");
-        sb.append("When introducing a new engine call, choose one from the matching list ");
-        sb.append("and use its exact `id`.\n\n");
+        sb.append("The user pre-selected these engines for this project in the workbench ");
+        sb.append("Available Engines panel. When introducing a new engine call (LLM invocation, ");
+        sb.append("database query, vector store, storage), choose from the matching list below ");
+        sb.append("and use its exact `id`.\n");
+        sb.append("If exactly one engine is listed for the type you need, use it without asking. ");
+        sb.append("If several are listed, ask the user which of the listed engines to use. ");
+        sb.append("Only when the list for that type is empty should you ask the user to choose ");
+        sb.append("or attach an engine. Never use an unlisted engine merely because it is ");
+        sb.append("accessible to you.\n\n");
 
         for (String[] section : ENGINE_SECTIONS) {
             appendEngineSection(sb, section[1], enginesByType, section[0]);
         }
-        return sb.toString();
+        return sb.toString().trim();
     }
 
     private static void appendEngineSection(

--- a/src/prerna/reactor/agent/ClaudeCodeAgentHarness.java
+++ b/src/prerna/reactor/agent/ClaudeCodeAgentHarness.java
@@ -87,6 +87,12 @@ public class ClaudeCodeAgentHarness implements IAgentHarness {
         if (systemPrompt == null) {
             systemPrompt = "";
         }
+        String selectedEnginesPrompt = ctx.getAgentConfig().getSelectedEnginesPrompt();
+        if (selectedEnginesPrompt != null && !selectedEnginesPrompt.isEmpty()) {
+            systemPrompt = systemPrompt.isEmpty()
+                    ? selectedEnginesPrompt
+                    : systemPrompt + "\n\n" + selectedEnginesPrompt;
+        }
         User         user           = ctx.getInsight().getUser();
         if (user == null) {
             throw new IllegalArgumentException(NAME + ": insight has no user");

--- a/src/prerna/reactor/agent/GitHubCopilotPyAgentHarness.java
+++ b/src/prerna/reactor/agent/GitHubCopilotPyAgentHarness.java
@@ -84,6 +84,14 @@ public class GitHubCopilotPyAgentHarness implements IAgentHarness {
 		if (systemPrompt == null) {
 			systemPrompt = "";
 		}
+		// Selected-engines block resolved per run by AgentConfigLoader from the
+		// run's target project; keeps workbench engine selections prompt-visible.
+		String selectedEnginesPrompt = ctx.getAgentConfig().getSelectedEnginesPrompt();
+		if (selectedEnginesPrompt != null && !selectedEnginesPrompt.isEmpty()) {
+			systemPrompt = systemPrompt.isEmpty()
+					? selectedEnginesPrompt
+					: systemPrompt + "\n\n" + selectedEnginesPrompt;
+		}
 		User         user           = ctx.getInsight().getUser();
 		if (user == null) {
 			throw new IllegalArgumentException(NAME + ": insight has no user");

--- a/src/prerna/reactor/agent/config/AgentConfig.java
+++ b/src/prerna/reactor/agent/config/AgentConfig.java
@@ -57,6 +57,7 @@ public final class AgentConfig {
     private final String authoredPrompt;
     private final String agentAgentsMd;
     private final String workdirAgentsMd;
+    private final String selectedEnginesPrompt;
 
     // Model
     private final String modelId;
@@ -100,6 +101,7 @@ public final class AgentConfig {
         this.authoredPrompt  = b.authoredPrompt;
         this.agentAgentsMd   = b.agentAgentsMd;
         this.workdirAgentsMd = b.workdirAgentsMd;
+        this.selectedEnginesPrompt = b.selectedEnginesPrompt;
         this.modelId         = b.modelId;
         this.modelParams     = b.modelParams != null
                 ? Collections.unmodifiableMap(new HashMap<>(b.modelParams))
@@ -170,7 +172,18 @@ public final class AgentConfig {
     }
 
     /**
-     * Convenience: the three agent-side layers joined with blank-line separators.
+     * The "Selected Engines" block for the run's target project (the engines the
+     * user picked in the workbench Available Engines panel), resolved fresh from
+     * the project dependency store by
+     * {@link prerna.reactor.agent.config.AgentConfigLoader}. {@code null} when the
+     * run has no {@code project} param or resolution failed.
+     */
+    public String getSelectedEnginesPrompt() {
+        return selectedEnginesPrompt;
+    }
+
+    /**
+     * Convenience: the agent-side prompt layers joined with blank-line separators.
      * Returns an empty string (never {@code null}) when no layer is populated.
      */
     public String getComposedAgentPrompt() {
@@ -178,6 +191,7 @@ public final class AgentConfig {
         appendLayer(sb, agentAgentsMd);
         appendLayer(sb, workdirAgentsMd);
         appendLayer(sb, authoredPrompt);
+        appendLayer(sb, selectedEnginesPrompt);
         return sb.toString();
     }
 
@@ -302,6 +316,7 @@ public final class AgentConfig {
         private String authoredPrompt;
         private String agentAgentsMd;
         private String workdirAgentsMd;
+        private String selectedEnginesPrompt;
         private String modelId;
         private Map<String, Object> modelParams;
         private Map<String, Object> agentParams;
@@ -321,6 +336,7 @@ public final class AgentConfig {
         public Builder authoredPrompt(String v)      { this.authoredPrompt = v;      return this; }
         public Builder agentAgentsMd(String v)       { this.agentAgentsMd = v;       return this; }
         public Builder workdirAgentsMd(String v)     { this.workdirAgentsMd = v;     return this; }
+        public Builder selectedEnginesPrompt(String v) { this.selectedEnginesPrompt = v; return this; }
         public Builder modelId(String v)             { this.modelId = v;             return this; }
         public Builder modelParams(Map<String, Object> v) { this.modelParams = v;    return this; }
         public Builder agentParams(Map<String, Object> v) { this.agentParams = v;    return this; }

--- a/src/prerna/reactor/agent/config/AgentConfigLoader.java
+++ b/src/prerna/reactor/agent/config/AgentConfigLoader.java
@@ -52,6 +52,8 @@ import prerna.auth.utils.SecurityProjectUtils;
 import prerna.engine.impl.model.Room;
 import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
 import prerna.engine.impl.model.inferencetracking.reactors.workspaces.AbstractWorkspaceReactor;
+import prerna.reactor.agent.AgentRunner;
+import prerna.reactor.agent.AppBuilderHarnessConfiguration;
 import prerna.reactor.agent.IAgentHook;
 import prerna.reactor.agent.IAgentRunHook;
 import prerna.reactor.agent.IToolHook;
@@ -152,6 +154,10 @@ public final class AgentConfigLoader {
         // tolerates null workingDir.
         b.workdirAgentsMd(AgentsMdLoader.discover(workingDir));
 
+        // Selected-engines block: read fresh from the project dependency store
+        // every run so workbench selections are always current and prompt-visible.
+        b.selectedEnginesPrompt(resolveSelectedEnginesPrompt(paramMap));
+
         // 5. Model
         b.modelId(StringUtils.trimToNull(modelId));
         b.modelParams(paramMap);
@@ -181,11 +187,12 @@ public final class AgentConfigLoader {
 
         AgentConfig cfg = b.build();
         logger.info(
-                "AgentConfigLoader: resolved room={} workspaceId={} name={} modelId={} workingDir={} mcps={} skills={} runHooks={} toolHooks={} subagents={} budgets(turns={},refl={},secs={}) authoredChars={} workdirAgentsMdChars={} cfgJson={}",
+                "AgentConfigLoader: resolved room={} workspaceId={} name={} modelId={} workingDir={} mcps={} skills={} runHooks={} toolHooks={} subagents={} budgets(turns={},refl={},secs={}) authoredChars={} workdirAgentsMdChars={} selectedEnginesChars={} cfgJson={}",
                 room.getId(), cfg.getWorkspaceId(), cfg.getName(), cfg.getModelId(), cfg.getWorkingDir(),
                 cfg.getMcps().size(), cfg.getSkills().size(), cfg.getRunHooks().size(), cfg.getToolHooks().size(), cfg.getSubagents().size(),
                 cfg.getBudgets().getMaxTurns(), cfg.getBudgets().getMaxReflections(), cfg.getBudgets().getMaxSeconds(),
                 lengthOrZero(cfg.getAuthoredPrompt()), lengthOrZero(cfg.getWorkdirAgentsMd()),
+                lengthOrZero(cfg.getSelectedEnginesPrompt()),
                 cfgJson == null ? "absent" : "present");
         return cfg;
     }
@@ -448,6 +455,33 @@ public final class AgentConfigLoader {
         }
         // (c) legacy column fallback
         return StringUtils.trimToNull((String) workspaceRow.get("system_prompt"));
+    }
+
+    /**
+     * Resolves the "Selected Engines" prompt block for the run's target project
+     * ({@code paramMap["project"]}, kept in the paramMap by
+     * {@link prerna.reactor.agent.AgentRunner}). {@code null} when the run has no
+     * project param or resolution fails - the block must never break run setup.
+     */
+    private static String resolveSelectedEnginesPrompt(Map<String, Object> paramMap) {
+        if (paramMap == null) {
+            return null;
+        }
+        Object projectObj = paramMap.get(AgentRunner.PARAM_PROJECT);
+        if (projectObj == null) {
+            return null;
+        }
+        String projectId = StringUtils.trimToNull(String.valueOf(projectObj));
+        if (projectId == null) {
+            return null;
+        }
+        try {
+            return AppBuilderHarnessConfiguration.buildSelectedEnginesPrompt(projectId);
+        } catch (Exception e) {
+            logger.warn("AgentConfigLoader: selected-engines prompt resolution failed for project={}: {}",
+                    projectId, e.getMessage());
+            return null;
+        }
     }
 
     /** Parse {@code room.options.instructions} as a non-blank string, or {@code null}. */

--- a/src/prerna/reactor/security/SetProjectDependenciesReactor.java
+++ b/src/prerna/reactor/security/SetProjectDependenciesReactor.java
@@ -39,7 +39,6 @@ import prerna.auth.User;
 import prerna.auth.utils.SecurityEngineUtils;
 import prerna.auth.utils.SecurityProjectUtils;
 import prerna.engine.api.IEngine;
-import prerna.reactor.agent.AppBuilderHarnessConfiguration;
 import prerna.sablecc2.om.GenRowStruct;
 import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.ReactorKeysEnum;
@@ -94,18 +93,6 @@ public class SetProjectDependenciesReactor extends AbstractSetMetadataReactor {
 		}
 
 		SecurityProjectUtils.updateProjectDependencies(user, projectId, dependencyList);
-
-		// Regenerate the agent-facing selected-engines skill so Claude sees the
-		// updated engine connections. Reads back the full dependency details
-		// (with engine names) - required by the skill writer. Failures are
-		// logged inside the helper; we don't let them surface as user-visible
-		// errors because the dependency write itself already succeeded.
-		try {
-			List<Map<String, Object>> details = SecurityProjectUtils.getProjectDependencyDetails(projectId);
-			AppBuilderHarnessConfiguration.regenerateSelectedEnginesSkillFromDependencies(projectId, details);
-		} catch (Exception e) {
-			classLogger.error("Failed to regenerate selected-engines skill for project: {}", projectId, e);
-		}
 
 		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN);
 		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Successfully set the new dependencies"));

--- a/src/prerna/util/SystemAgentSeeder.java
+++ b/src/prerna/util/SystemAgentSeeder.java
@@ -334,7 +334,7 @@ public class SystemAgentSeeder {
 			State any non-material assumption that affects the result in a short progress update or final summary.
 
 			Engines and durable data:
-			Before introducing any new MODEL / DATABASE / VECTOR / STORAGE call, load the selected-engines skill. Never hardcode or guess engine IDs.
+			Your system prompt contains a "Selected Engines" section listing the engines the user selected for this project. Before introducing any new MODEL / DATABASE / VECTOR / STORAGE call, pick the engine from that section. Never hardcode or guess engine IDs.
 			Use an engine without asking only when the user explicitly supplied its exact ID or exactly one compatible engine of that type is already selected for the project.
 			If multiple compatible engines are selected, ask which one to use. If none is selected, ask the user to choose or attach one. Do not choose an engine merely because it is accessible, appears first in a list, exists in another project, or appears in sample code.
 			The model running this agent is not automatically the model that should power the app. Never copy the harness model ID into app code unless the user explicitly selected that same model for the app.


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

In the app building mode of RunAgent, we previously took the users selected engines and wrote them to a skill file. This relied on the agent reading the skill file. This now writes the selected engines to the system prompt which ensure the context is supplied to the agent. 

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->