### PR TITLE
RunAgent dispatches provider-executed builtin tools (web_search) as local MCP tools

### DIFF
--- a/src/prerna/engine/impl/model/Room.java
+++ b/src/prerna/engine/impl/model/Room.java
@@ -766,6 +766,9 @@ public class Room implements Serializable {
 	private boolean allToolCallsAnswered(ResponseMessage toolResponse, int toolResponseIdx, String newToolCallId) {
 		Set<String> allIds = new HashSet<>();
 		for (Map<String, Object> tc : toolResponse.getToolResponses()) {
+			if (MessageUtils.isServerToolCall(tc)) {
+				continue;
+			}
 			allIds.add(String.valueOf(tc.get("id")));
 		}
 		if (allIds.isEmpty()) {

--- a/src/prerna/engine/impl/model/message/MessageUtils.java
+++ b/src/prerna/engine/impl/model/message/MessageUtils.java
@@ -929,6 +929,32 @@ public class MessageUtils {
 	}
 
 	/**
+	 * Returns {@code true} when the tool call map represents a provider-executed
+	 * built-in tool (e.g. OpenAI {@code web_search_call} items or Anthropic
+	 * {@code server_tool_use} blocks). The python model clients flag these with
+	 * {@code server_tool: true} on the tool_call entry; the provider has already
+	 * run the tool and its output travels as a sibling TOOL_RESULT part, so the
+	 * platform must never dispatch these locally nor wait on a tool result for
+	 * their call ids.
+	 *
+	 * @param toolCall raw tool call map from a {@link ToolCallMessagePart}
+	 * @return whether the call was executed server-side by the model provider
+	 */
+	public static boolean isServerToolCall(Map<String, Object> toolCall) {
+		if (toolCall == null) {
+			return false;
+		}
+		Object flag = toolCall.get("server_tool");
+		if (flag == null) {
+			flag = toolCall.get("serverTool");
+		}
+		if (flag instanceof Boolean) {
+			return (Boolean) flag;
+		}
+		return flag != null && Boolean.parseBoolean(flag.toString());
+	}
+
+	/**
 	 * Converts OpenAI-style tool definitions to MCP-compatible tool definitions.
 	 * Built-in non-function tools are passed through unchanged.
 	 *

--- a/src/prerna/reactor/agent/runtime/HarnessToolExecutor.java
+++ b/src/prerna/reactor/agent/runtime/HarnessToolExecutor.java
@@ -52,6 +52,7 @@ import com.google.gson.Gson;
 import prerna.auth.User;
 import prerna.engine.api.ToolExecutionResult;
 import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.message.MessageUtils;
 import prerna.engine.impl.model.message.ResponseMessage;
 import prerna.engine.impl.model.responses.AskModelEngineResponse;
 import prerna.om.ThreadStore;
@@ -89,7 +90,7 @@ final class HarnessToolExecutor {
 	private static final String TOOL_STATUS_ERROR = "error";
 
 	private static final Gson GSON = new Gson();
-	private static final int MAX_LIVE_TOOL_RESULT_CHARS = 12_000;
+	static final int MAX_LIVE_TOOL_RESULT_CHARS = 12_000;
 
 	/** How often the parallel-batch wait polls for cancellation. */
 	private static final long CANCEL_POLL_MS = 100L;
@@ -109,7 +110,21 @@ final class HarnessToolExecutor {
 
 		Room room = ctx.getRoom();
 		String parentMsgId = toolResponse.getMessageId();
-		List<Map<String, Object>> toolCalls = toolResponse.getToolResponses();
+		List<Map<String, Object>> allToolCalls = toolResponse.getToolResponses();
+		List<Map<String, Object>> toolCalls = new ArrayList<>();
+		for (Map<String, Object> toolCall : allToolCalls) {
+			if (MessageUtils.isServerToolCall(toolCall)) {
+				continue;
+			}
+			toolCalls.add(toolCall);
+		}
+		if (toolCalls.size() < allToolCalls.size()) {
+			logger.info("HarnessToolExecutor: skipping {} provider-executed server tool call(s) iter={} room={}",
+					allToolCalls.size() - toolCalls.size(), state.getIterations(), room.getId());
+		}
+		if (toolCalls.isEmpty()) {
+			return toolResponse;
+		}
 		String jobId = ThreadStore.getJobId();
 		AskModelEngineResponse<?> nextModelResp = null;
 

--- a/src/prerna/reactor/agent/runtime/SemossAgentHarness.java
+++ b/src/prerna/reactor/agent/runtime/SemossAgentHarness.java
@@ -41,8 +41,11 @@ import prerna.engine.impl.model.Room;
 import prerna.engine.impl.model.RoomMessageStore;
 import prerna.engine.impl.model.message.AbstractMessage;
 import prerna.engine.impl.model.message.InputMessage;
+import prerna.engine.impl.model.message.MessagePart;
 import prerna.engine.impl.model.message.MessageUtils;
 import prerna.engine.impl.model.message.ResponseMessage;
+import prerna.engine.impl.model.message.ToolResultMessagePart;
+import prerna.engine.impl.model.message.ToolResultPart;
 import prerna.om.Insight;
 import prerna.om.ThreadStore;
 import prerna.reactor.agent.AgentHarnessResult;
@@ -567,6 +570,7 @@ public class SemossAgentHarness implements IAgentHarness {
 		streams.completeActiveReasoning(runId);
 		streams.completeActiveMessage(runId, response != null ? response.getMessageId() : null,
 				response != null ? response.getContent() : null);
+		publishServerToolItems(runId, response);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -580,6 +584,9 @@ public class SemossAgentHarness implements IAgentHarness {
 			return;
 		}
 		for (Map<String, Object> toolCall : toolCalls) {
+			if (MessageUtils.isServerToolCall(toolCall)) {
+				continue;
+			}
 			HarnessToolExecutor.ParsedToolCall tc = new HarnessToolExecutor.ParsedToolCall(toolCall);
 			Object metaObj = toolCall.get("_meta");
 			Map<String, Object> meta = metaObj instanceof Map ? (Map<String, Object>) metaObj : null;
@@ -587,6 +594,42 @@ public class SemossAgentHarness implements IAgentHarness {
 			AgentRunStreamService.get().publishToolStarted(runId,
 					AgentStreamItems.toolItem(tc.toolCallId, tc.rawToolName, title != null ? title.toString() : null,
 							tc.toolParams, meta, AgentStreamItems.TOOL_QUEUED));
+		}
+	}
+
+	/**
+	 * Publishes provider-executed built-in tool calls (web_search, etc.) as
+	 * already-completed run items so the workbench shows the activity and its
+	 * output. Their results are embedded in the assistant response as
+	 * server-flagged TOOL_RESULT parts - the harness never executes them.
+	 */
+	private static void publishServerToolItems(String runId, ResponseMessage response) {
+		if (runId == null || runId.trim().isEmpty() || response == null || !response.hasToolResponses()) {
+			return;
+		}
+		Map<String, String> serverOutputsByCallId = new HashMap<>();
+		for (MessagePart part : response.getParts()) {
+			if (part instanceof ToolResultMessagePart) {
+				ToolResultPart toolResult = ((ToolResultMessagePart) part).getToolResult();
+				if (toolResult != null && Boolean.TRUE.equals(toolResult.getServerTool())
+						&& toolResult.getToolCallId() != null) {
+					serverOutputsByCallId.put(toolResult.getToolCallId(), toolResult.getOutput());
+				}
+			}
+		}
+		for (Map<String, Object> toolCall : response.getToolResponses()) {
+			if (!MessageUtils.isServerToolCall(toolCall)) {
+				continue;
+			}
+			HarnessToolExecutor.ParsedToolCall tc = new HarnessToolExecutor.ParsedToolCall(toolCall);
+			Map<String, Object> item = AgentStreamItems.toolItem(tc.toolCallId, tc.rawToolName, null, tc.toolParams,
+					null, AgentStreamItems.TOOL_COMPLETED);
+			String output = AgentStreamItems.truncate(serverOutputsByCallId.get(tc.toolCallId),
+					HarnessToolExecutor.MAX_LIVE_TOOL_RESULT_CHARS);
+			if (output != null && !output.isBlank()) {
+				item.put("output", output);
+			}
+			AgentRunStreamService.get().publishToolCompleted(runId, item);
 		}
 	}
 
@@ -655,8 +698,23 @@ public class SemossAgentHarness implements IAgentHarness {
 		return RUN_ROLE_ASSISTANT;
 	}
 
+	/**
+	 * True when the response contains at least one tool call the harness must
+	 * execute. Provider-executed built-in tools (flagged {@code server_tool}) are
+	 * excluded - the provider already ran them mid-turn and their results are
+	 * embedded in the response, so a response containing only server tool calls
+	 * is a normal assistant text turn.
+	 */
 	private static boolean hasAssistantToolCalls(ResponseMessage message) {
-		return message != null && message.hasToolResponses();
+		if (message == null || !message.hasToolResponses()) {
+			return false;
+		}
+		for (Map<String, Object> toolCall : message.getToolResponses()) {
+			if (!MessageUtils.isServerToolCall(toolCall)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private static void persistAgentRunTags(Room room, AgentRunContext ctx) {


### PR DESCRIPTION
### Symptom

With a model that has builtin tools enabled via MODELMETADATA (e.g. `web_search`), the RunAgent/workbench flow shows the search executing and returning results, but the tool item is painted as **FAILED** with:

```
Tool execution error: cannot resolve engine/project id from tool name 'web_search'
```

Simple flows (LLM reactor) were unaffected because they don't run the tool-execution loop.

### Root cause

Builtin tools are **provider-executed**: OpenAI Responses returns `web_search_call` items and Anthropic returns `server_tool_use` blocks after running the tool server-side, mid-turn. The Python model clients already handle this correctly — they emit a `TOOL_CALL` part flagged `"server_tool": true` **plus** a paired `TOOL_RESULT` part carrying the provider's output, embedded in the assistant response.

The Java agent harness ignored that flag and treated every `TOOL_CALL` part as something it must execute:

1. `SemossAgentHarness` saw the tool-call part and entered the tool-execution branch.
2. `HarnessToolExecutor` dispatched `web_search` down the MCP path — no `a<engineId>_` prefix, no `_meta`, so engine resolution failed and the error above was published to the UI.
3. The failure was then written back to the room as a tool result for a call id the provider had **already answered**, so the replayed history carried a duplicate/bogus output for that id on every follow-up model call.

### Changes

- **`MessageUtils`** — new `isServerToolCall(Map)` predicate keyed on the `server_tool` / `serverTool` flag. Deliberately not name-based: a client MCP tool legitimately named `web_search` still executes normally.
- **`HarnessToolExecutor.executeToolBatch`** — filters server-executed calls out of the batch before dispatch (logged). A batch that becomes empty is returned as a normal assistant turn.
- **`SemossAgentHarness`**
  - `hasAssistantToolCalls` now counts only client-executable calls, so a response whose only tool activity is server-side no longer enters the tool loop.
  - `publishToolItemsQueued` skips server tools (no more QUEUED item that never runs).
  - New `publishServerToolItems` (invoked from `completeActiveItems`, i.e. for every new assistant response) publishes server tool calls as **COMPLETED** run items with the provider output pulled from the sibling server-flagged `ToolResultPart` — the workbench still shows the Web Search card, now with results instead of an error.
- **`Room.allToolCallsAnswered`** — excludes server-tool ids when deciding whether a tool batch is complete. Without this, a mixed batch (server `web_search` + a real client/MCP tool in one response) would wait forever on an id that no tool-result carrier will ever answer. This also covers HITL ask-tool resumes via `continueAfterToolExecutionResults`.

No Python/FE changes needed: both provider clients already flag server tools consistently, the message builders already replay the embedded `TOOL_CALL`/`TOOL_RESULT` parts correctly on subsequent asks, and `COMPLETED` is an existing stream item status.

### Behavior after

- Server-executed builtin tools are never dispatched locally and never written back as tool results.
- Workbench shows them as completed tool items with the provider's output attached.
- Mixed server + client tool batches continue as soon as the client tools finish.
- Applies to both OpenAI (`web_search_call`) and Anthropic (`server_tool_use`) shapes.
