### PR TITLE
Catalog-driven model import: `ListStaticModelCatalog` pixel + serving-host pricing for Vertex/Bedrock/Azure

### DIFF
--- a/meta/model.json
+++ b/meta/model.json
@@ -139,9 +139,9 @@
       },
       "kilo": {
         "tencent/hy3": {
-          "input": 0.14,
-          "output": 0.58,
-          "cache_read": 0.035
+          "input": 0.132,
+          "output": 0.528,
+          "cache_read": 0.033
         }
       },
       "nano-gpt": {
@@ -153,16 +153,16 @@
       },
       "openrouter": {
         "tencent/hy3": {
-          "input": 0.132,
-          "output": 0.528,
-          "cache_read": 0.033
+          "input": 0.0825,
+          "output": 0.33,
+          "cache_read": 0.020625
         }
       },
       "vercel": {
         "tencent/hy3": {
-          "input": 0.14,
-          "output": 0.58,
-          "cache_read": 0.035
+          "input": 0.132,
+          "output": 0.528,
+          "cache_read": 0.033
         }
       }
     },
@@ -267,7 +267,7 @@
         "nvidia/nemotron-3-nano-30b-a3b": {
           "input": 0.05,
           "output": 0.2,
-          "cache_read": 0.03
+          "cache_read": 0.025
         }
       },
       "nano-gpt": {
@@ -802,6 +802,13 @@
           "input": 0.08,
           "output": 0.2,
           "cache_read": 0.04
+        }
+      },
+      "vercel": {
+        "nvidia/nemotron-3.5-lightning": {
+          "input": 0.05,
+          "output": 0.15,
+          "cache_read": 0.05
         }
       }
     },
@@ -1732,11 +1739,18 @@
           "cache_read": 0.028
         }
       },
-      "merge-gateway": {
+      "llmgateway-providers": {
         "deepseek/deepseek-v4-flash": {
           "input": 0.14,
           "output": 0.28,
           "cache_read": 0.0028
+        }
+      },
+      "merge-gateway": {
+        "deepseek/deepseek-v4-flash": {
+          "input": 0.22,
+          "output": 0.66,
+          "cache_read": 0.007
         }
       },
       "nano-gpt": {
@@ -1762,9 +1776,9 @@
       },
       "openrouter": {
         "deepseek/deepseek-v4-flash": {
-          "input": 0.0826,
-          "output": 0.1652,
-          "cache_read": 0.01652
+          "input": 0.07798,
+          "output": 0.15596,
+          "cache_read": 0.015596
         }
       },
       "orcarouter": {
@@ -1847,7 +1861,7 @@
     "structured_output": true,
     "temperature": true,
     "release_date": "2026-08-12",
-    "last_updated": "2026-08-12",
+    "last_updated": "2026-08-22",
     "modalities": {
       "input": [
         "text"
@@ -1856,11 +1870,18 @@
         "text"
       ]
     },
-    "open_weights": false,
+    "open_weights": true,
     "limit": {
       "context": 1000000,
       "output": 384000
     },
+    "license": "MIT",
+    "weights": [
+      {
+        "label": "Hugging Face",
+        "url": "https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro-0813"
+      }
+    ],
     "provider": "deepseek",
     "pricing": {
       "arcee": {
@@ -1879,9 +1900,9 @@
       },
       "merge-gateway": {
         "deepseek/deepseek-v4-pro-0813": {
-          "input": 0.435,
-          "output": 0.87,
-          "cache_read": 0.003625
+          "input": 0.66,
+          "output": 1.98,
+          "cache_read": 0.022
         }
       },
       "nano-gpt": {
@@ -1900,16 +1921,16 @@
       },
       "openrouter": {
         "deepseek/deepseek-v4-pro-0813": {
-          "input": 0.66,
-          "output": 1.98,
-          "cache_read": 0.022
+          "input": 1.122,
+          "output": 3.366,
+          "cache_read": 0.0374
         }
       },
       "vercel": {
         "deepseek/deepseek-v4-pro-0813": {
-          "input": 1.32,
-          "output": 3.96,
-          "cache_read": 0.132
+          "input": 0.66,
+          "output": 1.98,
+          "cache_read": 0.066
         }
       }
     },
@@ -2101,6 +2122,13 @@
           "cache_read": 0.2
         }
       },
+      "cloudflare-ai-gateway": {
+        "deepseek/deepseek-v4-pro": {
+          "input": 1.74,
+          "output": 3.48,
+          "cache_read": 0.145
+        }
+      },
       "crossmodel": {
         "deepseek/deepseek-v4-pro": {
           "input": 1.215,
@@ -2151,11 +2179,18 @@
           "cache_read": 0.135
         }
       },
-      "merge-gateway": {
+      "llmgateway-providers": {
         "deepseek/deepseek-v4-pro": {
           "input": 0.435,
           "output": 0.87,
           "cache_read": 0.003625
+        }
+      },
+      "merge-gateway": {
+        "deepseek/deepseek-v4-pro": {
+          "input": 0.66,
+          "output": 1.98,
+          "cache_read": 0.022
         }
       },
       "nano-gpt": {
@@ -2181,9 +2216,9 @@
       },
       "openrouter": {
         "deepseek/deepseek-v4-pro": {
-          "input": 0.66,
-          "output": 1.98,
-          "cache_read": 0.022
+          "input": 0.87,
+          "output": 1.74,
+          "cache_read": 0.0725
         }
       },
       "orcarouter": {
@@ -2374,9 +2409,9 @@
       },
       "openrouter": {
         "deepseek/deepseek-v3.2": {
-          "input": 0.269,
-          "output": 0.4,
-          "cache_read": 0.1345
+          "input": 0.26,
+          "output": 0.38,
+          "cache_read": 0.13
         }
       },
       "tensorx": {
@@ -2476,13 +2511,6 @@
     ],
     "provider": "deepseek",
     "pricing": {
-      "deepseek": {
-        "deepseek-chat": {
-          "input": 0.14,
-          "output": 0.28,
-          "cache_read": 0.0028
-        }
-      },
       "edenai": {
         "deepseek/deepseek-chat": {
           "input": 0.28,
@@ -2582,21 +2610,6 @@
     ],
     "provider": "deepseek",
     "pricing": {
-      "deepseek": {
-        "deepseek-reasoner": {
-          "input": 0.14,
-          "output": 0.28,
-          "reasoning": 0.28,
-          "cache_read": 0.0028
-        }
-      },
-      "edenai": {
-        "deepseek/deepseek-reasoner": {
-          "input": 0.28,
-          "output": 0.42,
-          "cache_read": 0.028
-        }
-      },
       "orcarouter": {
         "deepseek/deepseek-reasoner": {
           "input": 0.435,
@@ -2758,24 +2771,24 @@
     "pricing": {
       "ambient": {
         "deepseek/deepseek-v4-flash-0731": {
-          "input": 0.14,
-          "output": 0.28,
-          "cache_read": 0.028,
+          "input": 0.08,
+          "output": 0.18,
+          "cache_read": 0.016,
           "cache_write": 0
         }
       },
       "kilo": {
         "deepseek/deepseek-v4-flash-0731": {
-          "input": 0.14,
-          "output": 0.28,
+          "input": 0.44,
+          "output": 1.32,
           "cache_read": 0.028
         }
       },
       "merge-gateway": {
         "deepseek/deepseek-v4-flash-0731": {
-          "input": 0.14,
-          "output": 0.28,
-          "cache_read": 0.0028
+          "input": 0.22,
+          "output": 0.66,
+          "cache_read": 0.007
         }
       },
       "nano-gpt": {
@@ -2785,11 +2798,18 @@
           "cache_read": 0.014
         }
       },
+      "ofox": {
+        "deepseek/deepseek-v4-flash-0731": {
+          "input": 0.44,
+          "output": 1.32,
+          "cache_read": 0.014
+        }
+      },
       "openrouter": {
         "deepseek/deepseek-v4-flash-0731": {
-          "input": 0.14,
-          "output": 0.28,
-          "cache_read": 0.028
+          "input": 0.06,
+          "output": 0.12,
+          "cache_read": 0.012
         }
       },
       "perplexity-agent": {
@@ -2808,9 +2828,9 @@
       },
       "vercel": {
         "deepseek/deepseek-v4-flash-0731": {
-          "input": 0.13,
-          "output": 0.26,
-          "cache_read": 0.028
+          "input": 0.076,
+          "output": 0.153,
+          "cache_read": 0.014
         }
       }
     },
@@ -2838,6 +2858,168 @@
         "tools",
         "top_a",
         "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "reasoning": {
+        "default_effort": "high",
+        "default_enabled": true,
+        "mandatory": false,
+        "supported_efforts": [
+          "max",
+          "high",
+          "low"
+        ],
+        "supports_max_tokens": null
+      }
+    }
+  },
+  "deepseek-v4-pro-0423": {
+    "id": "deepseek/deepseek-v4-pro-0423",
+    "name": "DeepSeek V4 Pro 0423",
+    "description": "DeepSeek V4 Pro initial snapshot with million-token context and support for thinking and non-thinking modes",
+    "family": "deepseek-thinking",
+    "attachment": false,
+    "reasoning": true,
+    "tool_call": true,
+    "structured_output": true,
+    "temperature": true,
+    "knowledge": "2025-05",
+    "release_date": "2026-04-23",
+    "last_updated": "2026-04-23",
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    },
+    "provider": "deepseek",
+    "pricing": {
+      "merge-gateway": {
+        "deepseek/deepseek-v4-pro-0423": {
+          "input": 1.65,
+          "output": 3.3
+        }
+      },
+      "ofox": {
+        "deepseek/deepseek-v4-pro-0423": {
+          "input": 1.32,
+          "output": 3.96,
+          "cache_read": 0.044
+        }
+      }
+    }
+  },
+  "deepseek-v4-flash-vision-exp": {
+    "id": "deepseek/deepseek-v4-flash-vision-exp",
+    "name": "DeepSeek V4 Flash Vision Exp",
+    "description": "Experimental multimodal DeepSeek V4 Flash model for image understanding, coding, and agentic work",
+    "family": "deepseek-flash",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "structured_output": true,
+    "temperature": true,
+    "release_date": "2026-08-21",
+    "last_updated": "2026-08-21",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "limit": {
+      "context": 1000000,
+      "output": 384000
+    },
+    "provider": "deepseek",
+    "pricing": {
+      "crossmodel": {
+        "deepseek/deepseek-v4-flash-vision-exp": {
+          "input": 0.405,
+          "output": 1.215,
+          "cache_read": 0.0135,
+          "cache_write": 0.405
+        }
+      },
+      "deepseek": {
+        "deepseek-v4-flash-vision-exp": {
+          "input": 0.14,
+          "output": 0.28,
+          "reasoning": 0.28,
+          "cache_read": 0.0028
+        }
+      },
+      "edenai": {
+        "deepseek/deepseek-v4-flash-vision-exp": {
+          "input": 0.22,
+          "output": 0.66,
+          "cache_read": 0.007
+        }
+      },
+      "kilo": {
+        "deepseek/deepseek-v4-flash-vision-exp": {
+          "input": 0.22,
+          "output": 0.66,
+          "cache_read": 0.007
+        }
+      },
+      "nano-gpt": {
+        "deepseek/deepseek-v4-flash-vision-exp": {
+          "input": 0.22,
+          "output": 0.66,
+          "cache_read": 0.007
+        }
+      },
+      "ofox": {
+        "deepseek/deepseek-v4-flash-vision-exp": {
+          "input": 0.44,
+          "output": 1.32,
+          "cache_read": 0.014
+        }
+      },
+      "openrouter": {
+        "deepseek/deepseek-v4-flash-vision-exp": {
+          "input": 0.22,
+          "output": 0.66,
+          "cache_read": 0.007
+        }
+      },
+      "vercel": {
+        "deepseek/deepseek-v4-flash-vision-exp": {
+          "input": 0.22,
+          "output": 0.66,
+          "cache_read": 0.007
+        }
+      }
+    },
+    "openrouter": {
+      "id": "deepseek/deepseek-v4-flash-vision-exp",
+      "match_method": "exact_id",
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logprobs",
+        "max_tokens",
+        "presence_penalty",
+        "reasoning",
+        "reasoning_effort",
+        "response_format",
+        "stop",
+        "temperature",
+        "tool_choice",
+        "tools",
         "top_logprobs",
         "top_p"
       ],
@@ -2954,15 +3136,7 @@
         "format": "safetensors"
       }
     ],
