### PR TITLE
fix: dialect-aware boolean literal for IS_TEMPLATE backfill (SQL Server startup)

### DIFF
--- a/src/prerna/auth/utils/AbstractSecurityUtils.java
+++ b/src/prerna/auth/utils/AbstractSecurityUtils.java
@@ -669,6 +669,15 @@ public abstract class AbstractSecurityUtils {
 		throw new IllegalArgumentException("Admin only configuration must be defined for catalog type = " + type);
 	}
 
+	/**
+	 * Databases without a native boolean type (e.g. SQL Server BIT) reject the
+	 * FALSE keyword literal, so pick the literal based on the dialect
+	 */
+	static String getIsTemplateFalseBackfillSql(AbstractSqlQueryUtil queryUtil) {
+		String falseLiteral = queryUtil.allowBooleanDataType() ? "FALSE" : "0";
+		return "UPDATE PROJECT SET IS_TEMPLATE = " + falseLiteral + " WHERE IS_TEMPLATE IS NULL";
+	}
+
 	public static void initialize() throws Exception {
 		IRDBMSEngine securityDb = SystemEngineRegistry.getSecurityDb();
 		String database = securityDb.getDatabase();
@@ -1103,7 +1112,7 @@ public abstract class AbstractSecurityUtils {
 				// backfill display name from canonical name for existing rows
 				securityDb.insertData(
 						"UPDATE PROJECT SET PROJECTDISPLAYNAME = PROJECTNAME WHERE PROJECTDISPLAYNAME IS NULL OR PROJECTDISPLAYNAME = ''");
-				securityDb.insertData("UPDATE PROJECT SET IS_TEMPLATE = FALSE WHERE IS_TEMPLATE IS NULL");
+				securityDb.insertData(getIsTemplateFalseBackfillSql(queryUtil));
 			}
 			if (allowIfExistsIndexs) {
 				String sql = queryUtil.createIndexIfNotExists("PROJECT_GLOBAL_INDEX", "PROJECT", "GLOBAL");

--- a/test/prerna/auth/utils/AbstractSecurityUtilsSqlDialectUnitTests.java
+++ b/test/prerna/auth/utils/AbstractSecurityUtilsSqlDialectUnitTests.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.auth.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import prerna.SemossUnitTest;
+import prerna.util.sql.RdbmsTypeEnum;
+import prerna.util.sql.SqlQueryUtilFactory;
+
+public class AbstractSecurityUtilsSqlDialectUnitTests extends SemossUnitTest {
+
+	@Test
+	void isTemplateBackfillUsesBitLiteralOnSqlServer() {
+		assertEquals("UPDATE PROJECT SET IS_TEMPLATE = 0 WHERE IS_TEMPLATE IS NULL",
+				AbstractSecurityUtils.getIsTemplateFalseBackfillSql(
+						SqlQueryUtilFactory.initialize(RdbmsTypeEnum.SQL_SERVER)));
+	}
+
+	@Test
+	void isTemplateBackfillUsesBooleanLiteralOnNativeBooleanDatabases() {
+		assertEquals("UPDATE PROJECT SET IS_TEMPLATE = FALSE WHERE IS_TEMPLATE IS NULL",
+				AbstractSecurityUtils.getIsTemplateFalseBackfillSql(
+						SqlQueryUtilFactory.initialize(RdbmsTypeEnum.H2_DB)));
+	}
+}


### PR DESCRIPTION
## Description
Startup fails when the Security database runs on Microsoft SQL Server. The security db migration in `AbstractSecurityUtils.initialize()` runs `UPDATE PROJECT SET IS_TEMPLATE = FALSE WHERE IS_TEMPLATE IS NULL`, but `IS_TEMPLATE` is created as `BIT` on SQL Server (via `getBooleanDataTypeName()`), and SQL Server rejects the `FALSE` keyword literal. `BIT` requires `0`/`1`.

Fixes #2935

## Changes Made
- Build the `IS_TEMPLATE` backfill statement with a dialect-aware literal: `queryUtil.allowBooleanDataType() ? "FALSE" : "0"`. `MicrosoftSqlServerQueryUtil` already reports `false` here, so SQL Server (and Synapse) get `0` while native-boolean databases keep `FALSE`.
- Extracted the statement into a small package-private helper, `AbstractSecurityUtils.getIsTemplateFalseBackfillSql(queryUtil)`, so it is testable without booting a security database.
- Added `AbstractSecurityUtilsSqlDialectUnitTests` with two regression tests: SQL Server produces `IS_TEMPLATE = 0`, H2 (native boolean) produces `IS_TEMPLATE = FALSE`.

## How to Test
1. `mvn surefire:test -Dtest=AbstractSecurityUtilsSqlDialectUnitTests` — both tests pass.
2. Configure the Security database for SQL Server (`CUSTOM_SECURITY_RDBMS_TYPE=sql_server`, `CUSTOM_SECURITY_DRIVER=com.microsoft.sqlserver.jdbc.SQLServerDriver`) and start SEMOSS. Initialization completes past the PROJECT migration instead of failing on the `IS_TEMPLATE` update.
3. Expected: no behavior change on H2/Postgres and other native-boolean databases; the executed SQL is identical to before.

## Notes
Behavior is unchanged for every dialect where `allowBooleanDataType()` is true; only non-native-boolean dialects switch to the numeric literal.
