### PR TITLE
Compilation fix modality enforcer

### DIFF
--- a/src/prerna/engine/impl/model/message/MessageInputMedia.java
+++ b/src/prerna/engine/impl/model/message/MessageInputMedia.java
@@ -27,6 +27,7 @@
  *******************************************************************************/
 package prerna.engine.impl.model.message;
 
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -170,7 +171,8 @@ public class MessageInputMedia {
 		if (fragmentStart >= 0) {
 			url = url.substring(0, fragmentStart);
 		}
-		return MimeTypeUtility.detectMimeTypeFromName(url);
+		String detected = MimeTypeUtility.detectMimeType(new ByteArrayInputStream(new byte[0]), url);
+		return detected == null || MimeTypeUtility.DEFAULT_MIME_TYPE.equals(detected) ? null : detected;
 	}
 
 	public String getSourceUrl() {

--- a/src/prerna/engine/impl/model/message/MessageInputMedia.java
+++ b/src/prerna/engine/impl/model/message/MessageInputMedia.java
@@ -170,8 +170,7 @@ public class MessageInputMedia {
 		if (fragmentStart >= 0) {
 			url = url.substring(0, fragmentStart);
 		}
-		String detected = new Tika().detect(url);
-		return detected == null || "application/octet-stream".equals(detected) ? null : detected;
+		return MimeTypeUtility.detectMimeTypeFromName(url);
 	}
 
 	public String getSourceUrl() {

--- a/src/prerna/util/MimeTypeUtility.java
+++ b/src/prerna/util/MimeTypeUtility.java
@@ -154,35 +154,6 @@ public class MimeTypeUtility {
 	}
 
 	/**
-	 * Detect the mime type from a file or URL name alone, without reading any
-	 * contents. Useful for remote media where only the name is available.
-	 *
-	 * @param name a file name, path, or URL
-	 * @return the base mime type, or null when the name has no recognized
-	 *         extension
-	 */
-	public static String detectMimeTypeFromName(String name) {
-		if (name == null || name.isBlank()) {
-			return null;
-		}
-		Metadata metadata = new Metadata();
-		metadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, name);
-		try {
-			TikaConfig config = TikaConfig.getDefaultConfig();
-			// a null stream restricts detection to the resource name hint
-			MediaType mediaType = config.getDetector().detect(null, metadata);
-			if (mediaType == null) {
-				return null;
-			}
-			String baseType = mediaType.getBaseType().toString();
-			return DEFAULT_MIME_TYPE.equals(baseType) ? null : baseType;
-		} catch (IOException e) {
-			classLogger.error(Constants.ERROR_MESSAGE, e);
-			return null;
-		}
-	}
-
-	/**
 	 * Detect the mime type of a file and fall back to the file format when the
 	 * contents of the file cannot be read
 	 *

--- a/src/prerna/util/MimeTypeUtility.java
+++ b/src/prerna/util/MimeTypeUtility.java
@@ -154,9 +154,38 @@ public class MimeTypeUtility {
 	}
 
 	/**
+	 * Detect the mime type from a file or URL name alone, without reading any
+	 * contents. Useful for remote media where only the name is available.
+	 *
+	 * @param name a file name, path, or URL
+	 * @return the base mime type, or null when the name has no recognized
+	 *         extension
+	 */
+	public static String detectMimeTypeFromName(String name) {
+		if (name == null || name.isBlank()) {
+			return null;
+		}
+		Metadata metadata = new Metadata();
+		metadata.add(TikaCoreProperties.RESOURCE_NAME_KEY, name);
+		try {
+			TikaConfig config = TikaConfig.getDefaultConfig();
+			// a null stream restricts detection to the resource name hint
+			MediaType mediaType = config.getDetector().detect(null, metadata);
+			if (mediaType == null) {
+				return null;
+			}
+			String baseType = mediaType.getBaseType().toString();
+			return DEFAULT_MIME_TYPE.equals(baseType) ? null : baseType;
+		} catch (IOException e) {
+			classLogger.error(Constants.ERROR_MESSAGE, e);
+			return null;
+		}
+	}
+
+	/**
 	 * Detect the mime type of a file and fall back to the file format when the
 	 * contents of the file cannot be read
-	 * 
+	 *
 	 * @param filePath
 	 * @param format   the file extension, i.e. png, jpeg
 	 * @return the base mime type, never null


### PR DESCRIPTION
## Description

Fixes a compilation error from the merge of #2896 (input modality enforcement) and #2910 (media tool response). #2910 consolidated MIME detection into `MimeTypeUtility` and removed the direct Tika imports from `MessageInputMedia`, stranding a `new Tika().detect(url)` call in #2896's `resolveMimeType()`.

## Changes Made

- `MessageInputMedia.resolveMimeType()` now uses the existing `MimeTypeUtility.detectMimeType(InputStream, fileName)` with an empty stream, so the detector falls back to name-based (extension) detection without fetching the URL. `application/octet-stream` results are treated as unknown, preserving the fail-open behavior for unclassifiable URLs.