-    "provider": "arcee-ai",
-    "pricing": {
-      "vercel": {
-        "arcee-ai/trinity-mini": {
-          "input": 0.045,
-          "output": 0.15
-        }
-      }
-    }
+    "provider": "arcee-ai"
   },
   "trinity-large-thinking": {
     "id": "arcee-ai/trinity-large-thinking",
@@ -3209,8 +3383,8 @@
     "pricing": {
       "kilo": {
         "google/gemma-4-26b-a4b-it": {
-          "input": 0.07,
-          "output": 0.34
+          "input": 0.042,
+          "output": 0.22
         }
       },
       "merge-gateway": {
@@ -3221,9 +3395,9 @@
       },
       "nano-gpt": {
         "google/gemma-4-26b-a4b-it": {
-          "input": 0.13,
-          "output": 0.4,
-          "cache_read": 0.065
+          "input": 0.08,
+          "output": 0.33,
+          "cache_read": 0.04
         }
       },
       "novita-ai": {
@@ -3483,16 +3657,16 @@
   "gemini-flash-lite-latest": {
     "id": "google/gemini-flash-lite-latest",
     "name": "Gemini Flash-Lite Latest",
-    "description": "Low-latency Gemini model for high-volume multimodal and agent workloads",
+    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
     "family": "gemini-flash-lite",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "structured_output": true,
     "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2026-05-07",
-    "last_updated": "2026-05-07",
+    "knowledge": "2026-03",
+    "release_date": "2026-07-21",
+    "last_updated": "2026-07-21",
     "modalities": {
       "input": [
         "text",
@@ -3514,10 +3688,9 @@
     "pricing": {
       "google": {
         "gemini-flash-lite-latest": {
-          "input": 0.25,
-          "output": 1.5,
-          "cache_read": 0.025,
-          "input_audio": 0.5
+          "input": 0.3,
+          "output": 2.5,
+          "cache_read": 0.03
         }
       },
       "merge-gateway": {
@@ -3545,6 +3718,31 @@
         }
       }
     }
+  },
+  "gemini-3.5-transcribe-live": {
+    "id": "google/gemini-3.5-transcribe-live",
+    "name": "Gemini 3.5 Transcribe Live",
+    "description": "Speech transcription model for accurate audio-to-text and captioning workflows",
+    "family": "gemini",
+    "attachment": false,
+    "reasoning": false,
+    "tool_call": false,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "audio"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "limit": {
+      "context": 0,
+      "output": 0
+    },
+    "provider": "google"
   },
   "gemini-2.0-flash": {
     "id": "google/gemini-2.0-flash",
@@ -4855,9 +5053,9 @@
       },
       "kilo": {
         "google/gemma-4-31b-it": {
-          "input": 0.08,
-          "output": 0.35,
-          "cache_read": 0.01
+          "input": 0.09,
+          "output": 0.34,
+          "cache_read": 0.05
         }
       },
       "lilac": {
@@ -4874,9 +5072,9 @@
       },
       "nano-gpt": {
         "google/gemma-4-31b-it": {
-          "input": 0.1,
-          "output": 0.35,
-          "cache_read": 0.05
+          "input": 0.08,
+          "output": 0.33,
+          "cache_read": 0.04
         }
       },
       "novita-ai": {
@@ -4893,9 +5091,9 @@
       },
       "openrouter": {
         "google/gemma-4-31b-it": {
-          "input": 0.1,
+          "input": 0.09,
           "output": 0.34,
-          "cache_read": 0.1
+          "cache_read": 0.05
         }
       },
       "orcarouter": {
@@ -5151,16 +5349,16 @@
   "gemini-flash-latest": {
     "id": "google/gemini-flash-latest",
     "name": "Gemini Flash Latest",
-    "description": "Fast Gemini model balancing multimodal reasoning, tool use, and cost",
+    "description": "High-efficiency Gemini model for agentic workflows, coding, and multimodal reasoning",
     "family": "gemini-flash",
     "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "structured_output": true,
     "temperature": true,
-    "knowledge": "2025-01",
-    "release_date": "2026-05-19",
-    "last_updated": "2026-05-19",
+    "knowledge": "2026-03",
+    "release_date": "2026-08-13",
+    "last_updated": "2026-08-13",
     "modalities": {
       "input": [
         "text",
@@ -5182,20 +5380,20 @@
     "pricing": {
       "edenai": {
         "google/gemini-flash-latest": {
-          "input": 0.75,
-          "output": 3.75,
-          "reasoning": 3.75,
-          "cache_read": 0.075,
-          "cache_write": 0.041667,
-          "input_audio": 0.75
+          "input": 1.5,
+          "output": 7.5,
+          "reasoning": 7.5,
+          "cache_read": 0.15,
+          "cache_write": 0.083333,
+          "input_audio": 1.5
         }
       },
       "google": {
         "gemini-flash-latest": {
-          "input": 1.5,
-          "output": 9,
-          "cache_read": 0.15,
-          "input_audio": 1.5
+          "input": 0.75,
+          "output": 3.75,
+          "cache_read": 0.075,
+          "input_audio": 0.75
         }
       },
       "merge-gateway": {
@@ -5208,10 +5406,10 @@
       },
       "nano-gpt": {
         "google/gemini-flash-latest": {
-          "input": 0.75,
-          "output": 3.75,
-          "cache_read": 0.075,
-          "cache_write": 0.041667
+          "input": 0.375,
+          "output": 1.875,
+          "cache_read": 0.0375,
+          "cache_write": 0.020833
         }
       },
       "orcarouter": {
@@ -6356,10 +6554,10 @@
       },
       "google": {
         "gemini-3.6-flash": {
-          "input": 1.5,
-          "output": 7.5,
-          "cache_read": 0.15,
-          "input_audio": 1.5
+          "input": 0.75,
+          "output": 3.75,
+          "cache_read": 0.075,
+          "input_audio": 0.75
         }
       },
       "impossibl": {
@@ -6395,10 +6593,10 @@
       },
       "ofox": {
         "google/gemini-3.6-flash": {
-          "input": 1.5,
-          "output": 7.5,
-          "cache_read": 0.15,
-          "cache_write": 0.083,
+          "input": 0.75,
+          "output": 3.75,
+          "cache_read": 0.075,
+          "cache_write": 0.0415,
           "input_audio": 1.5
         }
       },
@@ -7640,12 +7838,12 @@
     "pricing": {
       "edenai": {
         "google/gemini-3.7-flash": {
-          "input": 0.75,
-          "output": 3.75,
-          "reasoning": 3.75,
-          "cache_read": 0.075,
-          "cache_write": 0.041667,
-          "input_audio": 0.75
+          "input": 1.5,
+          "output": 7.5,
+          "reasoning": 7.5,
+          "cache_read": 0.15,
+          "cache_write": 0.083333,
+          "input_audio": 1.5
         }
       },
       "google": {
@@ -7658,11 +7856,11 @@
       },
       "kilo": {
         "google/gemini-3.7-flash": {
-          "input": 0.75,
-          "output": 3.75,
-          "reasoning": 3.75,
-          "cache_read": 0.075,
-          "cache_write": 0.041667
+          "input": 1.5,
+          "output": 7.5,
+          "reasoning": 7.5,
+          "cache_read": 0.15,
+          "cache_write": 0.083333
         }
       },
       "merge-gateway": {
@@ -7678,6 +7876,15 @@
           "output": 1.875,
           "cache_read": 0.0375,
           "cache_write": 0.020833
+        }
+      },
+      "ofox": {
+        "google/gemini-3.7-flash": {
+          "input": 0.75,
+          "output": 3.75,
+          "cache_read": 0.075,
+          "cache_write": 0.0415,
+          "input_audio": 1.5
         }
       },
       "openrouter": {
@@ -8013,7 +8220,7 @@
       "kilo": {
         "meta/muse-glimmer-30b": {
           "input": 0.3,
-          "output": 1.2,
+          "output": 1.1,
           "cache_read": 0.04
         }
       },
@@ -8199,6 +8406,13 @@
           "cache_read": 0.15
         }
       },
+      "llmgateway-providers": {
+        "meta/muse-spark-1.2": {
+          "input": 1.25,
+          "output": 4.25,
+          "cache_read": 0.15
+        }
+      },
       "merge-gateway": {
         "meta/muse-spark-1.2": {
           "input": 1.25,
@@ -8221,6 +8435,13 @@
         }
       },
       "openrouter": {
+        "meta/muse-spark-1.2": {
+          "input": 1.25,
+          "output": 4.25,
+          "cache_read": 0.15
+        }
+      },
+      "opper": {
         "meta/muse-spark-1.2": {
           "input": 1.25,
           "output": 4.25,
@@ -8381,6 +8602,13 @@
     "provider": "meta",
     "pricing": {
       "kilo": {
+        "meta/muse-spark-1.1": {
+          "input": 1.25,
+          "output": 4.25,
+          "cache_read": 0.15
+        }
+      },
+      "llmgateway-providers": {
         "meta/muse-spark-1.1": {
           "input": 1.25,
           "output": 4.25,
@@ -9275,7 +9503,7 @@
     "name": "Seed 1.6 Flash",
     "description": "Low-latency ByteDance Seed model for high-throughput chat, extraction, and lightweight tool use",
     "family": "seed",
-    "attachment": false,
+    "attachment": true,
     "reasoning": false,
     "tool_call": true,
     "temperature": true,
@@ -9283,7 +9511,8 @@
     "last_updated": "2025-08-28",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -9407,7 +9636,7 @@
     "name": "Seed 1.8",
     "description": "ByteDance Seed model for multimodal reasoning, long-context analysis, and agent workflows",
     "family": "seed",
-    "attachment": false,
+    "attachment": true,
     "reasoning": true,
     "tool_call": true,
     "temperature": true,
@@ -9415,7 +9644,8 @@
     "last_updated": "2025-12-28",
     "modalities": {
       "input": [
-        "text"
+        "text",
+        "image"
       ],
       "output": [
         "text"
@@ -9658,9 +9888,9 @@
       },
       "openrouter": {
         "moonshotai/kimi-k2.7-code": {
-          "input": 0.71,
-          "output": 3.5,
-          "cache_read": 0.15
+          "input": 0.67,
+          "output": 3.4,
+          "cache_read": 0.19
         }
       },
       "tensorx": {
@@ -9880,6 +10110,13 @@
           "cache_read": 0.3
         }
       },
+      "cloudflare-ai-gateway": {
+        "moonshotai/kimi-k3": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3
+        }
+      },
       "impossibl": {
         "moonshotai/kimi-k3": {
           "input": 3,
@@ -9913,6 +10150,12 @@
           "input": 3,
           "output": 15,
           "cache_read": 0.3
+        }
+      },
+      "nvidia": {
+        "moonshotai/kimi-k3": {
+          "input": 0,
+          "output": 0
         }
       },
       "ofox": {
@@ -10153,9 +10396,9 @@
       },
       "openrouter": {
         "moonshotai/kimi-k2.5": {
-          "input": 0.57,
-          "output": 2.85,
-          "cache_read": 0.095
+          "input": 0.6,
+          "output": 3,
+          "cache_read": 0.1
         }
       },
       "tensorx": {
@@ -10553,9 +10796,9 @@
       },
       "openrouter": {
         "moonshotai/kimi-k2.6": {
-          "input": 0.5605,
-          "output": 2.36,
-          "cache_read": 0.0944
+          "input": 0.95,
+          "output": 4,
+          "cache_read": 0.16
         }
       },
       "tensorx": {
@@ -10881,6 +11124,14 @@
           "cache_write": 6.25
         }
       },
+      "llmgateway-providers": {
+        "anthropic/claude-opus-4-7": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
       "merge-gateway": {
         "anthropic/claude-opus-4-7": {
           "input": 5,
@@ -10890,6 +11141,14 @@
         }
       },
       "nearai": {
+        "anthropic/claude-opus-4-7": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "opper": {
         "anthropic/claude-opus-4-7": {
           "input": 5,
           "output": 25,
@@ -11160,7 +11419,23 @@
           "cache_write": 6.25
         }
       },
+      "llmgateway-providers": {
+        "anthropic/claude-opus-4-8": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
       "merge-gateway": {
+        "anthropic/claude-opus-4-8": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "opper": {
         "anthropic/claude-opus-4-8": {
           "input": 5,
           "output": 25,
@@ -11422,6 +11697,14 @@
           "cache_write": 2.5
         }
       },
+      "llmgateway-providers": {
+        "anthropic/claude-sonnet-5": {
+          "input": 2,
+          "output": 10,
+          "cache_read": 0.2,
+          "cache_write": 2.5
+        }
+      },
       "merge-gateway": {
         "anthropic/claude-sonnet-5": {
           "input": 2,
@@ -11447,6 +11730,14 @@
         }
       },
       "openrouter": {
+        "anthropic/claude-sonnet-5": {
+          "input": 2,
+          "output": 10,
+          "cache_read": 0.2,
+          "cache_write": 2.5
+        }
+      },
+      "opper": {
         "anthropic/claude-sonnet-5": {
           "input": 2,
           "output": 10,
@@ -11587,6 +11878,14 @@
           "cache_write": 3.75
         }
       },
+      "llmgateway-providers": {
+        "anthropic/claude-sonnet-4-5-20250929": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
       "merge-gateway": {
         "anthropic/claude-sonnet-4-5-20250929": {
           "input": 3,
@@ -11643,6 +11942,14 @@
         }
       },
       "impossibl": {
+        "anthropic/claude-opus-4-5": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "opper": {
         "anthropic/claude-opus-4-5": {
           "input": 5,
           "output": 25,
@@ -11834,6 +12141,14 @@
           "cache_write": 3.75
         }
       },
+      "llmgateway-providers": {
+        "anthropic/claude-sonnet-4-6": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
       "merge-gateway": {
         "anthropic/claude-sonnet-4-6": {
           "input": 3,
@@ -11843,6 +12158,14 @@
         }
       },
       "nearai": {
+        "anthropic/claude-sonnet-4-6": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
+      "opper": {
         "anthropic/claude-sonnet-4-6": {
           "input": 3,
           "output": 15,
@@ -11966,6 +12289,14 @@
           "cache_write": 1.25
         }
       },
+      "llmgateway-providers": {
+        "anthropic/claude-haiku-4-5-20251001": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        }
+      },
       "merge-gateway": {
         "anthropic/claude-haiku-4-5-20251001": {
           "input": 1,
@@ -12030,10 +12361,26 @@
           "cache_write": 3.75
         }
       },
+      "llmgateway-providers": {
+        "anthropic/claude-sonnet-4-5": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
       "nearai": {
         "anthropic/claude-sonnet-4-5": {
           "input": 3,
           "output": 15.5,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
+      "opper": {
+        "anthropic/claude-sonnet-4-5": {
+          "input": 3,
+          "output": 15,
           "cache_read": 0.3,
           "cache_write": 3.75
         }
@@ -12119,6 +12466,14 @@
         }
       },
       "edenai": {
+        "anthropic/claude-opus-4-5-20251101": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "llmgateway-providers": {
         "anthropic/claude-opus-4-5-20251101": {
           "input": 5,
           "output": 25,
@@ -12282,6 +12637,14 @@
           "cache_write": 12.5
         }
       },
+      "llmgateway-providers": {
+        "anthropic/claude-fable-5": {
+          "input": 10,
+          "output": 50,
+          "cache_read": 1,
+          "cache_write": 12.5
+        }
+      },
       "merge-gateway": {
         "anthropic/claude-fable-5": {
           "input": 10,
@@ -12307,6 +12670,14 @@
         }
       },
       "openrouter": {
+        "anthropic/claude-fable-5": {
+          "input": 10,
+          "output": 50,
+          "cache_read": 1,
+          "cache_write": 12.5
+        }
+      },
+      "opper": {
         "anthropic/claude-fable-5": {
           "input": 10,
           "output": 50,
@@ -12517,7 +12888,23 @@
           "cache_write": 1.25
         }
       },
+      "llmgateway-providers": {
+        "anthropic/claude-haiku-4-5": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        }
+      },
       "nearai": {
+        "anthropic/claude-haiku-4-5": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        }
+      },
+      "opper": {
         "anthropic/claude-haiku-4-5": {
           "input": 1,
           "output": 5,
@@ -12690,6 +13077,14 @@
           "cache_write": 6.25
         }
       },
+      "llmgateway-providers": {
+        "anthropic/claude-opus-4-6": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
       "merge-gateway": {
         "anthropic/claude-opus-4-6": {
           "input": 5,
@@ -12699,6 +13094,14 @@
         }
       },
       "nearai": {
+        "anthropic/claude-opus-4-6": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "opper": {
         "anthropic/claude-opus-4-6": {
           "input": 5,
           "output": 25,
@@ -13000,6 +13403,14 @@
           "cache_write": 6.25
         }
       },
+      "llmgateway-providers": {
+        "anthropic/claude-opus-5": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
       "merge-gateway": {
         "anthropic/claude-opus-5": {
           "input": 5,
@@ -13025,6 +13436,14 @@
         }
       },
       "openrouter": {
+        "anthropic/claude-opus-5": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "opper": {
         "anthropic/claude-opus-5": {
           "input": 5,
           "output": 25,
@@ -13873,6 +14292,13 @@
           "cache_read": 1.25
         }
       },
+      "llmgateway-providers": {
+        "openai/gpt-4o": {
+          "input": 2.5,
+          "output": 10,
+          "cache_read": 1.25
+        }
+      },
       "merge-gateway": {
         "openai/gpt-4o": {
           "input": 2.5,
@@ -14014,13 +14440,6 @@
     },
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/gpt-5.3-chat-latest": {
-          "input": 1.75,
-          "output": 14,
-          "cache_read": 0.175
-        }
-      },
       "merge-gateway": {
         "openai/gpt-5.3-chat-latest": {
           "input": 1.75,
@@ -14030,6 +14449,13 @@
       },
       "openai": {
         "gpt-5.3-chat-latest": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        }
+      },
+      "opper": {
+        "openai/gpt-5.3-chat-latest": {
           "input": 1.75,
           "output": 14,
           "cache_read": 0.175
@@ -14103,6 +14529,13 @@
         }
       },
       "kilo": {
+        "openai/gpt-5-nano": {
+          "input": 0.05,
+          "output": 0.4,
+          "cache_read": 0.005
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-5-nano": {
           "input": 0.05,
           "output": 0.4,
@@ -14284,6 +14717,13 @@
           "cache_read": 0.075
         }
       },
+      "llmgateway-providers": {
+        "openai/gpt-4o-mini": {
+          "input": 0.15,
+          "output": 0.6,
+          "cache_read": 0.075
+        }
+      },
       "merge-gateway": {
         "openai/gpt-4o-mini": {
           "input": 0.15,
@@ -14403,13 +14843,6 @@
     ],
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/gpt-3.5-turbo": {
-          "input": 0.5,
-          "output": 1.5,
-          "cache_read": 0
-        }
-      },
       "edenai": {
         "openai/gpt-3.5-turbo": {
           "input": 0.5,
@@ -14423,6 +14856,12 @@
         }
       },
       "kilo": {
+        "openai/gpt-3.5-turbo": {
+          "input": 0.5,
+          "output": 1.5
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-3.5-turbo": {
           "input": 0.5,
           "output": 1.5
@@ -14524,12 +14963,6 @@
     },
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/o1-pro": {
-          "input": 150,
-          "output": 600
-        }
-      },
       "edenai": {
         "openai/o1-pro": {
           "input": 150,
@@ -14742,21 +15175,7 @@
       "cloudflare-ai-gateway": {
         "openai/gpt-5.5-pro": {
           "input": 30,
-          "output": 180,
-          "tiers": [
-            {
-              "input": 60,
-              "output": 270,
-              "tier": {
-                "type": "context",
-                "size": 272000
-              }
-            }
-          ],
-          "context_over_200k": {
-            "input": 60,
-            "output": 270
-          }
+          "output": 180
         }
       },
       "crossmodel": {
@@ -14837,6 +15256,26 @@
           "output": 180
         }
       },
+      "llmgateway-providers": {
+        "openai/gpt-5.5-pro": {
+          "input": 30,
+          "output": 180,
+          "tiers": [
+            {
+              "input": 60,
+              "output": 270,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 60,
+            "output": 270
+          }
+        }
+      },
       "openai": {
         "gpt-5.5-pro": {
           "input": 30,
@@ -14858,6 +15297,26 @@
         }
       },
       "openrouter": {
+        "openai/gpt-5.5-pro": {
+          "input": 30,
+          "output": 180,
+          "tiers": [
+            {
+              "input": 60,
+              "output": 270,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 60,
+            "output": 270
+          }
+        }
+      },
+      "opper": {
         "openai/gpt-5.5-pro": {
           "input": 30,
           "output": 180,
@@ -15002,12 +15461,6 @@
     ],
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/gpt-4-turbo": {
-          "input": 10,
-          "output": 30
-        }
-      },
       "edenai": {
         "openai/gpt-4-turbo": {
           "input": 10,
@@ -15021,6 +15474,12 @@
         }
       },
       "kilo": {
+        "openai/gpt-4-turbo": {
+          "input": 10,
+          "output": 30
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-4-turbo": {
           "input": 10,
           "output": 30
@@ -15128,12 +15587,6 @@
     ],
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/gpt-4": {
-          "input": 30,
-          "output": 60
-        }
-      },
       "edenai": {
         "openai/gpt-4": {
           "input": 30,
@@ -15141,6 +15594,12 @@
         }
       },
       "kilo": {
+        "openai/gpt-4": {
+          "input": 30,
+          "output": 60
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-4": {
           "input": 30,
           "output": 60
@@ -15203,7 +15662,7 @@
     "reasoning": true,
     "tool_call": false,
     "structured_output": true,
-    "temperature": true,
+    "temperature": false,
     "knowledge": "2024-09-30",
     "release_date": "2025-08-07",
     "last_updated": "2025-08-07",
@@ -15369,28 +15828,10 @@
     "pricing": {
       "cloudflare-ai-gateway": {
         "openai/gpt-5.6-sol": {
-          "input": 5,
-          "output": 30,
-          "cache_read": 0.5,
-          "cache_write": 6.25,
-          "tiers": [
-            {
-              "input": 10,
-              "output": 45,
-              "cache_read": 1,
-              "cache_write": 12.5,
-              "tier": {
-                "type": "context",
-                "size": 272000
-              }
-            }
-          ],
-          "context_over_200k": {
-            "input": 10,
-            "output": 45,
-            "cache_read": 1,
-            "cache_write": 12.5
-          }
+          "input": 2,
+          "output": 10,
+          "cache_read": 0.25,
+          "cache_write": 3.125
         }
       },
       "crossmodel": {
@@ -15421,16 +15862,16 @@
       },
       "edenai": {
         "openai/gpt-5.6-sol": {
-          "input": 5,
-          "output": 30,
-          "cache_read": 0.5,
-          "cache_write": 6.25,
+          "input": 4,
+          "output": 20,
+          "cache_read": 0.4,
+          "cache_write": 5,
           "tiers": [
             {
-              "input": 10,
-              "output": 45,
-              "cache_read": 1,
-              "cache_write": 12.5,
+              "input": 8,
+              "output": 30,
+              "cache_read": 0.8,
+              "cache_write": 10,
               "tier": {
                 "type": "context",
                 "size": 272000
@@ -15438,10 +15879,10 @@
             }
           ],
           "context_over_200k": {
-            "input": 10,
-            "output": 45,
-            "cache_read": 1,
-            "cache_write": 12.5
+            "input": 8,
+            "output": 30,
+            "cache_read": 0.8,
+            "cache_write": 10
           }
         }
       },
@@ -15473,6 +15914,14 @@
       },
       "kilo": {
         "openai/gpt-5.6-sol": {
+          "input": 4,
+          "output": 20,
+          "cache_read": 0.4,
+          "cache_write": 5
+        }
+      },
+      "llmgateway-providers": {
+        "openai/gpt-5.6-sol": {
           "input": 5,
           "output": 30,
           "cache_read": 0.5,
@@ -15488,22 +15937,74 @@
       },
       "nano-gpt": {
         "openai/gpt-5.6-sol": {
+          "input": 2,
+          "output": 10,
+          "cache_read": 0.2,
+          "cache_write": 2.5
+        }
+      },
+      "ofox": {
+        "openai/gpt-5.6-sol": {
           "input": 2.5,
           "output": 15,
           "cache_read": 0.25,
           "cache_write": 3.125
         }
       },
-      "ofox": {
-        "openai/gpt-5.6-sol": {
-          "input": 5,
-          "output": 30,
-          "cache_read": 0.5,
-          "cache_write": 6.25
-        }
-      },
       "openai": {
         "gpt-5.6-sol": {
+          "input": 4,
+          "output": 20,
+          "cache_read": 0.4,
+          "cache_write": 5,
+          "tiers": [
+            {
+              "input": 8,
+              "output": 30,
+              "cache_read": 0.8,
+              "cache_write": 10,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 8,
+            "output": 30,
+            "cache_read": 0.8,
+            "cache_write": 10
+          }
+        }
+      },
+      "openrouter": {
+        "openai/gpt-5.6-sol": {
+          "input": 2,
+          "output": 10,
+          "cache_read": 0.2,
+          "cache_write": 2.5,
+          "tiers": [
+            {
+              "input": 4,
+              "output": 15,
+              "cache_read": 0.4,
+              "cache_write": 5,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 4,
+            "output": 15,
+            "cache_read": 0.4,
+            "cache_write": 5
+          }
+        }
+      },
+      "opper": {
+        "openai/gpt-5.6-sol": {
           "input": 5,
           "output": 30,
           "cache_read": 0.5,
@@ -15528,38 +16029,12 @@
           }
         }
       },
-      "openrouter": {
-        "openai/gpt-5.6-sol": {
-          "input": 2.5,
-          "output": 15,
-          "cache_read": 0.25,
-          "cache_write": 3.125,
-          "tiers": [
-            {
-              "input": 5,
-              "output": 22.5,
-              "cache_read": 0.5,
-              "cache_write": 6.25,
-              "tier": {
-                "type": "context",
-                "size": 272000
-              }
-            }
-          ],
-          "context_over_200k": {
-            "input": 5,
-            "output": 22.5,
-            "cache_read": 0.5,
-            "cache_write": 6.25
-          }
-        }
-      },
       "vercel": {
         "openai/gpt-5.6-sol": {
-          "input": 2.5,
-          "output": 15,
-          "cache_read": 0.25,
-          "cache_write": 3.125
+          "input": 2,
+          "output": 10,
+          "cache_read": 0.2,
+          "cache_write": 2.5
         }
       },
       "zenmux": {
@@ -15658,12 +16133,6 @@
     ],
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/o3-pro": {
-          "input": 20,
-          "output": 80
-        }
-      },
       "edenai": {
         "openai/o3-pro": {
           "input": 20,
@@ -15763,13 +16232,6 @@
           "input": 9,
           "output": 36,
           "cache_read": 2.2
-        }
-      },
-      "vercel": {
-        "openai/o3-deep-research": {
-          "input": 10,
-          "output": 40,
-          "cache_read": 2.5
         }
       }
     }
@@ -15893,21 +16355,7 @@
       "cloudflare-ai-gateway": {
         "openai/gpt-5.4-pro": {
           "input": 30,
-          "output": 180,
-          "tiers": [
-            {
-              "input": 60,
-              "output": 270,
-              "tier": {
-                "type": "context",
-                "size": 272000
-              }
-            }
-          ],
-          "context_over_200k": {
-            "input": 60,
-            "output": 270
-          }
+          "output": 180
         }
       },
       "edenai": {
@@ -15962,6 +16410,12 @@
           "output": 180
         }
       },
+      "llmgateway-providers": {
+        "openai/gpt-5.4-pro": {
+          "input": 30,
+          "output": 180
+        }
+      },
       "ofox": {
         "openai/gpt-5.4-pro": {
           "input": 30,
@@ -15989,6 +16443,26 @@
         }
       },
       "openrouter": {
+        "openai/gpt-5.4-pro": {
+          "input": 30,
+          "output": 180,
+          "tiers": [
+            {
+              "input": 60,
+              "output": 270,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 60,
+            "output": 270
+          }
+        }
+      },
+      "opper": {
         "openai/gpt-5.4-pro": {
           "input": 30,
           "output": 180,
@@ -16150,6 +16624,13 @@
         }
       },
       "kilo": {
+        "openai/gpt-5": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-5": {
           "input": 1.25,
           "output": 10,
@@ -16538,6 +17019,13 @@
           "cache_read": 0.025
         }
       },
+      "llmgateway-providers": {
+        "openai/gpt-5-mini": {
+          "input": 0.25,
+          "output": 2,
+          "cache_read": 0.025
+        }
+      },
       "merge-gateway": {
         "openai/gpt-5-mini": {
           "input": 0.25,
@@ -16770,25 +17258,7 @@
           "input": 0.2,
           "output": 1.2,
           "cache_read": 0.02,
-          "cache_write": 0.25,
-          "tiers": [
-            {
-              "input": 0.4,
-              "output": 1.8,
-              "cache_read": 0.04,
-              "cache_write": 0.5,
-              "tier": {
-                "type": "context",
-                "size": 272000
-              }
-            }
-          ],
-          "context_over_200k": {
-            "input": 0.4,
-            "output": 1.8,
-            "cache_read": 0.04,
-            "cache_write": 0.5
-          }
+          "cache_write": 0.25
         }
       },
       "crossmodel": {
@@ -16877,6 +17347,14 @@
           "cache_write": 0.25
         }
       },
+      "llmgateway-providers": {
+        "openai/gpt-5.6-luna": {
+          "input": 0.2,
+          "output": 1.2,
+          "cache_read": 0.02,
+          "cache_write": 0.25
+        }
+      },
       "merge-gateway": {
         "openai/gpt-5.6-luna": {
           "input": 0.2,
@@ -16927,6 +17405,32 @@
         }
       },
       "openrouter": {
+        "openai/gpt-5.6-luna": {
+          "input": 0.2,
+          "output": 1.2,
+          "cache_read": 0.02,
+          "cache_write": 0.25,
+          "tiers": [
+            {
+              "input": 0.4,
+              "output": 1.8,
+              "cache_read": 0.04,
+              "cache_write": 0.5,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 0.4,
+            "output": 1.8,
+            "cache_read": 0.04,
+            "cache_write": 0.5
+          }
+        }
+      },
+      "opper": {
         "openai/gpt-5.6-luna": {
           "input": 0.2,
           "output": 1.2,
@@ -17027,7 +17531,7 @@
     "reasoning": true,
     "tool_call": true,
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-02-05",
     "last_updated": "2026-02-05",
@@ -17072,13 +17576,6 @@
     ],
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/gpt-5.3-codex": {
-          "input": 1.75,
-          "output": 14,
-          "cache_read": 0.175
-        }
-      },
       "edenai": {
         "openai/gpt-5.3-codex": {
           "input": 1.75,
@@ -17100,6 +17597,13 @@
         }
       },
       "kilo": {
+        "openai/gpt-5.3-codex": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-5.3-codex": {
           "input": 1.75,
           "output": 14,
@@ -17128,6 +17632,13 @@
         }
       },
       "openrouter": {
+        "openai/gpt-5.3-codex": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        }
+      },
+      "opper": {
         "openai/gpt-5.3-codex": {
           "input": 1.75,
           "output": 14,
@@ -17349,9 +17860,8 @@
       },
       "openrouter": {
         "openai/gpt-oss-120b": {
-          "input": 0.03,
-          "output": 0.17,
-          "cache_read": 0.03
+          "input": 0.037,
+          "output": 0.17
         }
       },
       "pioneer": {
@@ -17484,13 +17994,6 @@
     },
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/gpt-5.3-codex-spark": {
-          "input": 1.75,
-          "output": 14,
-          "cache_read": 0.175
-        }
-      },
       "openai": {
         "gpt-5.3-codex-spark": {
           "input": 1.75,
@@ -17566,6 +18069,13 @@
         }
       },
       "kilo": {
+        "openai/gpt-4.1-nano": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.025
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-4.1-nano": {
           "input": 0.1,
           "output": 0.4,
@@ -17685,13 +18195,6 @@
     ],
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/o1": {
-          "input": 15,
-          "output": 60,
-          "cache_read": 7.5
-        }
-      },
       "edenai": {
         "openai/o1": {
           "input": 15,
@@ -17707,6 +18210,13 @@
         }
       },
       "kilo": {
+        "openai/o1": {
+          "input": 15,
+          "output": 60,
+          "cache_read": 7.5
+        }
+      },
+      "llmgateway-providers": {
         "openai/o1": {
           "input": 15,
           "output": 60,
@@ -17786,7 +18296,7 @@
     "reasoning": true,
     "tool_call": true,
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2025-12-11",
     "last_updated": "2025-12-11",
@@ -17816,13 +18326,6 @@
     ],
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/gpt-5.2": {
-          "input": 1.75,
-          "output": 14,
-          "cache_read": 0.175
-        }
-      },
       "edenai": {
         "openai/gpt-5.2": {
           "input": 1.75,
@@ -17838,6 +18341,13 @@
         }
       },
       "kilo": {
+        "openai/gpt-5.2": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-5.2": {
           "input": 1.75,
           "output": 14,
@@ -18066,7 +18576,7 @@
     "reasoning": true,
     "tool_call": true,
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -18263,6 +18773,13 @@
           "cache_read": 0.075
         }
       },
+      "llmgateway-providers": {
+        "openai/gpt-5.4-mini": {
+          "input": 0.75,
+          "output": 4.5,
+          "cache_read": 0.075
+        }
+      },
       "merge-gateway": {
         "openai/gpt-5.4-mini": {
           "input": 0.75,
@@ -18299,6 +18816,13 @@
         }
       },
       "openrouter": {
+        "openai/gpt-5.4-mini": {
+          "input": 0.75,
+          "output": 4.5,
+          "cache_read": 0.075
+        }
+      },
+      "opper": {
         "openai/gpt-5.4-mini": {
           "input": 0.75,
           "output": 4.5,
@@ -18531,6 +19055,13 @@
           "cache_read": 0.5
         }
       },
+      "llmgateway-providers": {
+        "openai/o3": {
+          "input": 2,
+          "output": 8,
+          "cache_read": 0.5
+        }
+      },
       "merge-gateway": {
         "openai/o3": {
           "input": 2,
@@ -18677,12 +19208,6 @@
     },
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/gpt-5-pro": {
-          "input": 15,
-          "output": 120
-        }
-      },
       "edenai": {
         "openai/gpt-5-pro": {
           "input": 15,
@@ -18696,6 +19221,12 @@
         }
       },
       "kilo": {
+        "openai/gpt-5-pro": {
+          "input": 15,
+          "output": 120
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-5-pro": {
           "input": 15,
           "output": 120
@@ -19045,24 +19576,7 @@
       "cloudflare-ai-gateway": {
         "openai/gpt-5.5": {
           "input": 5,
-          "output": 30,
-          "cache_read": 0.5,
-          "tiers": [
-            {
-              "input": 10,
-              "output": 45,
-              "cache_read": 1,
-              "tier": {
-                "type": "context",
-                "size": 272000
-              }
-            }
-          ],
-          "context_over_200k": {
-            "input": 10,
-            "output": 45,
-            "cache_read": 1
-          }
+          "output": 30
         }
       },
       "crossmodel": {
@@ -19180,6 +19694,29 @@
           "cache_read": 0.5
         }
       },
+      "llmgateway-providers": {
+        "openai/gpt-5.5": {
+          "input": 5,
+          "output": 30,
+          "cache_read": 0.5,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 45,
+              "cache_read": 1,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 45,
+            "cache_read": 1
+          }
+        }
+      },
       "merge-gateway": {
         "openai/gpt-5.5": {
           "input": 5,
@@ -19264,6 +19801,29 @@
         }
       },
       "openrouter": {
+        "openai/gpt-5.5": {
+          "input": 5,
+          "output": 30,
+          "cache_read": 0.5,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 45,
+              "cache_read": 1,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 45,
+            "cache_read": 1
+          }
+        }
+      },
+      "opper": {
         "openai/gpt-5.5": {
           "input": 5,
           "output": 30,
@@ -19629,6 +20189,13 @@
           "cache_read": 0.5
         }
       },
+      "llmgateway-providers": {
+        "openai/gpt-4.1": {
+          "input": 2,
+          "output": 8,
+          "cache_read": 0.5
+        }
+      },
       "merge-gateway": {
         "openai/gpt-4.1": {
           "input": 2,
@@ -19976,25 +20543,7 @@
           "input": 2,
           "output": 12,
           "cache_read": 0.2,
-          "cache_write": 2.5,
-          "tiers": [
-            {
-              "input": 4,
-              "output": 18,
-              "cache_read": 0.4,
-              "cache_write": 5,
-              "tier": {
-                "type": "context",
-                "size": 272000
-              }
-            }
-          ],
-          "context_over_200k": {
-            "input": 4,
-            "output": 18,
-            "cache_read": 0.4,
-            "cache_write": 5
-          }
+          "cache_write": 2.5
         }
       },
       "crossmodel": {
@@ -20083,6 +20632,14 @@
           "cache_write": 2.5
         }
       },
+      "llmgateway-providers": {
+        "openai/gpt-5.6-terra": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2,
+          "cache_write": 2.5
+        }
+      },
       "merge-gateway": {
         "openai/gpt-5.6-terra": {
           "input": 2,
@@ -20133,6 +20690,32 @@
         }
       },
       "openrouter": {
+        "openai/gpt-5.6-terra": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2,
+          "cache_write": 2.5,
+          "tiers": [
+            {
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4,
+              "cache_write": 5,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 4,
+            "output": 18,
+            "cache_read": 0.4,
+            "cache_write": 5
+          }
+        }
+      },
+      "opper": {
         "openai/gpt-5.6-terra": {
           "input": 2,
           "output": 12,
@@ -20290,6 +20873,13 @@
           "cache_read": 0.275
         }
       },
+      "llmgateway-providers": {
+        "openai/o4-mini": {
+          "input": 1.1,
+          "output": 4.4,
+          "cache_read": 0.275
+        }
+      },
       "merge-gateway": {
         "openai/o4-mini": {
           "input": 1.1,
@@ -20371,7 +20961,7 @@
     "reasoning": true,
     "tool_call": true,
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-05",
     "last_updated": "2026-03-05",
@@ -20593,23 +21183,7 @@
         "openai/gpt-5.4": {
           "input": 2.5,
           "output": 15,
-          "cache_read": 0.25,
-          "tiers": [
-            {
-              "input": 5,
-              "output": 22.5,
-              "cache_read": 0.5,
-              "tier": {
-                "type": "context",
-                "size": 272000
-              }
-            }
-          ],
-          "context_over_200k": {
-            "input": 5,
-            "output": 22.5,
-            "cache_read": 0.5
-          }
+          "cache_read": 0.25
         }
       },
       "crossmodel": {
@@ -20685,6 +21259,13 @@
         }
       },
       "kilo": {
+        "openai/gpt-5.4": {
+          "input": 2.5,
+          "output": 15,
+          "cache_read": 0.25
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-5.4": {
           "input": 2.5,
           "output": 15,
@@ -20775,6 +21356,29 @@
         }
       },
       "openrouter": {
+        "openai/gpt-5.4": {
+          "input": 2.5,
+          "output": 15,
+          "cache_read": 0.25,
+          "tiers": [
+            {
+              "input": 5,
+              "output": 22.5,
+              "cache_read": 0.5,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 5,
+            "output": 22.5,
+            "cache_read": 0.5
+          }
+        }
+      },
+      "opper": {
         "openai/gpt-5.4": {
           "input": 2.5,
           "output": 15,
@@ -20937,6 +21541,13 @@
         }
       },
       "kilo": {
+        "openai/o3-mini": {
+          "input": 1.1,
+          "output": 4.4,
+          "cache_read": 0.55
+        }
+      },
+      "llmgateway-providers": {
         "openai/o3-mini": {
           "input": 1.1,
           "output": 4.4,
@@ -21185,6 +21796,12 @@
           "input": 0.15,
           "output": 0.6
         }
+      },
+      "vercel": {
+        "openai/gpt-oss-safeguard-120b": {
+          "input": 0.15,
+          "output": 0.6
+        }
       }
     }
   },
@@ -21243,13 +21860,6 @@
     },
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/gpt-5.2-chat-latest": {
-          "input": 1.75,
-          "output": 14,
-          "cache_read": 0.175
-        }
-      },
       "merge-gateway": {
         "openai/gpt-5.2-chat-latest": {
           "input": 1.75,
@@ -21303,12 +21913,6 @@
     },
     "provider": "openai",
     "pricing": {
-      "cloudflare-ai-gateway": {
-        "openai/gpt-5.2-pro": {
-          "input": 21,
-          "output": 168
-        }
-      },
       "edenai": {
         "openai/gpt-5.2-pro": {
           "input": 21,
@@ -21316,6 +21920,12 @@
         }
       },
       "kilo": {
+        "openai/gpt-5.2-pro": {
+          "input": 21,
+          "output": 168
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-5.2-pro": {
           "input": 21,
           "output": 168
@@ -21760,6 +22370,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "aixy": {
+        "openai/gpt-4.1-mini": {
+          "input": 0.4,
+          "output": 1.6,
+          "cache_read": 0.1
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-4.1-mini": {
           "input": 0.4,
@@ -21782,6 +22399,13 @@
         }
       },
       "kilo": {
+        "openai/gpt-4.1-mini": {
+          "input": 0.4,
+          "output": 1.6,
+          "cache_read": 0.1
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-4.1-mini": {
           "input": 0.4,
           "output": 1.6,
@@ -21937,9 +22561,8 @@
       },
       "kilo": {
         "openai/gpt-oss-20b": {
-          "input": 0.03,
-          "output": 0.13,
-          "cache_read": 0.03
+          "input": 0.02,
+          "output": 0.1
         }
       },
       "lmstudio": {
@@ -22119,7 +22742,7 @@
     "reasoning": true,
     "tool_call": true,
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2025-08-31",
     "release_date": "2026-03-17",
     "last_updated": "2026-03-17",
@@ -22316,6 +22939,13 @@
           "cache_read": 0.02
         }
       },
+      "llmgateway-providers": {
+        "openai/gpt-5.4-nano": {
+          "input": 0.2,
+          "output": 1.25,
+          "cache_read": 0.02
+        }
+      },
       "merge-gateway": {
         "openai/gpt-5.4-nano": {
           "input": 0.2,
@@ -22352,6 +22982,13 @@
         }
       },
       "openrouter": {
+        "openai/gpt-5.4-nano": {
+          "input": 0.2,
+          "output": 1.25,
+          "cache_read": 0.02
+        }
+      },
+      "opper": {
         "openai/gpt-5.4-nano": {
           "input": 0.2,
           "output": 1.25,
@@ -22425,7 +23062,7 @@
     "reasoning": true,
     "tool_call": true,
     "structured_output": true,
-    "temperature": false,
+    "temperature": true,
     "knowledge": "2024-09-30",
     "release_date": "2025-11-13",
     "last_updated": "2025-11-13",
@@ -22468,6 +23105,13 @@
         }
       },
       "kilo": {
+        "openai/gpt-5.1": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        }
+      },
+      "llmgateway-providers": {
         "openai/gpt-5.1": {
           "input": 1.25,
           "output": 10,
@@ -22603,6 +23247,13 @@
     },
     "provider": "xai",
     "pricing": {
+      "cloudflare-ai-gateway": {
+        "xai/grok-4.6": {
+          "input": 2,
+          "output": 6,
+          "cache_read": 0.5
+        }
+      },
       "edenai": {
         "xai/grok-4.6": {
           "input": 2,
@@ -22633,7 +23284,7 @@
           "cache_read": 0.375
         }
       },
-      "perplexity-agent": {
+      "opper": {
         "xai/grok-4.6": {
           "input": 2,
           "output": 6,
@@ -22656,11 +23307,27 @@
           }
         }
       },
-      "vercel": {
+      "perplexity-agent": {
         "xai/grok-4.6": {
           "input": 2,
           "output": 6,
-          "cache_read": 0.5
+          "cache_read": 0.5,
+          "tiers": [
+            {
+              "input": 4,
+              "output": 12,
+              "cache_read": 1,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 4,
+            "output": 12,
+            "cache_read": 1
+          }
         }
       },
       "xai": {
@@ -22698,10 +23365,12 @@
         "reasoning_effort",
         "response_format",
         "seed",
+        "stop",
         "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
+        "top_k",
         "top_logprobs",
         "top_p"
       ],
@@ -22795,6 +23464,13 @@
     ],
     "provider": "xai",
     "pricing": {
+      "cloudflare-ai-gateway": {
+        "xai/grok-4.5": {
+          "input": 2,
+          "output": 6,
+          "cache_read": 0.3
+        }
+      },
       "edenai": {
         "xai/grok-4.5": {
           "input": 2,
@@ -22832,11 +23508,27 @@
           "cache_read": 0.5
         }
       },
-      "vercel": {
+      "opper": {
         "xai/grok-4.5": {
           "input": 2,
           "output": 6,
-          "cache_read": 0.3
+          "cache_read": 0.3,
+          "tiers": [
+            {
+              "input": 4,
+              "output": 12,
+              "cache_read": 0.6,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 4,
+            "output": 12,
+            "cache_read": 0.6
+          }
         }
       },
       "xai": {
@@ -22923,6 +23615,13 @@
     },
     "provider": "xai",
     "pricing": {
+      "cloudflare-ai-gateway": {
+        "xai/grok-4.20-0309-non-reasoning": {
+          "input": 2,
+          "output": 6,
+          "cache_read": 0.2
+        }
+      },
       "edenai": {
         "xai/grok-4.20-0309-non-reasoning": {
           "input": 1.25,
@@ -23084,6 +23783,13 @@
     },
     "provider": "xai",
     "pricing": {
+      "cloudflare-ai-gateway": {
+        "xai/grok-4.20-0309-reasoning": {
+          "input": 2,
+          "output": 6,
+          "cache_read": 0.2
+        }
+      },
       "edenai": {
         "xai/grok-4.20-0309-reasoning": {
           "input": 1.25,
@@ -23269,11 +23975,27 @@
           "cache_read": 0.2
         }
       },
-      "vercel": {
+      "opper": {
         "xai/grok-build-0.1": {
           "input": 1,
           "output": 2,
-          "cache_read": 0.2
+          "cache_read": 0.2,
+          "tiers": [
+            {
+              "input": 2,
+              "output": 4,
+              "cache_read": 0.4,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 2,
+            "output": 4,
+            "cache_read": 0.4
+          }
         }
       },
       "xai": {
@@ -23386,6 +24108,13 @@
     ],
     "provider": "xai",
     "pricing": {
+      "cloudflare-ai-gateway": {
+        "xai/grok-4.3": {
+          "input": 1.25,
+          "output": 2.5,
+          "cache_read": 0.2
+        }
+      },
       "edenai": {
         "xai/grok-4.3": {
           "input": 1.25,
@@ -23439,11 +24168,27 @@
           }
         }
       },
-      "vercel": {
+      "opper": {
         "xai/grok-4.3": {
           "input": 1.25,
           "output": 2.5,
-          "cache_read": 0.2
+          "cache_read": 0.2,
+          "tiers": [
+            {
+              "input": 2.5,
+              "output": 5,
+              "cache_read": 0.4,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 2.5,
+            "output": 5,
+            "cache_read": 0.4
+          }
         }
       },
       "xai": {
@@ -24622,6 +25367,29 @@
           }
         }
       },
+      "llmgateway-providers": {
+        "xiaomi/mimo-v2.5": {
+          "input": 0.14,
+          "output": 0.28,
+          "cache_read": 0.0028,
+          "tiers": [
+            {
+              "input": 0.8,
+              "output": 4,
+              "cache_read": 0.16,
+              "tier": {
+                "type": "context",
+                "size": 256000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 0.8,
+            "output": 4,
+            "cache_read": 0.16
+          }
+        }
+      },
       "nano-gpt": {
         "xiaomi/mimo-v2.5": {
           "input": 0.14,
@@ -24956,6 +25724,29 @@
           }
         }
       },
+      "llmgateway-providers": {
+        "xiaomi/mimo-v2.5-pro": {
+          "input": 0.435,
+          "output": 0.87,
+          "cache_read": 0.0036,
+          "tiers": [
+            {
+              "input": 2,
+              "output": 6,
+              "cache_read": 0.4,
+              "tier": {
+                "type": "context",
+                "size": 256000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 2,
+            "output": 6,
+            "cache_read": 0.4
+          }
+        }
+      },
       "nano-gpt": {
         "xiaomi/mimo-v2.5-pro": {
           "input": 0.435,
@@ -25075,6 +25866,14 @@
           "input": 0.2,
           "output": 1.6,
           "reasoning": 4.8
+        }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen3-vl-plus": {
+          "input": 0.2,
+          "output": 1.6,
+          "cache_read": 0.04,
+          "cache_write": 0.25
         }
       }
     }
@@ -25423,6 +26222,21 @@
           "cache_write": 3.125
         }
       },
+      "cloudflare-ai-gateway": {
+        "alibaba/qwen3.7-max": {
+          "input": 1.25,
+          "output": 3.75,
+          "cache_read": 0.25
+        }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen3.7-max": {
+          "input": 2.5,
+          "output": 7.5,
+          "cache_read": 0.5,
+          "cache_write": 3.125
+        }
+      },
       "vercel": {
         "alibaba/qwen3.7-max": {
           "input": 2.5,
@@ -25535,6 +26349,12 @@
           "output": 0.27,
           "input_audio": 4.44,
           "output_audio": 8.89
+        }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen-omni-turbo": {
+          "input": 0.2,
+          "output": 0.8
         }
       }
     }
@@ -25780,6 +26600,12 @@
     "pricing": {
       "alibaba": {
         "qwen-max": {
+          "input": 1.6,
+          "output": 6.4
+        }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen-max": {
           "input": 1.6,
           "output": 6.4
         }
@@ -26037,6 +26863,12 @@
           "input": 0.6,
           "output": 3.6
         }
+      },
+      "cloudflare-ai-gateway": {
+        "alibaba/qwen3.5-397b-a17b": {
+          "input": 0.6,
+          "output": 3.6
+        }
       }
     },
     "openrouter": {
@@ -26176,6 +27008,14 @@
           "input": 0.4,
           "output": 1.2,
           "reasoning": 4
+        }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen-plus": {
+          "input": 0.4,
+          "output": 1.2,
+          "cache_read": 0.08,
+          "cache_write": 0.5
         }
       }
     },
@@ -26407,6 +27247,14 @@
           "input": 0.3,
           "output": 1.5
         }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen3-coder-flash": {
+          "input": 0.3,
+          "output": 1.5,
+          "cache_read": 0.06,
+          "cache_write": 0.375
+        }
       }
     },
     "openrouter": {
@@ -26463,6 +27311,13 @@
           "output": 7.8,
           "cache_read": 0.13,
           "cache_write": 1.625
+        }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen3.6-max-preview": {
+          "input": 1.3,
+          "output": 7.8,
+          "cache_read": 0.13
         }
       }
     },
@@ -26527,6 +27382,21 @@
     "pricing": {
       "alibaba": {
         "qwen3.8-max": {
+          "input": 2,
+          "output": 6,
+          "cache_read": 0.25,
+          "cache_write": 2.5
+        }
+      },
+      "cloudflare-ai-gateway": {
+        "alibaba/qwen3.8-max": {
+          "input": 2,
+          "output": 6,
+          "cache_read": 0.25
+        }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen3.8-max": {
           "input": 2,
           "output": 6,
           "cache_read": 0.25,
@@ -26634,6 +27504,21 @@
           }
         }
       },
+      "cloudflare-ai-gateway": {
+        "alibaba/qwen3.7-plus": {
+          "input": 0.32,
+          "output": 1.28,
+          "cache_read": 0.064
+        }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen3.7-plus": {
+          "input": 0.4,
+          "output": 1.6,
+          "cache_read": 0.08,
+          "cache_write": 0.5
+        }
+      },
       "vercel": {
         "alibaba/qwen3.7-plus": {
           "input": 0.4,
@@ -26736,6 +27621,14 @@
     },
     "provider": "alibaba",
     "pricing": {
+      "llmgateway-providers": {
+        "alibaba/qwen3.7-flash": {
+          "input": 0.03,
+          "output": 0.13,
+          "cache_read": 0.006,
+          "cache_write": 0.0375
+        }
+      },
       "vercel": {
         "alibaba/qwen3.7-flash": {
           "input": 0.03,
@@ -26759,6 +27652,81 @@
         "temperature",
         "tool_choice",
         "tools",
+        "top_logprobs",
+        "top_p"
+      ],
+      "reasoning": {
+        "default_effort": null,
+        "default_enabled": true,
+        "mandatory": false,
+        "supported_efforts": null,
+        "supports_max_tokens": true
+      }
+    }
+  },
+  "qwen3.8-flash": {
+    "id": "alibaba/qwen3.8-flash",
+    "name": "Qwen3.8 Flash",
+    "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
+    "family": "qwen",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "structured_output": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    },
+    "provider": "alibaba",
+    "pricing": {
+      "nano-gpt": {
+        "alibaba/qwen3.8-flash": {
+          "input": 0.16,
+          "output": 0.47,
+          "cache_read": 0.016,
+          "cache_write": 0.2
+        }
+      },
+      "vercel": {
+        "alibaba/qwen3.8-flash": {
+          "input": 0.16,
+          "output": 0.47,
+          "cache_read": 0.016,
+          "cache_write": 0.2
+        }
+      }
+    },
+    "openrouter": {
+      "id": "qwen/qwen3.8-flash",
+      "match_method": "exact_id",
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logprobs",
+        "max_tokens",
+        "presence_penalty",
+        "reasoning",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
         "top_logprobs",
         "top_p"
       ],
@@ -26963,6 +27931,14 @@
           "input": 0.05,
           "output": 0.4
         }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen-flash": {
+          "input": 0.05,
+          "output": 0.4,
+          "cache_read": 0.01,
+          "cache_write": 0.0625
+        }
       }
     }
   },
@@ -27020,6 +27996,20 @@
         "qwen3-max": {
           "input": 1.2,
           "output": 6
+        }
+      },
+      "cloudflare-ai-gateway": {
+        "alibaba/qwen3-max": {
+          "input": 1.2,
+          "output": 6
+        }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen3-max": {
+          "input": 1.2,
+          "output": 6,
+          "cache_read": 0.24,
+          "cache_write": 1.5
         }
       },
       "vercel": {
@@ -27106,6 +28096,12 @@
         "qwen3.6-35b-a3b": {
           "input": 0.248,
           "output": 1.485
+        }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen3.6-35b-a3b": {
+          "input": 0.375,
+          "output": 2.25
         }
       },
       "zenifra": {
@@ -27394,9 +28390,9 @@
     "pricing": {
       "vercel": {
         "alibaba/qwen3.8-27b": {
-          "input": 0.1,
-          "output": 0.4,
-          "cache_read": 0.01
+          "input": 0.55,
+          "output": 3.3,
+          "cache_read": 0.11
         }
       }
     },
@@ -27406,8 +28402,10 @@
       "supported_parameters": [
         "frequency_penalty",
         "include_reasoning",
+        "logit_bias",
         "logprobs",
         "max_tokens",
+        "min_p",
         "presence_penalty",
         "reasoning",
         "reasoning_effort",
@@ -27467,6 +28465,32 @@
     "pricing": {
       "alibaba": {
         "qwen3.6-plus": {
+          "input": 0.5,
+          "output": 3,
+          "cache_read": 0.05,
+          "cache_write": 0.625,
+          "tiers": [
+            {
+              "input": 2,
+              "output": 6,
+              "cache_read": 0.2,
+              "cache_write": 2.5,
+              "tier": {
+                "type": "context",
+                "size": 256000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 2,
+            "output": 6,
+            "cache_read": 0.2,
+            "cache_write": 2.5
+          }
+        }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen3.6-plus": {
           "input": 0.5,
           "output": 3,
           "cache_read": 0.05,
@@ -27833,6 +28857,14 @@
           "output": 5
         }
       },
+      "llmgateway-providers": {
+        "alibaba/qwen3-coder-plus": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.2,
+          "cache_write": 1.25
+        }
+      },
       "vercel": {
         "alibaba/qwen3-coder-plus": {
           "input": 1,
@@ -28006,6 +29038,14 @@
           "input": 0.1875,
           "output": 1.125,
           "cache_write": 0.234375
+        }
+      },
+      "llmgateway-providers": {
+        "alibaba/qwen3.6-flash": {
+          "input": 0.25,
+          "output": 1.5,
+          "cache_read": 0.05,
+          "cache_write": 0.3125
         }
       },
       "nano-gpt": {
@@ -28452,6 +29492,13 @@
           "cache_read": 0.5
         }
       },
+      "llmgateway-providers": {
+        "sakana/fugu-ultra": {
+          "input": 5,
+          "output": 30,
+          "cache_read": 0.5
+        }
+      },
       "llmtr": {
         "sakana/fugu-ultra": {
           "input": 5,
@@ -28680,7 +29727,19 @@
           "output": 1
         }
       },
+      "llmgateway-providers": {
+        "perplexity/sonar": {
+          "input": 1,
+          "output": 1
+        }
+      },
       "openrouter": {
+        "perplexity/sonar": {
+          "input": 1,
+          "output": 1
+        }
+      },
+      "opper": {
         "perplexity/sonar": {
           "input": 1,
           "output": 1
@@ -28749,7 +29808,19 @@
           "output": 8
         }
       },
+      "llmgateway-providers": {
+        "perplexity/sonar-reasoning-pro": {
+          "input": 2,
+          "output": 8
+        }
+      },
       "openrouter": {
+        "perplexity/sonar-reasoning-pro": {
+          "input": 2,
+          "output": 8
+        }
+      },
+      "opper": {
         "perplexity/sonar-reasoning-pro": {
           "input": 2,
           "output": 8
@@ -28828,7 +29899,19 @@
           "output": 15
         }
       },
+      "llmgateway-providers": {
+        "perplexity/sonar-pro": {
+          "input": 3,
+          "output": 15
+        }
+      },
       "openrouter": {
+        "perplexity/sonar-pro": {
+          "input": 3,
+          "output": 15
+        }
+      },
+      "opper": {
         "perplexity/sonar-pro": {
           "input": 3,
           "output": 15
@@ -29240,6 +30323,40 @@
       }
     }
   },
+  "glm-4.6v-flash": {
+    "id": "zhipuai/glm-4.6v-flash",
+    "name": "GLM-4.6V-Flash",
+    "description": "Lightweight GLM vision model for visual reasoning, documents, and multimodal agents",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "temperature": true,
+    "release_date": "2025-12-08",
+    "last_updated": "2025-12-08",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "limit": {
+      "context": 128000,
+      "output": 32768
+    },
+    "weights": [
+      {
+        "label": "Hugging Face",
+        "url": "https://huggingface.co/zai-org/GLM-4.6V-Flash"
+      }
+    ],
+    "provider": "zhipuai"
+  },
   "glm-4.7-flashx": {
     "id": "zhipuai/glm-4.7-flashx",
     "name": "GLM-4.7-FlashX",
@@ -29460,7 +30577,44 @@
       "context": 1000000,
       "output": 131072
     },
-    "provider": "zhipuai"
+    "provider": "zhipuai",
+    "pricing": {
+      "zhipuai": {
+        "glm-5.3": {
+          "input": 1.4,
+          "output": 4.4,
+          "cache_read": 0.26,
+          "cache_write": 0
+        }
+      }
+    },
+    "openrouter": {
+      "id": "z-ai/glm-5.3",
+      "match_method": "exact_id",
+      "supported_parameters": [
+        "include_reasoning",
+        "max_tokens",
+        "reasoning",
+        "reasoning_effort",
+        "response_format",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p"
+      ],
+      "reasoning": {
+        "default_effort": "max",
+        "default_enabled": true,
+        "mandatory": true,
+        "supported_efforts": [
+          "max",
+          "high",
+          "low"
+        ],
+        "supports_max_tokens": null
+      }
+    }
   },
   "glm-5.2": {
     "id": "zhipuai/glm-5.2",
@@ -30128,6 +31282,83 @@
       }
     }
   },
+  "glm-5.3-flash": {
+    "id": "zhipuai/glm-5.3-flash",
+    "name": "GLM-5.3-Flash",
+    "description": "Native multimodal GLM model for efficient coding and long-horizon agent tasks",
+    "family": "glm",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "structured_output": true,
+    "temperature": true,
+    "release_date": "2026-08-26",
+    "last_updated": "2026-08-26",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "limit": {
+      "context": 1000000,
+      "output": 131072
+    },
+    "provider": "zhipuai",
+    "pricing": {
+      "zhipuai": {
+        "glm-5.3-flash": {
+          "input": 0.075,
+          "output": 0.25,
+          "cache_read": 0.015,
+          "cache_write": 0
+        }
+      }
+    },
+    "openrouter": {
+      "id": "z-ai/glm-5.3-flash",
+      "match_method": "exact_id",
+      "supported_parameters": [
+        "frequency_penalty",
+        "include_reasoning",
+        "logit_bias",
+        "logprobs",
+        "max_tokens",
+        "min_p",
+        "presence_penalty",
+        "reasoning",
+        "reasoning_effort",
+        "repetition_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_logprobs",
+        "top_p"
+      ],
+      "reasoning": {
+        "default_effort": "max",
+        "default_enabled": true,
+        "mandatory": true,
+        "supported_efforts": [
+          "max",
+          "high",
+          "low"
+        ],
+        "supports_max_tokens": null
+      }
+    }
+  },
   "granite-4-h-micro": {
     "id": "ibm/granite-4-h-micro",
     "name": "Granite-4.0-H-Micro",
@@ -30295,7 +31526,6 @@
         "repetition_penalty",
         "seed",
         "stop",
-        "structured_outputs",
         "temperature",
         "tool_choice",
         "tools",
@@ -30522,8 +31752,8 @@
     "pricing": {
       "edenai": {
         "mistral/mistral-small-latest": {
-          "input": 0.06,
-          "output": 0.18
+          "input": 0.15,
+          "output": 0.6
         }
       },
       "merge-gateway": {
@@ -30807,6 +32037,12 @@
           "cache_read": 0.2
         }
       },
+      "llmgateway-providers": {
+        "mistral/mistral-large-latest": {
+          "input": 4,
+          "output": 12
+        }
+      },
       "merge-gateway": {
         "mistral/mistral-large-latest": {
           "input": 0.5,
@@ -30968,6 +32204,13 @@
     "pricing": {
       "edenai": {
         "mistral/devstral-2512": {
+          "input": 0.44,
+          "output": 2.2,
+          "cache_read": 0.044
+        }
+      },
+      "llmgateway-providers": {
+        "mistral/devstral-2512": {
           "input": 0.4,
           "output": 2
         }
@@ -30984,7 +32227,31 @@
           "input": 0.4,
           "output": 2
         }
+      },
+      "opper": {
+        "mistral/devstral-2512": {
+          "input": 0.4,
+          "output": 2
+        }
       }
+    },
+    "openrouter": {
+      "id": "mistralai/devstral-2512",
+      "match_method": "exact_id",
+      "supported_parameters": [
+        "frequency_penalty",
+        "max_tokens",
+        "presence_penalty",
+        "response_format",
+        "seed",
+        "stop",
+        "structured_outputs",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p"
+      ],
+      "reasoning": null
     }
   },
   "mistral-small-2603": {
@@ -31056,6 +32323,12 @@
           "input": 0.15,
           "output": 0.6
         }
+      },
+      "opper": {
+        "mistral/mistral-small-2603": {
+          "input": 0.15,
+          "output": 0.6
+        }
       }
     },
     "openrouter": {
@@ -31124,6 +32397,12 @@
     ],
     "provider": "mistral",
     "pricing": {
+      "llmgateway-providers": {
+        "mistral/mistral-small-2506": {
+          "input": 0.1,
+          "output": 0.3
+        }
+      },
       "mistral": {
         "mistral-small-2506": {
           "input": 0.1,
@@ -31244,6 +32523,12 @@
           "cache_read": 0.05
         }
       },
+      "llmgateway-providers": {
+        "mistral/mistral-large-2512": {
+          "input": 0.5,
+          "output": 1.5
+        }
+      },
       "merge-gateway": {
         "mistral/mistral-large-2512": {
           "input": 0.5,
@@ -31253,6 +32538,12 @@
       },
       "mistral": {
         "mistral-large-2512": {
+          "input": 0.5,
+          "output": 1.5
+        }
+      },
+      "opper": {
+        "mistral/mistral-large-2512": {
           "input": 0.5,
           "output": 1.5
         }
@@ -31632,8 +32923,8 @@
     "pricing": {
       "edenai": {
         "mistral/codestral-latest": {
-          "input": 1,
-          "output": 3
+          "input": 0.3,
+          "output": 0.9
         }
       },
       "merge-gateway": {
@@ -32190,8 +33481,8 @@
     },
     "open_weights": true,
     "limit": {
-      "context": 196608,
-      "output": 128000
+      "context": 204800,
+      "output": 131072
     },
     "weights": [
       {
@@ -32318,8 +33609,8 @@
     },
     "open_weights": true,
     "limit": {
-      "context": 512000,
-      "output": 128000
+      "context": 1048576,
+      "output": 512000
     },
     "weights": [
       {
@@ -32440,6 +33731,33 @@
       }
     }
   },
+  "image-01": {
+    "id": "minimax/image-01",
+    "name": "MiniMax image-01",
+    "description": "MiniMax text-to-image generation model with reference-image support",
+    "family": "minimax",
+    "attachment": true,
+    "reasoning": false,
+    "tool_call": false,
+    "temperature": false,
+    "release_date": "2025-02-15",
+    "last_updated": "2026-08-25",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "image"
+      ]
+    },
+    "open_weights": false,
+    "limit": {
+      "context": 0,
+      "output": 0
+    },
+    "provider": "minimax"
+  },
   "MiniMax-M2-Her": {
     "id": "minimax/MiniMax-M2-Her",
     "name": "MiniMax-M2 Her",
@@ -32461,8 +33779,8 @@
     },
     "open_weights": false,
     "limit": {
-      "context": 200000,
-      "output": 131000
+      "context": 65536,
+      "output": 2048
     },
     "provider": "minimax",
     "openrouter": {
@@ -32563,7 +33881,6 @@
         "logprobs",
         "max_tokens",
         "min_p",
-        "parallel_tool_calls",
         "presence_penalty",
         "reasoning",
         "repetition_penalty",

--- a/meta/model.json
+++ b/meta/model.json
@@ -1154,6 +1154,12 @@
     },
     "provider": "nvidia",
     "pricing": {
+      "amazon-bedrock": {
+        "nvidia.nemotron-nano-9b-v2": {
+          "input": 0.06,
+          "output": 0.23
+        }
+      },
       "merge-gateway": {
         "nvidia/nemotron-nano-9b-v2": {
           "input": 0.06,
@@ -1335,7 +1341,15 @@
         "source": "https://huggingface.co/microsoft/Phi-4-mini-instruct/resolve/main/README.md"
       }
     ],
-    "provider": "microsoft"
+    "provider": "microsoft",
+    "pricing": {
+      "azure": {
+        "phi-4-mini": {
+          "input": 0.075,
+          "output": 0.3
+        }
+      }
+    }
   },
   "mai-code-1-flash": {
     "id": "microsoft/mai-code-1-flash",
@@ -1543,6 +1557,12 @@
     ],
     "provider": "deepseek",
     "pricing": {
+      "azure": {
+        "deepseek-r1": {
+          "input": 1.35,
+          "output": 5.4
+        }
+      },
       "kilo": {
         "deepseek/deepseek-r1": {
           "input": 0.7,
@@ -1695,6 +1715,12 @@
           "cache_write": 0
         }
       },
+      "azure": {
+        "deepseek-v4-flash": {
+          "input": 0.19,
+          "output": 0.51
+        }
+      },
       "crossmodel": {
         "deepseek/deepseek-v4-flash": {
           "input": 0.405,
@@ -1776,9 +1802,9 @@
       },
       "openrouter": {
         "deepseek/deepseek-v4-flash": {
-          "input": 0.07798,
-          "output": 0.15596,
-          "cache_read": 0.015596
+          "input": 0.07952,
+          "output": 0.15904,
+          "cache_read": 0.015904
         }
       },
       "orcarouter": {
@@ -2122,6 +2148,12 @@
           "cache_read": 0.2
         }
       },
+      "azure": {
+        "deepseek-v4-pro": {
+          "input": 1.74,
+          "output": 3.48
+        }
+      },
       "cloudflare-ai-gateway": {
         "deepseek/deepseek-v4-pro": {
           "input": 1.74,
@@ -2372,6 +2404,12 @@
     ],
     "provider": "deepseek",
     "pricing": {
+      "azure": {
+        "deepseek-v3.2": {
+          "input": 0.58,
+          "output": 1.68
+        }
+      },
       "kilo": {
         "deepseek/deepseek-v3.2": {
           "input": 0.269,
@@ -3504,6 +3542,13 @@
           "output": 120
         }
       },
+      "google-vertex": {
+        "gemini-3-pro-image": {
+          "input": 2,
+          "output": 120,
+          "cache_read": 0.2
+        }
+      },
       "kilo": {
         "google/gemini-3-pro-image": {
           "input": 2,
@@ -3693,6 +3738,14 @@
           "cache_read": 0.03
         }
       },
+      "google-vertex": {
+        "gemini-flash-lite-latest": {
+          "input": 0.25,
+          "output": 1.5,
+          "cache_read": 0.025,
+          "input_audio": 0.5
+        }
+      },
       "merge-gateway": {
         "google/gemini-flash-lite-latest": {
           "input": 0.25,
@@ -3809,7 +3862,15 @@
       "context": 32768,
       "output": 16384
     },
-    "provider": "google"
+    "provider": "google",
+    "pricing": {
+      "google-vertex": {
+        "gemini-2.5-flash-tts": {
+          "input": 0.5,
+          "output": 10
+        }
+      }
+    }
   },
   "gemini-3.5-flash-lite": {
     "id": "google/gemini-3.5-flash-lite",
@@ -3928,6 +3989,13 @@
         }
       },
       "google": {
+        "gemini-3.5-flash-lite": {
+          "input": 0.3,
+          "output": 2.5,
+          "cache_read": 0.03
+        }
+      },
+      "google-vertex": {
         "gemini-3.5-flash-lite": {
           "input": 0.3,
           "output": 2.5,
@@ -4334,6 +4402,29 @@
           }
         }
       },
+      "google-vertex": {
+        "gemini-3.1-pro-preview": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2,
+          "tiers": [
+            {
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 4,
+            "output": 18,
+            "cache_read": 0.4
+          }
+        }
+      },
       "impossibl": {
         "google/gemini-3.1-pro-preview": {
           "input": 2,
@@ -4603,6 +4694,29 @@
           }
         }
       },
+      "google-vertex": {
+        "gemini-3.1-pro-preview-customtools": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2,
+          "tiers": [
+            {
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 4,
+            "output": 18,
+            "cache_read": 0.4
+          }
+        }
+      },
       "kilo": {
         "google/gemini-3.1-pro-preview-customtools": {
           "input": 2,
@@ -4834,6 +4948,14 @@
     "provider": "google",
     "pricing": {
       "google": {
+        "gemini-2.5-flash-lite": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.01,
+          "input_audio": 0.3
+        }
+      },
+      "google-vertex": {
         "gemini-2.5-flash-lite": {
           "input": 0.1,
           "output": 0.4,
@@ -5326,6 +5448,12 @@
           "output": 0
         }
       },
+      "google-vertex": {
+        "gemini-embedding-001": {
+          "input": 0.15,
+          "output": 0
+        }
+      },
       "merge-gateway": {
         "google/gemini-embedding-001": {
           "input": 0.15,
@@ -5394,6 +5522,14 @@
           "output": 3.75,
           "cache_read": 0.075,
           "input_audio": 0.75
+        }
+      },
+      "google-vertex": {
+        "gemini-flash-latest": {
+          "input": 1.5,
+          "output": 9,
+          "cache_read": 0.15,
+          "input_audio": 1.5
         }
       },
       "merge-gateway": {
@@ -5550,6 +5686,14 @@
         }
       },
       "google": {
+        "gemini-3.5-flash": {
+          "input": 1.5,
+          "output": 9,
+          "cache_read": 0.15,
+          "input_audio": 1.5
+        }
+      },
+      "google-vertex": {
         "gemini-3.5-flash": {
           "input": 1.5,
           "output": 9,
@@ -5833,6 +5977,14 @@
           "input_audio": 0.5
         }
       },
+      "google-vertex": {
+        "gemini-3.1-flash-lite": {
+          "input": 0.25,
+          "output": 1.5,
+          "cache_read": 0.025,
+          "input_audio": 0.5
+        }
+      },
       "impossibl": {
         "google/gemini-3.1-flash-lite": {
           "input": 0.25,
@@ -6013,6 +6165,14 @@
         }
       },
       "google": {
+        "gemini-2.5-flash": {
+          "input": 0.3,
+          "output": 2.5,
+          "cache_read": 0.03,
+          "input_audio": 1
+        }
+      },
+      "google-vertex": {
         "gemini-2.5-flash": {
           "input": 0.3,
           "output": 2.5,
@@ -6275,7 +6435,15 @@
       "context": 32768,
       "output": 16384
     },
-    "provider": "google"
+    "provider": "google",
+    "pricing": {
+      "google-vertex": {
+        "gemini-2.5-pro-tts": {
+          "input": 1,
+          "output": 20
+        }
+      }
+    }
   },
   "gemini-embedding-2": {
     "id": "google/gemini-embedding-2",
@@ -6560,6 +6728,14 @@
           "input_audio": 0.75
         }
       },
+      "google-vertex": {
+        "gemini-3.6-flash": {
+          "input": 0.75,
+          "output": 3.75,
+          "cache_read": 0.075,
+          "input_audio": 0.75
+        }
+      },
       "impossibl": {
         "google/gemini-3.6-flash": {
           "input": 1.5,
@@ -6689,6 +6865,13 @@
         "gemini-3.1-flash-image": {
           "input": 0.5,
           "output": 60
+        }
+      },
+      "google-vertex": {
+        "gemini-3.1-flash-image": {
+          "input": 0.5,
+          "output": 60,
+          "cache_read": 0.05
         }
       },
       "kilo": {
@@ -6988,6 +7171,14 @@
           "input_audio": 0.5
         }
       },
+      "google-vertex": {
+        "gemini-3.1-flash-lite-preview": {
+          "input": 0.25,
+          "output": 1.5,
+          "cache_read": 0.025,
+          "input_audio": 0.5
+        }
+      },
       "kilo": {
         "google/gemini-3.1-flash-lite-preview": {
           "input": 0.25,
@@ -7132,6 +7323,14 @@
         }
       },
       "google": {
+        "gemini-3-flash-preview": {
+          "input": 0.5,
+          "output": 3,
+          "cache_read": 0.05,
+          "input_audio": 1
+        }
+      },
+      "google-vertex": {
         "gemini-3-flash-preview": {
           "input": 0.5,
           "output": 3,
@@ -7297,6 +7496,12 @@
           "cache_read": 0.075
         }
       },
+      "google-vertex": {
+        "gemini-2.5-flash-image": {
+          "input": 0.3,
+          "output": 30
+        }
+      },
       "kilo": {
         "google/gemini-2.5-flash-image": {
           "input": 0.3,
@@ -7412,6 +7617,29 @@
         }
       },
       "google": {
+        "gemini-2.5-pro": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125,
+          "tiers": [
+            {
+              "input": 2.5,
+              "output": 15,
+              "cache_read": 0.25,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 2.5,
+            "output": 15,
+            "cache_read": 0.25
+          }
+        }
+      },
+      "google-vertex": {
         "gemini-2.5-pro": {
           "input": 1.25,
           "output": 10,
@@ -7854,6 +8082,14 @@
           "input_audio": 0.75
         }
       },
+      "google-vertex": {
+        "gemini-3.7-flash": {
+          "input": 0.75,
+          "output": 3.75,
+          "cache_read": 0.075,
+          "input_audio": 0.75
+        }
+      },
       "kilo": {
         "google/gemini-3.7-flash": {
           "input": 1.5,
@@ -8023,6 +8259,12 @@
     ],
     "provider": "meta",
     "pricing": {
+      "azure": {
+        "llama-3.3-70b-instruct": {
+          "input": 0.71,
+          "output": 0.71
+        }
+      },
       "merge-gateway": {
         "meta/llama-3.3-70b-instruct": {
           "input": 0.22,
@@ -9844,6 +10086,13 @@
           "cache_write": 0
         }
       },
+      "azure": {
+        "kimi-k2.7-code": {
+          "input": 0.95,
+          "output": 4,
+          "cache_read": 0.19
+        }
+      },
       "hpc-ai": {
         "moonshotai/kimi-k2.7-code": {
           "input": 0.95,
@@ -10346,6 +10595,12 @@
     ],
     "provider": "moonshotai",
     "pricing": {
+      "azure": {
+        "kimi-k2.5": {
+          "input": 0.6,
+          "output": 3
+        }
+      },
       "hpc-ai": {
         "moonshotai/kimi-k2.5": {
           "input": 0.6,
@@ -10571,6 +10826,12 @@
     ],
     "provider": "moonshotai",
     "pricing": {
+      "amazon-bedrock": {
+        "moonshot.kimi-k2-thinking": {
+          "input": 0.6,
+          "output": 2.5
+        }
+      },
       "kilo": {
         "moonshotai/kimi-k2-thinking": {
           "input": 0.6,
@@ -10740,6 +11001,12 @@
           "cache_write": 0
         }
       },
+      "azure": {
+        "kimi-k2.6": {
+          "input": 0.95,
+          "output": 4
+        }
+      },
       "fastrouter": {
         "moonshotai/kimi-k2.6": {
           "input": 0.75,
@@ -10896,6 +11163,22 @@
     ],
     "provider": "anthropic",
     "pricing": {
+      "google-vertex": {
+        "claude-opus-4@20250514": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-opus-4@20250514": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        }
+      },
       "merge-gateway": {
         "anthropic/claude-opus-4-20250514": {
           "input": 15,
@@ -11092,7 +11375,23 @@
     ],
     "provider": "anthropic",
     "pricing": {
+      "amazon-bedrock": {
+        "anthropic.claude-opus-4-7": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
       "anthropic": {
+        "claude-opus-4-7": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "azure": {
         "claude-opus-4-7": {
           "input": 5,
           "output": 25,
@@ -11114,6 +11413,58 @@
           "output": 25,
           "cache_read": 0.5,
           "cache_write": 6.25
+        }
+      },
+      "google-vertex": {
+        "claude-opus-4-7@default": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 37.5,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 37.5,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-opus-4-7@default": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 37.5,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 37.5,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
         }
       },
       "impossibl": {
@@ -11223,7 +11574,17 @@
       "context": 1000000,
       "output": 128000
     },
-    "provider": "anthropic"
+    "provider": "anthropic",
+    "pricing": {
+      "azure": {
+        "claude-mythos-5": {
+          "input": 10,
+          "output": 50,
+          "cache_read": 1,
+          "cache_write": 12.5
+        }
+      }
+    }
   },
   "claude-opus-4-1-20250805": {
     "id": "anthropic/claude-opus-4-1-20250805",
@@ -11254,6 +11615,30 @@
     },
     "provider": "anthropic",
     "pricing": {
+      "amazon-bedrock": {
+        "anthropic.claude-opus-4-1-20250805-v1:0": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        }
+      },
+      "google-vertex": {
+        "claude-opus-4-1@20250805": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-opus-4-1@20250805": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        }
+      },
       "merge-gateway": {
         "anthropic/claude-opus-4-1-20250805": {
           "input": 15,
@@ -11387,12 +11772,46 @@
     ],
     "provider": "anthropic",
     "pricing": {
+      "amazon-bedrock": {
+        "anthropic.claude-opus-4-8": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
       "anthropic": {
         "claude-opus-4-8": {
           "input": 5,
           "output": 25,
           "cache_read": 0.5,
           "cache_write": 6.25
+        }
+      },
+      "azure": {
+        "claude-opus-4-8": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 37.5,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 37.5,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
         }
       },
       "crossmodel": {
@@ -11409,6 +11828,58 @@
           "output": 25,
           "cache_read": 0.5,
           "cache_write": 6.25
+        }
+      },
+      "google-vertex": {
+        "claude-opus-4-8@default": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 37.5,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 37.5,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-opus-4-8@default": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 37.5,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 37.5,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
         }
       },
       "impossibl": {
@@ -11542,6 +12013,16 @@
       "output": 32000
     },
     "provider": "anthropic",
+    "pricing": {
+      "azure": {
+        "claude-opus-4-1": {
+          "input": 15,
+          "output": 75,
+          "cache_read": 1.5,
+          "cache_write": 18.75
+        }
+      }
+    },
     "openrouter": {
       "id": "anthropic/claude-opus-4.1",
       "match_method": "normalized_id",
@@ -11649,7 +12130,23 @@
     ],
     "provider": "anthropic",
     "pricing": {
+      "amazon-bedrock": {
+        "anthropic.claude-sonnet-5": {
+          "input": 2,
+          "output": 10,
+          "cache_read": 0.2,
+          "cache_write": 2.5
+        }
+      },
       "anthropic": {
+        "claude-sonnet-5": {
+          "input": 2,
+          "output": 10,
+          "cache_read": 0.2,
+          "cache_write": 2.5
+        }
+      },
+      "azure": {
         "claude-sonnet-5": {
           "input": 2,
           "output": 10,
@@ -11675,6 +12172,22 @@
       },
       "edenai": {
         "anthropic/claude-sonnet-5": {
+          "input": 2,
+          "output": 10,
+          "cache_read": 0.2,
+          "cache_write": 2.5
+        }
+      },
+      "google-vertex": {
+        "claude-sonnet-5@default": {
+          "input": 2,
+          "output": 10,
+          "cache_read": 0.2,
+          "cache_write": 2.5
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-sonnet-5@default": {
           "input": 2,
           "output": 10,
           "cache_read": 0.2,
@@ -11870,8 +12383,32 @@
     },
     "provider": "anthropic",
     "pricing": {
+      "amazon-bedrock": {
+        "anthropic.claude-sonnet-4-5-20250929-v1:0": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
       "anthropic": {
         "claude-sonnet-4-5-20250929": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
+      "google-vertex": {
+        "claude-sonnet-4-5@20250929": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-sonnet-4-5@20250929": {
           "input": 3,
           "output": 15,
           "cache_read": 0.3,
@@ -11926,6 +12463,14 @@
     "provider": "anthropic",
     "pricing": {
       "anthropic": {
+        "claude-opus-4-5": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "azure": {
         "claude-opus-4-5": {
           "input": 5,
           "output": 25,
@@ -12109,7 +12654,23 @@
     ],
     "provider": "anthropic",
     "pricing": {
+      "amazon-bedrock": {
+        "anthropic.claude-sonnet-4-6": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
       "anthropic": {
+        "claude-sonnet-4-6": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
+      "azure": {
         "claude-sonnet-4-6": {
           "input": 3,
           "output": 15,
@@ -12131,6 +12692,58 @@
           "output": 15,
           "cache_read": 0.3,
           "cache_write": 3.75
+        }
+      },
+      "google-vertex": {
+        "claude-sonnet-4-6@default": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "tiers": [
+            {
+              "input": 6,
+              "output": 22.5,
+              "cache_read": 0.6,
+              "cache_write": 7.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 6,
+            "output": 22.5,
+            "cache_read": 0.6,
+            "cache_write": 7.5
+          }
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-sonnet-4-6@default": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "tiers": [
+            {
+              "input": 6,
+              "output": 22.5,
+              "cache_read": 0.6,
+              "cache_write": 7.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 6,
+            "output": 22.5,
+            "cache_read": 0.6,
+            "cache_write": 7.5
+          }
         }
       },
       "impossibl": {
@@ -12281,8 +12894,32 @@
     },
     "provider": "anthropic",
     "pricing": {
+      "amazon-bedrock": {
+        "anthropic.claude-haiku-4-5-20251001-v1:0": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        }
+      },
       "anthropic": {
         "claude-haiku-4-5-20251001": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        }
+      },
+      "google-vertex": {
+        "claude-haiku-4-5@20251001": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-haiku-4-5@20251001": {
           "input": 1,
           "output": 5,
           "cache_read": 0.1,
@@ -12346,6 +12983,14 @@
     "provider": "anthropic",
     "pricing": {
       "anthropic": {
+        "claude-sonnet-4-5": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
+      "azure": {
         "claude-sonnet-4-5": {
           "input": 3,
           "output": 15,
@@ -12457,6 +13102,14 @@
     ],
     "provider": "anthropic",
     "pricing": {
+      "amazon-bedrock": {
+        "anthropic.claude-opus-4-5-20251101-v1:0": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
       "anthropic": {
         "claude-opus-4-5-20251101": {
           "input": 5,
@@ -12467,6 +13120,22 @@
       },
       "edenai": {
         "anthropic/claude-opus-4-5-20251101": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "google-vertex": {
+        "claude-opus-4-5@20251101": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-opus-4-5@20251101": {
           "input": 5,
           "output": 25,
           "cache_read": 0.5,
@@ -12589,7 +13258,23 @@
     ],
     "provider": "anthropic",
     "pricing": {
+      "amazon-bedrock": {
+        "anthropic.claude-fable-5": {
+          "input": 10,
+          "output": 50,
+          "cache_read": 1,
+          "cache_write": 12.5
+        }
+      },
       "anthropic": {
+        "claude-fable-5": {
+          "input": 10,
+          "output": 50,
+          "cache_read": 1,
+          "cache_write": 12.5
+        }
+      },
+      "azure": {
         "claude-fable-5": {
           "input": 10,
           "output": 50,
@@ -12615,6 +13300,22 @@
       },
       "edenai": {
         "anthropic/claude-fable-5": {
+          "input": 10,
+          "output": 50,
+          "cache_read": 1,
+          "cache_write": 12.5
+        }
+      },
+      "google-vertex": {
+        "claude-fable-5@default": {
+          "input": 10,
+          "output": 50,
+          "cache_read": 1,
+          "cache_write": 12.5
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-fable-5@default": {
           "input": 10,
           "output": 50,
           "cache_read": 1,
@@ -12771,6 +13472,22 @@
     ],
     "provider": "anthropic",
     "pricing": {
+      "google-vertex": {
+        "claude-sonnet-4@20250514": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-sonnet-4@20250514": {
+          "input": 3,
+          "output": 15,
+          "cache_read": 0.3,
+          "cache_write": 3.75
+        }
+      },
       "merge-gateway": {
         "anthropic/claude-sonnet-4-20250514": {
           "input": 3,
@@ -12865,6 +13582,14 @@
     "provider": "anthropic",
     "pricing": {
       "anthropic": {
+        "claude-haiku-4-5": {
+          "input": 1,
+          "output": 5,
+          "cache_read": 0.1,
+          "cache_write": 1.25
+        }
+      },
+      "azure": {
         "claude-haiku-4-5": {
           "input": 1,
           "output": 5,
@@ -13053,6 +13778,14 @@
     ],
     "provider": "anthropic",
     "pricing": {
+      "amazon-bedrock": {
+        "anthropic.claude-opus-4-6-v1": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
       "anthropic": {
         "claude-opus-4-6": {
           "input": 5,
@@ -13061,12 +13794,90 @@
           "cache_write": 6.25
         }
       },
+      "azure": {
+        "claude-opus-4-6": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 37.5,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 37.5,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
+        }
+      },
       "edenai": {
         "anthropic/claude-opus-4-6": {
           "input": 5,
           "output": 25,
           "cache_read": 0.5,
           "cache_write": 6.25
+        }
+      },
+      "google-vertex": {
+        "claude-opus-4-6@default": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 37.5,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 37.5,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-opus-4-6@default": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 37.5,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 200000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 37.5,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
         }
       },
       "impossibl": {
@@ -13363,7 +14174,23 @@
     ],
     "provider": "anthropic",
     "pricing": {
+      "amazon-bedrock": {
+        "anthropic.claude-opus-5": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
       "anthropic": {
+        "claude-opus-5": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "azure": {
         "claude-opus-5": {
           "input": 5,
           "output": 25,
@@ -13389,6 +14216,22 @@
       },
       "edenai": {
         "anthropic/claude-opus-5": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "google-vertex": {
+        "claude-opus-5@default": {
+          "input": 5,
+          "output": 25,
+          "cache_read": 0.5,
+          "cache_write": 6.25
+        }
+      },
+      "google-vertex-anthropic": {
+        "claude-opus-5@default": {
           "input": 5,
           "output": 25,
           "cache_read": 0.5,
@@ -14264,6 +15107,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-4o": {
+          "input": 2.5,
+          "output": 10,
+          "cache_read": 1.25
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-4o": {
           "input": 1.25,
@@ -14402,6 +15252,13 @@
     },
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-image-1.5": {
+          "input": 5,
+          "output": 32,
+          "cache_read": 1.25
+        }
+      },
       "vercel": {
         "openai/gpt-image-1.5": {
           "input": 5,
@@ -14500,6 +15357,13 @@
     },
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5-nano": {
+          "input": 0.05,
+          "output": 0.4,
+          "cache_read": 0.01
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-5-nano": {
           "input": 0.05,
@@ -14681,6 +15545,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-4o-mini": {
+          "input": 0.15,
+          "output": 0.6,
+          "cache_read": 0.075
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-4o-mini": {
           "input": 0.075,
@@ -15461,6 +16332,12 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-4-turbo": {
+          "input": 10,
+          "output": 30
+        }
+      },
       "edenai": {
         "openai/gpt-4-turbo": {
           "input": 10,
@@ -15826,6 +16703,32 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.6-sol": {
+          "input": 5,
+          "output": 30,
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 45,
+              "cache_read": 1,
+              "cache_write": 12.5,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 45,
+            "cache_read": 1,
+            "cache_write": 12.5
+          }
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-5.6-sol": {
           "input": 2,
@@ -16352,6 +17255,26 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.4-pro": {
+          "input": 30,
+          "output": 180,
+          "tiers": [
+            {
+              "input": 60,
+              "output": 270,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 60,
+            "output": 270
+          }
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-5.4-pro": {
           "input": 30,
@@ -16595,6 +17518,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.13
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-5": {
           "input": 1.25,
@@ -16767,6 +17697,13 @@
     },
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.1-codex-mini": {
+          "input": 0.25,
+          "output": 2,
+          "cache_read": 0.025
+        }
+      },
       "impossibl": {
         "openai/gpt-5.1-codex-mini": {
           "input": 0.25,
@@ -16911,6 +17848,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5-codex": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.13
+        }
+      },
       "impossibl": {
         "openai/gpt-5-codex": {
           "input": 1.25,
@@ -16984,6 +17928,13 @@
     },
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5-mini": {
+          "input": 0.25,
+          "output": 2,
+          "cache_read": 0.03
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-5-mini": {
           "input": 0.25,
@@ -17253,6 +18204,32 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.6-luna": {
+          "input": 0.2,
+          "output": 1.2,
+          "cache_read": 0.02,
+          "cache_write": 0.25,
+          "tiers": [
+            {
+              "input": 0.4,
+              "output": 1.8,
+              "cache_read": 0.04,
+              "cache_write": 0.5,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 0.4,
+            "output": 1.8,
+            "cache_read": 0.04,
+            "cache_write": 0.5
+          }
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-5.6-luna": {
           "input": 0.2,
@@ -17576,6 +18553,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.3-codex": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        }
+      },
       "edenai": {
         "openai/gpt-5.3-codex": {
           "input": 1.75,
@@ -17744,6 +18728,12 @@
       },
       "aiand": {
         "openai/gpt-oss-120b": {
+          "input": 0.15,
+          "output": 0.6
+        }
+      },
+      "amazon-bedrock": {
+        "openai.gpt-oss-120b": {
           "input": 0.15,
           "output": 0.6
         }
@@ -18047,6 +19037,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-4.1-nano": {
+          "input": 0.1,
+          "output": 0.4,
+          "cache_read": 0.025
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-4.1-nano": {
           "input": 0.1,
@@ -18195,6 +19192,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "o1": {
+          "input": 15,
+          "output": 60,
+          "cache_read": 7.5
+        }
+      },
       "edenai": {
         "openai/o1": {
           "input": 15,
@@ -18326,6 +19330,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.2": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.125
+        }
+      },
       "edenai": {
         "openai/gpt-5.2": {
           "input": 1.75,
@@ -18489,6 +19500,13 @@
     },
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-image-1": {
+          "input": 5,
+          "output": 40,
+          "cache_read": 1.25
+        }
+      },
       "vercel": {
         "openai/gpt-image-1": {
           "input": 5,
@@ -18731,6 +19749,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.4-mini": {
+          "input": 0.75,
+          "output": 4.5,
+          "cache_read": 0.075
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-5.4-mini": {
           "input": 0.75,
@@ -19027,6 +20052,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "o3": {
+          "input": 2,
+          "output": 8,
+          "cache_read": 0.5
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/o3": {
           "input": 2,
@@ -19208,6 +20240,12 @@
     },
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5-pro": {
+          "input": 15,
+          "output": 120
+        }
+      },
       "edenai": {
         "openai/gpt-5-pro": {
           "input": 15,
@@ -19573,6 +20611,29 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.5": {
+          "input": 5,
+          "output": 30,
+          "cache_read": 0.5,
+          "tiers": [
+            {
+              "input": 10,
+              "output": 45,
+              "cache_read": 1,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 10,
+            "output": 45,
+            "cache_read": 1
+          }
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-5.5": {
           "input": 5,
@@ -20023,6 +21084,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.2-codex": {
+          "input": 1.75,
+          "output": 14,
+          "cache_read": 0.175
+        }
+      },
       "impossibl": {
         "openai/gpt-5.2-codex": {
           "input": 1.75,
@@ -20154,6 +21222,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-4.1": {
+          "input": 2,
+          "output": 8,
+          "cache_read": 0.5
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-4.1": {
           "input": 2,
@@ -20538,6 +21613,32 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.6-terra": {
+          "input": 2,
+          "output": 12,
+          "cache_read": 0.2,
+          "cache_write": 2.5,
+          "tiers": [
+            {
+              "input": 4,
+              "output": 18,
+              "cache_read": 0.4,
+              "cache_write": 5,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 4,
+            "output": 18,
+            "cache_read": 0.4,
+            "cache_write": 5
+          }
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-5.6-terra": {
           "input": 2,
@@ -20845,6 +21946,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "o4-mini": {
+          "input": 1.1,
+          "output": 4.4,
+          "cache_read": 0.275
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/o4-mini": {
           "input": 1.1,
@@ -21179,6 +22287,29 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.4": {
+          "input": 2.5,
+          "output": 15,
+          "cache_read": 0.25,
+          "tiers": [
+            {
+              "input": 5,
+              "output": 22.5,
+              "cache_read": 0.5,
+              "tier": {
+                "type": "context",
+                "size": 272000
+              }
+            }
+          ],
+          "context_over_200k": {
+            "input": 5,
+            "output": 22.5,
+            "cache_read": 0.5
+          }
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-5.4": {
           "input": 2.5,
@@ -21519,6 +22650,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "o3-mini": {
+          "input": 1.1,
+          "output": 4.4,
+          "cache_read": 0.55
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/o3-mini": {
           "input": 1.1,
@@ -21791,6 +22929,12 @@
     ],
     "provider": "openai",
     "pricing": {
+      "amazon-bedrock": {
+        "openai.gpt-oss-safeguard-120b": {
+          "input": 0.15,
+          "output": 0.6
+        }
+      },
       "merge-gateway": {
         "openai/gpt-oss-safeguard-120b": {
           "input": 0.15,
@@ -22067,6 +23211,13 @@
     },
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-image-2": {
+          "input": 5,
+          "output": 30,
+          "cache_read": 1.25
+        }
+      },
       "openai": {
         "gpt-image-2": {
           "input": 5,
@@ -22139,6 +23290,13 @@
     },
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.1-codex-max": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        }
+      },
       "kilo": {
         "openai/gpt-5.1-codex-max": {
           "input": 1.25,
@@ -22247,6 +23405,13 @@
     },
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.1-codex": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        }
+      },
       "impossibl": {
         "openai/gpt-5.1-codex": {
           "input": 1.25,
@@ -22372,6 +23537,13 @@
     "pricing": {
       "aixy": {
         "openai/gpt-4.1-mini": {
+          "input": 0.4,
+          "output": 1.6,
+          "cache_read": 0.1
+        }
+      },
+      "azure": {
+        "gpt-4.1-mini": {
           "input": 0.4,
           "output": 1.6,
           "cache_read": 0.1
@@ -22526,6 +23698,12 @@
     ],
     "provider": "openai",
     "pricing": {
+      "amazon-bedrock": {
+        "openai.gpt-oss-20b": {
+          "input": 0.07,
+          "output": 0.3
+        }
+      },
       "deepinfra": {
         "openai/gpt-oss-20b": {
           "input": 0.03,
@@ -22897,6 +24075,13 @@
     ],
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.4-nano": {
+          "input": 0.2,
+          "output": 1.25,
+          "cache_read": 0.02
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-5.4-nano": {
           "input": 0.2,
@@ -23083,6 +24268,13 @@
     },
     "provider": "openai",
     "pricing": {
+      "azure": {
+        "gpt-5.1": {
+          "input": 1.25,
+          "output": 10,
+          "cache_read": 0.125
+        }
+      },
       "cloudflare-ai-gateway": {
         "openai/gpt-5.1": {
           "input": 1.25,
@@ -26443,6 +27635,12 @@
           "output": 2.8,
           "reasoning": 8.4
         }
+      },
+      "amazon-bedrock": {
+        "qwen.qwen3-32b-v1:0": {
+          "input": 0.15,
+          "output": 0.6
+        }
       }
     },
     "openrouter": {
@@ -27075,6 +28273,12 @@
     ],
     "provider": "alibaba",
     "pricing": {
+      "amazon-bedrock": {
+        "qwen.qwen3-coder-next": {
+          "input": 0.22,
+          "output": 1.8
+        }
+      },
       "vercel": {
         "alibaba/qwen3-coder-next": {
           "input": 0.5,
@@ -30461,6 +31665,12 @@
     ],
     "provider": "zhipuai",
     "pricing": {
+      "amazon-bedrock": {
+        "zai.glm-5": {
+          "input": 1,
+          "output": 3.2
+        }
+      },
       "zhipuai": {
         "glm-5": {
           "input": 1,
@@ -32683,6 +33893,12 @@
     ],
     "provider": "mistral",
     "pricing": {
+      "azure": {
+        "mistral-medium-2505": {
+          "input": 0.4,
+          "output": 2
+        }
+      },
       "edenai": {
         "mistral/mistral-medium-2505": {
           "input": 0.4,

--- a/src/prerna/reactor/model/ListStaticModelCatalogReactor.java
+++ b/src/prerna/reactor/model/ListStaticModelCatalogReactor.java
@@ -1,0 +1,95 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.model;
+
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import prerna.reactor.AbstractReactor;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+import prerna.util.StaticBuiltinToolsCatalog;
+import prerna.util.StaticModelMetadataCatalog;
+
+public class ListStaticModelCatalogReactor extends AbstractReactor {
+
+	static final String SERVING_PROVIDER_KEY = "servingProvider";
+
+	/**
+	 * Serving hosts the Add Model page has an import form for, in normalized
+	 * form. Azure is deliberately absent - the catalog's pricing never lists it
+	 * as a host and Azure imports are deployment-name based anyway.
+	 */
+	private static final Set<String> DEFAULT_SERVING_PROVIDERS = new LinkedHashSet<>(
+			List.of("openai", "anthropic", "google", "bedrock", "nvidia", "perplexity"));
+
+	public ListStaticModelCatalogReactor() {
+		this.keysToGet = new String[] { SERVING_PROVIDER_KEY };
+		this.keyRequired = new int[] { 0 };
+	}
+
+	@Override
+	public NounMetadata execute() {
+		organizeKeys();
+
+		Set<String> hosts = DEFAULT_SERVING_PROVIDERS;
+		String servingProvider = this.keyValue.get(SERVING_PROVIDER_KEY);
+		if (servingProvider != null && !servingProvider.trim().isEmpty()) {
+			String normalized = StaticBuiltinToolsCatalog.normalizeProviderKey(servingProvider);
+			if (normalized == null) {
+				throw new IllegalArgumentException("Unrecognized serving provider: " + servingProvider);
+			}
+			hosts = new LinkedHashSet<>(List.of(normalized));
+		}
+
+		Map<String, List<Map<String, Object>>> modelsByHost = StaticModelMetadataCatalog
+				.listImportableModels(getMetadataFile(), hosts);
+		return new NounMetadata(modelsByHost, PixelDataType.MAP);
+	}
+
+	Path getMetadataFile() {
+		return StaticModelMetadataCatalog.getMetadataFile();
+	}
+
+	@Override
+	public String getReactorDescription() {
+		return "Lists the meta/model.json catalog models importable through each connectable serving provider, "
+				+ "keyed by normalized provider (openai, anthropic, google, bedrock, nvidia, perplexity)";
+	}
+
+	@Override
+	protected String getDescriptionForKey(String key) {
+		if (key.equals(SERVING_PROVIDER_KEY)) {
+			return "Optional serving provider to list models for; omit to list all connectable providers";
+		}
+		return super.getDescriptionForKey(key);
+	}
+}

--- a/src/prerna/util/StaticModelMetadataCatalog.java
+++ b/src/prerna/util/StaticModelMetadataCatalog.java
@@ -427,6 +427,13 @@ public final class StaticModelMetadataCatalog {
 			return modelsByHost;
 		}
 
+		// several catalog hosts can normalize to one provider (google and
+		// google-vertex both serve gemini), so drop repeat model ids per host
+		Map<String, Set<String>> seenByHost = new LinkedHashMap<>();
+		for (String host : normalizedHosts) {
+			seenByHost.put(host, new LinkedHashSet<>());
+		}
+
 		JsonObject allMetadata = loadMetadata(metadataFile);
 		for (Map.Entry<String, JsonElement> catalogEntry : allMetadata.entrySet()) {
 			if (!catalogEntry.getValue().isJsonObject()) {
@@ -453,6 +460,9 @@ public final class StaticModelMetadataCatalog {
 					continue;
 				}
 				for (String servingModelId : ratesByModelId.keySet()) {
+					if (!seenByHost.get(normalized).add(servingModelId)) {
+						continue;
+					}
 					Map<String, Object> entry = new LinkedHashMap<>();
 					entry.put("key", catalogEntry.getKey());
 					entry.put("modelId", servingModelId);

--- a/src/prerna/util/StaticModelMetadataCatalog.java
+++ b/src/prerna/util/StaticModelMetadataCatalog.java
@@ -105,6 +105,17 @@ public final class StaticModelMetadataCatalog {
 			.comparingDouble((Map<String, Object> match) -> ((Number) match.get(MATCH_SCORE)).doubleValue()).reversed()
 			.thenComparing(match -> String.valueOf(match.get(MATCH_KEY)), String.CASE_INSENSITIVE_ORDER);
 
+	/**
+	 * Token limits below this are the catalog's 0/1 "unknown" placeholders, not
+	 * real values, and must not become form defaults.
+	 */
+	private static final long MINIMUM_REAL_TOKEN_LIMIT = 2;
+
+	private static final Comparator<Map<String, Object>> IMPORTABLE_MODEL_ORDER = Comparator
+			.comparing((Map<String, Object> entry) -> String.valueOf(entry.getOrDefault("releaseDate", "")),
+					Comparator.reverseOrder())
+			.thenComparing(entry -> String.valueOf(entry.get("modelId")), String.CASE_INSENSITIVE_ORDER);
+
 	private static volatile MetadataCache metadataCache;
 
 	private StaticModelMetadataCatalog() {
@@ -387,6 +398,85 @@ public final class StaticModelMetadataCatalog {
 		List<String> catalogKeys = new ArrayList<>(loadMetadata(metadataFile).keySet());
 		catalogKeys.sort(String.CASE_INSENSITIVE_ORDER);
 		return catalogKeys;
+	}
+
+	/**
+	 * The catalog models importable through each of the requested serving
+	 * providers, keyed by the normalized provider key the caller asked for (see
+	 * {@link StaticBuiltinToolsCatalog#normalizeProviderKey(String)}). A model is
+	 * listed under a provider when the catalog's pricing object names that
+	 * provider as a serving host - the pricing entry's inner key is the exact
+	 * model id that host serves, which is what an import form needs to submit.
+	 * <p>
+	 * Only text-output models are returned; image/video/embedding entries are
+	 * curated by hand where they are supported at all. Token limits are dropped
+	 * when the catalog holds a 0/1 placeholder rather than a real value. Entries
+	 * are sorted newest release first. Hosts with no catalog models map to an
+	 * empty list so the caller can tell "no models" from "unknown host".
+	 */
+	public static Map<String, List<Map<String, Object>>> listImportableModels(Path metadataFile,
+			Set<String> normalizedHosts) {
+		Map<String, List<Map<String, Object>>> modelsByHost = new LinkedHashMap<>();
+		if (normalizedHosts == null || normalizedHosts.isEmpty()) {
+			return modelsByHost;
+		}
+		for (String host : normalizedHosts) {
+			modelsByHost.put(host, new ArrayList<>());
+		}
+		if (!Files.isRegularFile(metadataFile)) {
+			return modelsByHost;
+		}
+
+		JsonObject allMetadata = loadMetadata(metadataFile);
+		for (Map.Entry<String, JsonElement> catalogEntry : allMetadata.entrySet()) {
+			if (!catalogEntry.getValue().isJsonObject()) {
+				continue;
+			}
+			JsonObject model = catalogEntry.getValue().getAsJsonObject();
+			JsonObject modalities = getObject(model, "modalities");
+			List<String> outputModalities = getStringList(modalities, "output");
+			if (!outputModalities.contains("text")) {
+				continue;
+			}
+			JsonObject pricing = getObject(model, "pricing");
+			if (pricing == null) {
+				continue;
+			}
+			for (String servingKey : pricing.keySet()) {
+				String normalized = StaticBuiltinToolsCatalog.normalizeProviderKey(servingKey);
+				List<Map<String, Object>> hostModels = normalized == null ? null : modelsByHost.get(normalized);
+				if (hostModels == null) {
+					continue;
+				}
+				JsonObject ratesByModelId = getObject(pricing, servingKey);
+				if (ratesByModelId == null) {
+					continue;
+				}
+				for (String servingModelId : ratesByModelId.keySet()) {
+					Map<String, Object> entry = new LinkedHashMap<>();
+					entry.put("key", catalogEntry.getKey());
+					entry.put("modelId", servingModelId);
+					putString(entry, "name", model, "name");
+					putString(entry, "description", model, "description");
+					putString(entry, "family", model, "family");
+					putString(entry, "provider", model, "provider");
+					putString(entry, "releaseDate", model, "release_date");
+					JsonObject limit = getObject(model, "limit");
+					putLong(entry, "contextLimit", limit, "context", MINIMUM_REAL_TOKEN_LIMIT);
+					putLong(entry, "outputLimit", limit, "output", MINIMUM_REAL_TOKEN_LIMIT);
+					entry.put("inputModalities", getStringList(modalities, "input"));
+					entry.put("outputModalities", outputModalities);
+					putBoolean(entry, "reasoning", model, "reasoning");
+					putBoolean(entry, "toolCall", model, "tool_call");
+					hostModels.add(entry);
+				}
+			}
+		}
+
+		for (List<Map<String, Object>> hostModels : modelsByHost.values()) {
+			hostModels.sort(IMPORTABLE_MODEL_ORDER);
+		}
+		return modelsByHost;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The Add Model page's cards have been hardcoded in the frontend, so every new model release
meant a manual FE edit. This PR exposes `meta/model.json` as the source of truth for
importable models per serving provider, and fixes the catalog data itself so first-party
hosts (Google Vertex, AWS Bedrock, Azure) are no longer dropped. The companion SemossWeb PR
consumes this to render model cards dynamically.

## What changed

### New pixel: `ListStaticModelCatalog(servingProvider=[...])`
- `prerna.reactor.model.ListStaticModelCatalogReactor` — lists the catalog models importable
  through each connectable serving provider, keyed by normalized provider
  (`openai`, `anthropic`, `google`, `bedrock`, `nvidia`, `perplexity`).
- `servingProvider` is optional; omitted = all of the above. Registered by the normal
  classpath scan.

### `StaticModelMetadataCatalog.listImportableModels(...)`
New read-only view over the catalog:
- A model is listed under a provider when its `pricing` object names that host — the pricing
  entry's **inner key is the exact model id that host serves** (e.g. Vertex
  `claude-sonnet-5@default`, Bedrock `anthropic.claude-sonnet-5`), which is what the import
  form needs to submit.
- Text-output models only (image/video/embedding entries stay hand-curated in the FE).
- Token limits are omitted when the catalog holds a `0`/`1` placeholder, so they can't
  become one-token form defaults.
- Per-host model-id dedup — `google` and `google-vertex` both normalize to `google` and would
  otherwise double-list every Gemini model.
- Entries sorted newest `release_date` first; each carries
  `key, modelId, name, description, family, provider, releaseDate, contextLimit, outputLimit,
  inputModalities, outputModalities, reasoning, toolCall`.

### Regenerated `meta/model.json` (363 models)
Generated by the or-metadata pipeline. The pipeline's merge step previously attached serving
pricing only when a host's model id was *verbatim* a canonical id, which silently dropped all
first-party host dialects:
- `google-vertex` (`claude-opus-5@default`) — 0/43 offerings attached
- `amazon-bedrock` (`anthropic.claude-opus-5`) — only 4 grafted `amazon.nova*` of 120
- `azure` (bare `claude-opus-5`) — 0/84

The pipeline now maps these three dialects with deterministic leaf transforms (strip `@date`/
`@default`, `vendor.` prefixes, `-v1:0` suffixes) against a unique-leaf lookup — ambiguous
matches are still refused, no fuzzy guessing. Result: Vertex 33/43, Bedrock 23/120, Azure
55/84 attached. Region-prefixed Bedrock inference profiles (`us.`, `eu.`, `global.`, ...) are
skipped deliberately: they duplicate the base model id. Every remaining unmatched Claude
offering is a region profile (verified).

## Notes

- `meta/model.json` hot-reloads on file replace (mtime+size cache) — updating the catalog on
  a running server refreshes the import page with **no redeploy and no FE build**.
- Azure pricing is now attached in the data (also feeds the MODELMETADATA `PRICING` column)
  but is not listed by the reactor — Azure imports are deployment-name based.