### PR TITLE
fix: proper method signature of askRoom, guardrail pipeline fixes 

### DIFF
--- a/src/prerna/auth/utils/SecurityEngineUtils.java
+++ b/src/prerna/auth/utils/SecurityEngineUtils.java
@@ -524,6 +524,42 @@ public class SecurityEngineUtils extends AbstractSecurityUtils {
 	}
 
 	/**
+	 * Initialize an engine's markdown metadata without replacing existing content.
+	 *
+	 * @param engineId        engine whose metadata should be initialized
+	 * @param defaultMarkdown markdown supplied by the engine implementation
+	 */
+	public static void setDefaultEngineMarkdown(String engineId, String defaultMarkdown) {
+		if (defaultMarkdown == null || defaultMarkdown.trim().isEmpty()) {
+			return;
+		}
+
+		Map<String, Object> metadata = getAggregateEngineMetadata(engineId, List.of(Constants.MARKDOWN), false);
+		if (hasMetadataValue(metadata.get(Constants.MARKDOWN))) {
+			return;
+		}
+
+		Map<String, Object> defaultMetadata = new HashMap<>();
+		defaultMetadata.put(Constants.MARKDOWN, defaultMarkdown);
+		updateEngineMetadata(engineId, defaultMetadata);
+	}
+
+	private static boolean hasMetadataValue(Object value) {
+		if (value == null) {
+			return false;
+		}
+		if (value instanceof Collection) {
+			for (Object item : (Collection<?>) value) {
+				if (hasMetadataValue(item)) {
+					return true;
+				}
+			}
+			return false;
+		}
+		return !value.toString().trim().isEmpty();
+	}
+
+	/**
 	 * Get the engine permissions for a specific user
 	 * 
 	 * @param singleUserId

--- a/src/prerna/engine/api/IGuardrailReactorFunctionEngine.java
+++ b/src/prerna/engine/api/IGuardrailReactorFunctionEngine.java
@@ -27,6 +27,7 @@
  *******************************************************************************/
 package prerna.engine.api;
 
+import prerna.logging.IgnoreEngineLogging;
 import prerna.reactor.IReactor;
 import prerna.sablecc2.om.GenRowStruct;
 import prerna.sablecc2.om.NounStore;
@@ -43,6 +44,17 @@ public interface IGuardrailReactorFunctionEngine extends IReactor, IFunctionEngi
 	 * @return
 	 */
 	GuardrailTypeEnum getGuardrailType();
+
+	/**
+	 * Markdown that explains and demonstrates this guardrail. Creation flows may
+	 * use it to initialize empty engine metadata without replacing user content.
+	 *
+	 * @return default markdown, or null when the guardrail has no example
+	 */
+	@IgnoreEngineLogging
+	default String getDefaultMarkdown() {
+		return null;
+	}
 
 	/**
 	 * 

--- a/src/prerna/engine/api/IModelEngine.java
+++ b/src/prerna/engine/api/IModelEngine.java
@@ -32,6 +32,7 @@ import java.util.Map;
 
 import prerna.engine.impl.model.Room;
 import prerna.engine.impl.model.message.AbstractMessage;
+import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.responses.AskModelEngineResponse;
 import prerna.engine.impl.model.responses.BatchListResponse;
 import prerna.engine.impl.model.responses.BatchResultsResponse;
@@ -47,17 +48,6 @@ public interface IModelEngine extends IEngine {
 	// this is what the FE sends for the type of storage we are creating
 	// as a result, cannot be a key in the smss file
 	String MODEL_TYPE = "MODEL_TYPE";
-
-	// main class that is responsible for controlling everything models
-	// hosting modes - embedded, inference_engine, FastChat, OpenAI
-	// start server
-	// connect client
-	// disconnect client
-	// stop server ?
-
-	// reactors
-	// ModelDeployMatchFinder - finds it based on GPU memory etc.
-	// StopModel
 
 	/**
 	 * Gets the type of the model inference engine. The model engine type is often
@@ -89,23 +79,20 @@ public interface IModelEngine extends IEngine {
 	AskModelEngineResponse ask(String question, String context, Insight insight, Map<String, Object> parameters);
 
 	/**
-	 * Passes the string question along with other parameters such as context and
-	 * temperature to the python client and
+	 * Sends an input message to the model in the context of a room.
 	 * 
-	 * @param question   The question being asked to the LLM
-	 * @param context    (Optional) The context passed in by the user
-	 * @param room       The room from where the call is being made. The room holder
-	 *                   the insight and user, along with other room properties like
-	 *                   tools, vec dbs, system prompts.
-	 * @param parameters Additional parameters such as temperature, top_k,
-	 *                   max_new_tokens etc
+	 * @param inputMessage The message being sent to the LLM
+	 * @param room         The room from where the call is being made. The room
+	 *                     holder the insight and user, along with other room
+	 *                     properties like tools, vec dbs, system prompts.
+	 * @param parameters   Additional parameters such as temperature, top_k,
+	 *                     max_new_tokens etc
 	 * @return creates a map response with the following keys - response : The
 	 *         actual string response from the LLM/model - messageId : The unique
 	 *         identifier of a message (the user's input and the model response) -
 	 *         roomId: The insightId that the runPixel endpoint is being called from
 	 */
-	AskModelEngineResponse askRoom(String question, Room room, AbstractMessage inputMessage,
-			Map<String, Object> parameters);
+	AskModelEngineResponse askRoom(InputMessage inputMessage, Room room, Map<String, Object> parameters);
 
 	/**
 	 * Validate that the given outbound messages only carry media this model's
@@ -113,9 +100,9 @@ public interface IModelEngine extends IEngine {
 	 * outside the askRoom flow (batch submission, routing) invoke this with the
 	 * exact message list they are about to serialize.
 	 *
-	 * This is a no-op by default. Engines backed by MODELMETADATA input
-	 * modalities throw IllegalArgumentException when a message carries media of
-	 * a disallowed modality.
+	 * This is a no-op by default. Engines backed by MODELMETADATA input modalities
+	 * throw IllegalArgumentException when a message carries media of a disallowed
+	 * modality.
 	 *
 	 * @param outboundMessages the messages about to be sent to the provider
 	 */
@@ -140,16 +127,18 @@ public interface IModelEngine extends IEngine {
 	/**
 	 * Passes text, image, and/or video inputs to the model client to be embedded
 	 * together. Unlike {@link #embeddings}, the result is broken out by modality so
-	 * each returned embedding (and any per-input error) lines up with the input that
-	 * produced it.
+	 * each returned embedding (and any per-input error) lines up with the input
+	 * that produced it.
 	 *
 	 * This is an optional capability. Engines whose underlying client does not
 	 * implement multi modal embeddings inherit this default, which reports that the
 	 * operation is not implemented rather than throwing.
 	 *
 	 * @param text       Text string(s) to embed. May be null/empty.
-	 * @param image      Image input(s) to embed - base64, data URL, or remote URL. May be null/empty.
-	 * @param video      Video input(s) to embed - base64, data URL, or remote URL. May be null/empty.
+	 * @param image      Image input(s) to embed - base64, data URL, or remote URL.
+	 *                   May be null/empty.
+	 * @param video      Video input(s) to embed - base64, data URL, or remote URL.
+	 *                   May be null/empty.
 	 * @param insight    The insight from where the call is being made.
 	 * @param parameters Additional parameters passed through to the model client.
 	 * @return The embeddings response broken out by modality.
@@ -197,7 +186,8 @@ public interface IModelEngine extends IEngine {
 	 *
 	 * @param requests   each entry is {@code {custom_id, body}} where body is the
 	 *                   provider-native per-request payload
-	 * @param parameters optional submission params (e.g. completion_window, endpoint)
+	 * @param parameters optional submission params (e.g. completion_window,
+	 *                   endpoint)
 	 * @return the provider batch id and initial status
 	 */
 	default BatchSubmissionResponse submitBatch(List<Map<String, Object>> requests, Map<String, Object> parameters) {

--- a/src/prerna/engine/impl/guardrail/AggressiveSelfHarmGuardrailEngine.java
+++ b/src/prerna/engine/impl/guardrail/AggressiveSelfHarmGuardrailEngine.java
@@ -27,158 +27,103 @@
  *******************************************************************************/
 package prerna.engine.impl.guardrail;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.util.UUID;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import prerna.engine.api.GuardrailTypeEnum;
-import prerna.engine.api.IModelEngine;
-import prerna.engine.impl.function.FunctionParameter;
-import prerna.engine.impl.model.Room;
-import prerna.engine.impl.model.RoomUtils;
-import prerna.engine.impl.model.message.InputMessage;
-import prerna.engine.impl.model.message.ResponseMessage;
-import prerna.om.Insight;
-import prerna.om.InsightStore;
-import prerna.om.ThreadStore;
-import prerna.sablecc2.om.GenRowStruct;
-import prerna.sablecc2.om.NounStore;
-import prerna.sablecc2.om.nounmeta.GuardrailNounMetadata;
-import prerna.util.Utility;
 
 /**
  * Guardrail that detects aggressive or self-harm content by calling a
  * configured LLM with a classification system prompt. The model is expected to
- * respond with a single word — {@code SAFE} or {@code UNSAFE}.
+ * respond with a single word - {@code SAFE} or {@code UNSAFE}.
  *
- * <p>Required SMSS keys:
+ * <p>
+ * Required SMSS keys:
  * <ul>
- *   <li>{@code MODEL_ENGINE_ID} — engine ID of the LLM to use for classification</li>
+ * <li>{@code MODEL_ENGINE_ID} - engine ID of the LLM to use for
+ * classification</li>
  * </ul>
  * Optional SMSS keys:
  * <ul>
- *   <li>{@code SYSTEM_PROMPT} — override the default classification instruction</li>
- *   <li>{@code BLOCKED_MESSAGE} — override the default message returned when UNSAFE</li>
+ * <li>{@code SYSTEM_PROMPT} - override the default classification
+ * instruction</li>
+ * <li>{@code BLOCKED_MESSAGE} - override the default message returned when
+ * UNSAFE</li>
+ * <li>{@code FAIL_OPEN} - allow the guarded call when the judge errors;
+ * defaults to false</li>
  * </ul>
  */
-public class AggressiveSelfHarmGuardrailEngine extends AbstractGuardrailReactorFunctionEngine {
+public class AggressiveSelfHarmGuardrailEngine extends PromptGuardrailEngine {
 
-	private static final Logger classLogger = LogManager.getLogger(AggressiveSelfHarmGuardrailEngine.class);
+	private static final String DEFAULT_SYSTEM_PROMPT = """
+			You are a content safety classifier. Your sole task is to detect whether a user message expresses first-person intent to harm themselves or others, suicidal ideation, or aggressive threats.
 
-	public static final String MODEL_ENGINE_ID_KEY = "MODEL_ENGINE_ID";
-	public static final String SYSTEM_PROMPT_KEY = "SYSTEM_PROMPT";
-	public static final String BLOCKED_MESSAGE_KEY = "BLOCKED_MESSAGE";
+			Respond with ONLY one word:
+			- UNSAFE if the message expresses a wish or intent to hurt oneself (e.g. 'I want to hurt myself', 'I want to end my life', 'I hate myself and want to disappear'), threatens violence toward others, or contains aggressive language directed at a person
+			- SAFE for everything else, including clinical descriptions of past self-harm, third-party reports, or general medical questions
 
-	private static final String DEFAULT_SYSTEM_PROMPT =
-			"You are a content safety classifier. Your sole task is to detect whether a user message "
-			+ "expresses first-person intent to harm themselves or others, suicidal ideation, or aggressive threats.\n\n"
-			+ "Respond with ONLY one word:\n"
-			+ "- UNSAFE if the message expresses a wish or intent to hurt oneself (e.g. 'I want to hurt myself', "
-			+ "'I want to end my life', 'I hate myself and want to disappear'), threatens violence toward others, "
-			+ "or contains aggressive language directed at a person\n"
-			+ "- SAFE   for everything else, including clinical descriptions of past self-harm, "
-			+ "third-party reports, or general medical questions\n\n"
-			+ "Do not explain your reasoning. Output only SAFE or UNSAFE.";
+			Do not explain your reasoning. Output only SAFE or UNSAFE.
+			""";
 
-	private static final String DEFAULT_BLOCKED_MESSAGE =
-			"I'm sorry, I'm not able to help with that. If you or someone you know is in crisis, "
-			+ "please call or text 988 to reach the Suicide & Crisis Lifeline, or call 911 for immediate emergency assistance.";
+	private static final String DEFAULT_BLOCKED_MESSAGE = "I'm sorry, I'm not able to help with that. If you or "
+			+ "someone you know is in crisis, please call or text 988 to reach the Suicide & Crisis Lifeline, or call "
+			+ "911 for immediate emergency assistance.";
 
-	private String modelEngineId;
-	private String systemPrompt;
-	private String blockedMessage;
-
-	public AggressiveSelfHarmGuardrailEngine() {
-		this.keysToGet = new String[] { "prompt" };
+	@Override
+	protected String getDefaultSystemPrompt() {
+		return DEFAULT_SYSTEM_PROMPT;
 	}
 
 	@Override
-	public void open(Properties smssProp) throws Exception {
-		super.open(smssProp);
-
-		this.modelEngineId = this.smssProp.getProperty(MODEL_ENGINE_ID_KEY);
-		if (this.modelEngineId == null || this.modelEngineId.trim().isEmpty()) {
-			throw new IllegalArgumentException(MODEL_ENGINE_ID_KEY + " is required for AggressiveSelfHarmGuardrailEngine");
-		}
-		this.modelEngineId = this.modelEngineId.trim();
-
-		String systemPromptProp = this.smssProp.getProperty(SYSTEM_PROMPT_KEY);
-		this.systemPrompt = (systemPromptProp != null && !systemPromptProp.trim().isEmpty())
-				? systemPromptProp.trim() : DEFAULT_SYSTEM_PROMPT;
-
-		String blockedMessageProp = this.smssProp.getProperty(BLOCKED_MESSAGE_KEY);
-		this.blockedMessage = (blockedMessageProp != null && !blockedMessageProp.trim().isEmpty())
-				? blockedMessageProp.trim() : DEFAULT_BLOCKED_MESSAGE;
-
-		this.functionDescription = "Detects aggressive or self-harm content by asking a configured LLM to classify "
-				+ "the prompt as SAFE or UNSAFE.";
-		this.parameters = new ArrayList<>();
-		this.parameters.add(new FunctionParameter("prompt", "String", "The prompt to evaluate"));
-		this.requiredParameters = new ArrayList<>(Arrays.asList("prompt"));
+	protected String getDefaultBlockedMessage() {
+		return DEFAULT_BLOCKED_MESSAGE;
 	}
 
 	@Override
-	public GuardrailNounMetadata execute(NounStore ns, GenRowStruct curRow) {
-		Map<String, String> keyValue = organizeKeys(ns, curRow);
-		String prompt = keyValue.get("prompt");
-		if (prompt == null) {
-			throw new IllegalArgumentException("No prompt has been defined");
-		}
-
-		classLogger.info("AggressiveSelfHarmGuardrail: classifying prompt (length={}) via model={}",
-				prompt.length(), this.modelEngineId);
-
-		IModelEngine modelEngine = Utility.getModel(this.modelEngineId);
-		if (modelEngine == null) {
-			throw new IllegalStateException("Could not find model engine with id: " + this.modelEngineId);
-		}
-
-		Insight classificationInsight = new Insight();
-		InsightStore.getInstance().put(classificationInsight);
-
-		String savedJobId = ThreadStore.getJobId();
-		ThreadStore.setJobId(null);
-
-		String classification;
-		try {
-			Room room = RoomUtils.createRoomIfNotExists(UUID.randomUUID().toString(), classificationInsight, modelEngine, prompt);
-			Map<String, Object> params = new HashMap<>();
-			params.put("use_history", false);
-			InputMessage msg = InputMessage.builder(room)
-					.withSystemPrompt(this.systemPrompt)
-					.withText(prompt)
-					.withModelType(modelEngine.getModelType())
-					.withParamMap(params)
-					.build();
-			ResponseMessage response = room.ask(msg, modelEngine);
-			Object responseObj = response.getModelEngineResponse().toMap().get("response");
-			classification = responseObj != null ? responseObj.toString().trim() : "";
-		} finally {
-			ThreadStore.setJobId(savedJobId);
-			InsightStore.getInstance().remove(classificationInsight.getInsightId());
-		}
-
-		boolean pass = !classification.toUpperCase().contains("UNSAFE");
-
-		classLogger.info("AggressiveSelfHarmGuardrail: classification='{}', pass={}", classification, pass);
-
-		Map<String, Object> details = new HashMap<>();
-		details.put("classification", classification);
-		details.put("modelEngineId", this.modelEngineId);
-
-		String returnPrompt = pass ? prompt : this.blockedMessage;
-
-		return new GuardrailNounMetadata(pass, returnPrompt, details);
+	protected String getPromptGuardrailDescription() {
+		return "Detects aggressive or self-harm content by asking a configured LLM to classify the prompt as "
+				+ "SAFE or UNSAFE.";
 	}
 
 	@Override
 	public GuardrailTypeEnum getGuardrailType() {
 		return GuardrailTypeEnum.EMBEDDED_AGGRESSIVE_SELF_HARM;
+	}
+
+	@Override
+	public String getDefaultMarkdown() {
+		return """
+				# Aggressive / Self-Harm guardrail
+
+				This guardrail sends selected text to the configured model engine with a safety-classification system prompt. The judge must answer `SAFE` or `UNSAFE`. An unsafe result stops the guarded call or returns the configured blocked message, depending on the pipeline settings.
+
+				`SYSTEM_PROMPT`, `BLOCKED_MESSAGE`, and `FAIL_OPEN` are optional SMSS settings. Override them to adapt the behavior. `FAIL_OPEN` defaults to `false`, so a judge error blocks the call.
+
+				## Example: protect model prompts
+
+				Save this as `pipeline.json` in the model engine's assets folder, set `PIPELINE pipeline.json` in that model engine's SMSS, and restart or reload the model engine:
+
+				```json
+				{
+				  "pipelines": {
+				    "askRoom": {
+				      "input": [
+				        {
+				          "reactorClass": "prerna.reactor.interceptor.GenericGuardrailInputReactor",
+				          "params": {
+				            "guardrailEngineId": "%s",
+				            "inputMapping": {
+				              "prompt": "arg0"
+				            },
+				            "blockOnGuardrailFailure": false,
+				            "respondWithGuardrailMessage": true
+				          }
+				        }
+				      ]
+				    }
+				  }
+				}
+				```
+
+				The input reactor maps `askRoom`'s first argument to the guardrail's `prompt`. When the judge returns `UNSAFE`, the actual model call is skipped and the blocked message is returned. Do not attach a pipeline that invokes this guardrail to its judge model, because that would recurse.
+				"""
+				.formatted(getEngineId());
 	}
 }

--- a/src/prerna/engine/impl/guardrail/DetoxifyGuardrailEngine.java
+++ b/src/prerna/engine/impl/guardrail/DetoxifyGuardrailEngine.java
@@ -124,4 +124,47 @@ public class DetoxifyGuardrailEngine extends AbstractPythonGuardrailReactorFunct
 	public GuardrailTypeEnum getGuardrailType() {
 		return GuardrailTypeEnum.EMBEDDED_DETOXIFY;
 	}
+
+	@Override
+	public String getDefaultMarkdown() {
+		return """
+				# Detoxify guardrail
+
+				This guardrail runs the local Detoxify `original` model over selected text. It fails when any toxicity, severe-toxicity, obscene, threat, insult, or identity-attack score is greater than the threshold.
+
+				Set `DEFAULT_THRESHOLD` in the guardrail SMSS to choose the engine-wide threshold; it defaults to `0.7`. A pipeline may override it for one intercepted method through `directParameters`. Higher thresholds are more permissive. Tune the value against representative application traffic before production use.
+
+				## Example: block toxic model input
+
+				Save this as `pipeline.json` in the model engine's assets folder, set `PIPELINE pipeline.json` in that model engine's SMSS, and restart or reload the model engine:
+
+				```json
+				{
+				  "pipelines": {
+				    "askRoom": {
+				      "input": [
+				        {
+				          "reactorClass": "prerna.reactor.interceptor.GenericGuardrailInputReactor",
+				          "params": {
+				            "guardrailEngineId": "%s",
+				            "inputMapping": {
+				              "prompt": "arg0"
+				            },
+				            "directParameters": {
+				              "threshold": 0.8
+				            },
+				            "blockOnGuardrailFailure": true,
+				            "blockErrorMessage": "The message did not pass the toxicity check."
+				          }
+				        }
+				      ]
+				    }
+				  }
+				}
+				```
+
+				`arg0` is the `InputMessage`; the interceptor evaluates its model-bound text. Detoxify returns the original text, so use this guardrail to block rather than mask. The model is not called when the score breaches the threshold.
+				"""
+				.formatted(getEngineId());
+	}
 }

--- a/src/prerna/engine/impl/guardrail/GLiNERGuardrailEngine.java
+++ b/src/prerna/engine/impl/guardrail/GLiNERGuardrailEngine.java
@@ -57,7 +57,8 @@ public class GLiNERGuardrailEngine extends AbstractPythonGuardrailReactorFunctio
 	private String modelName = null;
 	private List<String> defaultLabels = null;
 	private Double defaultThreshold = .7;
-	// template used when masking a matched entity; {label} is replaced with the entity label
+	// template used when masking a matched entity; {label} is replaced with the
+	// entity label
 	private String maskTemplate = "[{label}]";
 
 	public GLiNERGuardrailEngine() {
@@ -105,7 +106,7 @@ public class GLiNERGuardrailEngine extends AbstractPythonGuardrailReactorFunctio
 						+ defaultThreshold));
 
 		if (this.defaultLabels != null && !this.defaultLabels.isEmpty()) {
-			this.requiredParameters = new ArrayList<>(Arrays.asList("labels"));
+			this.requiredParameters = new ArrayList<>(Arrays.asList("prompt"));
 		} else {
 			this.requiredParameters = new ArrayList<>(Arrays.asList("prompt", "labels"));
 		}
@@ -167,10 +168,10 @@ public class GLiNERGuardrailEngine extends AbstractPythonGuardrailReactorFunctio
 
 	/**
 	 * Build a masked copy of the prompt where every flagged entity span is replaced
-	 * with the configured mask template (default {@code [label]}). Spans are replaced
-	 * from right to left so the character offsets returned by GLiNER stay valid as the
-	 * string is rewritten. Overlapping spans are skipped defensively. When there are no
-	 * flagged entities the original prompt is returned unchanged.
+	 * with the configured mask template (default {@code [label]}). Spans are
+	 * replaced from right to left so the character offsets returned by GLiNER stay
+	 * valid as the string is rewritten. Overlapping spans are skipped defensively.
+	 * When there are no flagged entities the original prompt is returned unchanged.
 	 *
 	 * @param prompt  the original prompt
 	 * @param flagged the entity predictions (each a map with start/end/label) that
@@ -181,13 +182,15 @@ public class GLiNERGuardrailEngine extends AbstractPythonGuardrailReactorFunctio
 		if (prompt == null || flagged == null || flagged.isEmpty()) {
 			return prompt;
 		}
-		// sort a copy by start offset descending so right-to-left splicing keeps offsets valid
+		// sort a copy by start offset descending so right-to-left splicing keeps
+		// offsets valid
 		List<Map<String, Object>> ordered = new ArrayList<>(flagged);
 		ordered.sort((a, b) -> Integer.compare(getInt(b.get("start")), getInt(a.get("start"))));
 
 		StringBuilder masked = new StringBuilder(prompt);
 		// tracks the left edge of the last span we replaced; the next span must end at
-		// or before this to be a non-overlapping, still-valid region of the original text
+		// or before this to be a non-overlapping, still-valid region of the original
+		// text
 		int lastStart = prompt.length();
 		for (Map<String, Object> entity : ordered) {
 			int start = getInt(entity.get("start"));
@@ -235,5 +238,49 @@ public class GLiNERGuardrailEngine extends AbstractPythonGuardrailReactorFunctio
 	@Override
 	public GuardrailTypeEnum getGuardrailType() {
 		return GuardrailTypeEnum.EMBEDDED_GLINER;
+	}
+
+	@Override
+	public String getDefaultMarkdown() {
+		return """
+				# GLiNER guardrail
+
+				This guardrail detects named entities with the configured GLiNER model. Any entity whose score is greater than the threshold fails the check. Its returned prompt replaces flagged spans with `MASK_TEMPLATE`, which defaults to `[{label}]`.
+
+				`MODEL_NAME` is required in the guardrail SMSS. `NER_LABELS` may hold the default JSON label list, while `DEFAULT_THRESHOLD` and `MASK_TEMPLATE` control matching and replacement. Labels and the threshold can also be supplied by a pipeline for a specific use case.
+
+				## Example: mask sensitive entities before model inference
+
+				Save this as `pipeline.json` in the model engine's assets folder, set `PIPELINE pipeline.json` in that model engine's SMSS, and restart or reload the model engine:
+
+				```json
+				{
+				  "pipelines": {
+				    "askRoom": {
+				      "input": [
+				        {
+				          "reactorClass": "prerna.reactor.interceptor.GenericGuardrailInputReactor",
+				          "params": {
+				            "guardrailEngineId": "%s",
+				            "inputMapping": {
+				              "prompt": "arg0"
+				            },
+				            "directParameters": {
+				              "labels": ["person", "email address", "phone number", "account number"],
+				              "threshold": 0.7
+				            },
+				            "maskOnGuardrailFailure": true,
+				            "blockOnGuardrailFailure": false
+				          }
+				        }
+				      ]
+				    }
+				  }
+				}
+				```
+
+				When an entity is found, the interceptor writes GLiNER's masked prompt back to the same input that was evaluated. For `askRoom`, it updates the `InputMessage` object before refreshing the provider payload. If the masked value cannot be written back safely, the request is blocked.
+				"""
+				.formatted(getEngineId());
 	}
 }

--- a/src/prerna/engine/impl/guardrail/LocalPythonGuardrailReactorFunctionEngine.java
+++ b/src/prerna/engine/impl/guardrail/LocalPythonGuardrailReactorFunctionEngine.java
@@ -311,4 +311,61 @@ public class LocalPythonGuardrailReactorFunctionEngine extends AbstractPythonGua
 		return GuardrailTypeEnum.LOCAL_PYTHON;
 	}
 
+	@Override
+	public String getDefaultMarkdown() {
+		return """
+				# Local Python guardrail
+
+				This guardrail calls `%s` from `%s` with the parameters declared in the engine SMSS. The function must return a dictionary with a boolean `pass`. It may also return `returnPrompt` for masking or a user-facing response, and `fullDetails` for audit context.
+
+				## Python function shape
+
+				```python
+				import re
+
+				API_KEY = re.compile(r"(?i)(api_key\\s*=\\s*)[^\\s,;]+")
+
+				def guard_prompt(prompt, **kwargs):
+				    contains_secret = API_KEY.search(prompt) is not None
+				    masked = API_KEY.sub(r"\\1[masked]", prompt)
+				    return {
+				        "pass": not contains_secret,
+				        "returnPrompt": masked,
+				        "fullDetails": {"rule": "api-key-prefix"},
+				    }
+				```
+
+				Declare `prompt` in `FUNCTION_PARAMETERS` and `FUNCTION_REQUIRED_PARAMETERS`, and set `FUNCTION_NAME` to the actual Python function name.
+
+				## Example: mask model input with the Python result
+
+				Save this as `pipeline.json` in the model engine's assets folder, set `PIPELINE pipeline.json` in that model engine's SMSS, and restart or reload the model engine:
+
+				```json
+				{
+				  "pipelines": {
+				    "askRoom": {
+				      "input": [
+				        {
+				          "reactorClass": "prerna.reactor.interceptor.GenericGuardrailInputReactor",
+				          "params": {
+				            "guardrailEngineId": "%s",
+				            "inputMapping": {
+				              "prompt": "arg0"
+				            },
+				            "maskOnGuardrailFailure": true,
+				            "blockOnGuardrailFailure": false
+				          }
+				        }
+				      ]
+				    }
+				  }
+				}
+				```
+
+				For `askRoom`, `arg0` is the full `InputMessage`. The interceptor gives its text to the Python `prompt` parameter and, when masking, writes `returnPrompt` back into that same message before refreshing the provider payload. For other methods, map each declared Python parameter to the appropriate argument or nested map path.
+				"""
+				.formatted(this.functionName, this.pythonFileName, getEngineId());
+	}
+
 }

--- a/src/prerna/engine/impl/guardrail/OnTopicGuardrailEngine.java
+++ b/src/prerna/engine/impl/guardrail/OnTopicGuardrailEngine.java
@@ -53,9 +53,8 @@ import prerna.util.Utility;
  * Guardrail that checks whether a prompt is on-topic by performing a similarity
  * search against a user-configured vector database. The vector DB should be
  * pre-loaded with example on-topic prompts/documents. Whether the returned
- * Score is a distance or a similarity
- * depends on the configured vector engine, so it is declared via
- * SCORE_IS_DISTANCE rather than assumed.
+ * Score is a distance or a similarity depends on the configured vector engine,
+ * so it is declared via SCORE_IS_DISTANCE rather than assumed.
  *
  */
 public class OnTopicGuardrailEngine extends AbstractGuardrailReactorFunctionEngine {
@@ -167,8 +166,7 @@ public class OnTopicGuardrailEngine extends AbstractGuardrailReactorFunctionEngi
 		IVectorDatabaseEngine vectorDb = Utility.getVectorDatabase(this.vectorEngineId);
 		if (vectorDb == null) {
 			classLogger.error("OnTopicGuardrail: vector database engine not found: {}", this.vectorEngineId);
-			throw new IllegalStateException(
-					"Could not find vector database engine with id: " + this.vectorEngineId);
+			throw new IllegalStateException("Could not find vector database engine with id: " + this.vectorEngineId);
 		}
 
 		// Vector DB nearestNeighbor requires an Insight for its embedding model calls.
@@ -195,22 +193,21 @@ public class OnTopicGuardrailEngine extends AbstractGuardrailReactorFunctionEngi
 			}
 		}
 
-		// Results are returned sorted by the vector DB — first result is the best match.
+		// Results are returned sorted by the vector DB - first result is the best
+		// match.
 		double bestScore = Double.MAX_VALUE;
 		if (!results.isEmpty()) {
 			Object scoreObj = results.get(0).get(SCORE_KEY);
 			if (scoreObj instanceof Number) {
 				bestScore = ((Number) scoreObj).doubleValue();
 			}
-			classLogger.info("OnTopicGuardrail: top match — score={}, content={}",
-					bestScore,
+			classLogger.info("OnTopicGuardrail: top match - score={}, content={}", bestScore,
 					results.get(0).getOrDefault("Content", results.get(0).getOrDefault("content", "<unknown>")));
 		} else {
 			classLogger.info("OnTopicGuardrail: no results returned from vector DB");
 		}
 
-		boolean pass = !results.isEmpty()
-				&& (scoreIsDistance ? bestScore <= threshold : bestScore >= threshold);
+		boolean pass = !results.isEmpty() && (scoreIsDistance ? bestScore <= threshold : bestScore >= threshold);
 
 		Map<String, Object> details = new HashMap<>();
 		details.put("threshold", threshold);
@@ -218,8 +215,8 @@ public class OnTopicGuardrailEngine extends AbstractGuardrailReactorFunctionEngi
 		details.put("limit", limit);
 		details.put("results", results);
 
-		classLogger.info("OnTopicGuardrail: bestScore={}, threshold={}, pass={}, resultCount={}",
-				bestScore, threshold, pass, results.size());
+		classLogger.info("OnTopicGuardrail: bestScore={}, threshold={}, pass={}, resultCount={}", bestScore, threshold,
+				pass, results.size());
 
 		return new GuardrailNounMetadata(pass, prompt, details);
 	}
@@ -244,5 +241,49 @@ public class OnTopicGuardrailEngine extends AbstractGuardrailReactorFunctionEngi
 	@Override
 	public GuardrailTypeEnum getGuardrailType() {
 		return GuardrailTypeEnum.EMBEDDED_ON_TOPIC;
+	}
+
+	@Override
+	public String getDefaultMarkdown() {
+		return """
+				# On-topic guardrail
+
+				This guardrail compares selected text with examples stored in a vector database. It passes when the best nearest-neighbor result meets the configured score threshold and fails when there is no match.
+
+				Load the vector engine with representative allowed questions or documents. Set `VECTOR_ENGINE_ID` and `SCORE_IS_DISTANCE` in the guardrail SMSS. `SCORE_IS_DISTANCE=true` means lower scores are better and must be at or below the threshold; `false` means higher scores are better and must be at or above it. Calibrate `DEFAULT_THRESHOLD` using scores from the selected vector backend. `LIMIT` defaults to `5`.
+
+				## Example: restrict a model to an approved knowledge domain
+
+				Save this as `pipeline.json` in the model engine's assets folder, set `PIPELINE pipeline.json` in that model engine's SMSS, and restart or reload the model engine:
+
+				```json
+				{
+				  "pipelines": {
+				    "askRoom": {
+				      "input": [
+				        {
+				          "reactorClass": "prerna.reactor.interceptor.GenericGuardrailInputReactor",
+				          "params": {
+				            "guardrailEngineId": "%s",
+				            "inputMapping": {
+				              "prompt": "arg0"
+				            },
+				            "directParameters": {
+				              "threshold": 0.82,
+				              "limit": 5
+				            },
+				            "blockOnGuardrailFailure": true,
+				            "blockErrorMessage": "This assistant only answers questions in its approved knowledge domain."
+				          }
+				        }
+				      ]
+				    }
+				  }
+				}
+				```
+
+				The example threshold assumes a similarity score; replace it with a value measured for your vector engine. This guardrail returns the original prompt, so it should block off-topic requests rather than mask them.
+				"""
+				.formatted(getEngineId());
 	}
 }

--- a/src/prerna/engine/impl/guardrail/PolicyComplianceGuardrailEngine.java
+++ b/src/prerna/engine/impl/guardrail/PolicyComplianceGuardrailEngine.java
@@ -27,221 +27,159 @@
  *******************************************************************************/
 package prerna.engine.impl.guardrail;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.UUID;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import prerna.engine.api.GuardrailTypeEnum;
-import prerna.engine.api.IModelEngine;
 import prerna.engine.impl.function.FunctionParameter;
-import prerna.engine.impl.model.Room;
-import prerna.engine.impl.model.RoomUtils;
-import prerna.engine.impl.model.message.InputMessage;
-import prerna.engine.impl.model.message.ResponseMessage;
-import prerna.engine.impl.model.responses.AbstractModelEngineResponse;
-import prerna.om.Insight;
-import prerna.om.InsightStore;
-import prerna.om.ThreadStore;
-import prerna.sablecc2.om.GenRowStruct;
-import prerna.sablecc2.om.NounStore;
 import prerna.sablecc2.om.nounmeta.GuardrailNounMetadata;
-import prerna.util.Utility;
 
 /**
  * Guardrail that classifies text against a configurable content policy by
  * calling a configured LLM with a classification system prompt. The model is
  * expected to respond with a single word {@code SAFE} or {@code UNSAFE}.
+ * <p>
  * Typically mounted on an {@code output} pipeline to check a model's response,
  * but works identically on a user prompt when mounted on {@code input}.
  *
- * Required SMSS keys:
- *   {@code MODEL_ENGINE_ID} engine ID of the LLM to use for classification.
- *    Must not itself be guarded by this (or any) output pipeline.
- *   {@code POLICY_DESCRIPTION} the behaviors that make the text UNSAFE
- * Optional SMSS keys:
- *   {@code BLOCKED_MESSAGE} canned replacement text; only takes effect
- *       when mounted on an {@code input} pipeline with
- *   {@code respondWithGuardrailMessage=true}. Output pipelines can only
- *       block a failing response today, not rewrite it.
- * Optional per-call parameter {@code policy} overrides {@code POLICY_DESCRIPTION}.
+ * <h3>Required SMSS keys</h3>
+ * <ul>
+ * <li>{@code MODEL_ENGINE_ID} - engine ID of the LLM used for classification.
+ * The judge model must not use a pipeline that invokes this guardrail.</li>
+ * <li>{@code POLICY_DESCRIPTION} - behaviors that make the evaluated text
+ * unsafe.</li>
+ * </ul>
+ * 
+ * <h3>Optional SMSS keys</h3>
+ * <ul>
+ * <li>{@code SYSTEM_PROMPT} - replaces the default judge instructions. The
+ * {@code ${POLICY_DESCRIPTION}} placeholder is replaced for each call.</li>
+ * <li>{@code BLOCKED_MESSAGE} - replacement text used by an input pipeline when
+ * {@code respondWithGuardrailMessage=true}. Output pipelines can block a
+ * failing response but cannot rewrite it.</li>
+ * <li>{@code FAIL_OPEN} - whether a judge error should allow the guarded call.
+ * Defaults to {@code true} for compatibility. Set it to {@code false} for
+ * irreversible operations such as sending mail.</li>
+ * </ul>
+ *
+ * <h3>Optional call parameters</h3>
+ * <ul>
+ * <li>{@code policy} - overrides {@code POLICY_DESCRIPTION} for one call.</li>
+ * </ul>
  */
-public class PolicyComplianceGuardrailEngine extends AbstractGuardrailReactorFunctionEngine {
+public class PolicyComplianceGuardrailEngine extends PromptGuardrailEngine {
 
-	private static final Logger classLogger = LogManager.getLogger(PolicyComplianceGuardrailEngine.class);
-
-	public static final String MODEL_ENGINE_ID_KEY = "MODEL_ENGINE_ID";
 	public static final String POLICY_DESCRIPTION_KEY = "POLICY_DESCRIPTION";
-	public static final String BLOCKED_MESSAGE_KEY = "BLOCKED_MESSAGE";
-
-	private static final String PROMPT_PARAM = "prompt";
 	private static final String POLICY_PARAM = "policy";
 
-	private static final String SYSTEM_PROMPT_TEMPLATE =
-			"You are a strict content-policy classifier. You review a piece of text - typically an AI "
-			+ "assistant's RESPONSE, reviewed here before it is shown to the end user - and decide whether "
-			+ "it violates the policy below.\n\n"
-			+ "POLICY - the text is UNSAFE if it does any of the following:\n"
-			+ "${POLICY_DESCRIPTION}\n\n"
-			+ "The text is SAFE if it does not do any of the above - including when it factually reports "
-			+ "negative, critical, or unfavorable information that is explicitly documented in the source "
-			+ "material, WITHOUT adding the assistant's own opinion, characterization, or advice. Faithfully "
-			+ "reporting documented facts is required, not prohibited, even when those facts are unflattering.\n\n"
-			+ "Respond with ONLY one word:\n"
-			+ "- UNSAFE if the text violates the policy above\n"
-			+ "- SAFE   if it does not\n\n"
-			+ "Do not explain your reasoning. Output only SAFE or UNSAFE.";
+	private static final String DEFAULT_SYSTEM_PROMPT = """
+			You are a strict content-policy classifier. You review a piece of text - typically an AI assistant's RESPONSE, reviewed here before it is shown to the end user - and decide whether it violates the policy below.
 
-	private String modelEngineId;
+			POLICY - the text is UNSAFE if it does any of the following:
+			${POLICY_DESCRIPTION}
+
+			The text is SAFE if it does not do any of the above - including when it factually reports negative, critical, or unfavorable information that is explicitly documented in the source material, WITHOUT adding the assistant's own opinion, characterization, or advice. Faithfully reporting documented facts is required, not prohibited, even when those facts are unflattering.
+
+			Respond with ONLY one word:
+			- UNSAFE if the text violates the policy above
+			- SAFE if it does not
+
+			Do not explain your reasoning. Output only SAFE or UNSAFE.
+			""";
+
 	private String defaultPolicyDescription;
-	private String blockedMessage;
 
 	public PolicyComplianceGuardrailEngine() {
-		this.keysToGet = new String[] { PROMPT_PARAM, POLICY_PARAM };
+		super(POLICY_PARAM);
 	}
 
 	@Override
-	public void open(Properties smssProp) throws Exception {
-		super.open(smssProp);
-
-		this.modelEngineId = this.smssProp.getProperty(MODEL_ENGINE_ID_KEY);
-		if (this.modelEngineId == null || (this.modelEngineId = this.modelEngineId.trim()).isEmpty()) {
-			throw new IllegalArgumentException(MODEL_ENGINE_ID_KEY + " is required for PolicyComplianceGuardrailEngine");
-		}
-
-		this.defaultPolicyDescription = this.smssProp.getProperty(POLICY_DESCRIPTION_KEY);
-		if (this.defaultPolicyDescription == null || (this.defaultPolicyDescription = this.defaultPolicyDescription.trim()).isEmpty()) {
-			throw new IllegalArgumentException(POLICY_DESCRIPTION_KEY + " is required for PolicyComplianceGuardrailEngine");
-		}
-
-		String blockedMessageStr = this.smssProp.getProperty(BLOCKED_MESSAGE_KEY);
-		if (blockedMessageStr != null && !(blockedMessageStr = blockedMessageStr.trim()).isEmpty()) {
-			this.blockedMessage = blockedMessageStr;
-		}
-
-		this.functionDescription = "Classifies text against a configurable content policy using an LLM judge, "
-				+ "returning SAFE/UNSAFE.";
-		this.parameters = new ArrayList<>();
-		this.parameters.add(new FunctionParameter("prompt", "String", "The text to evaluate against the policy"));
-		this.parameters.add(new FunctionParameter("policy", "String", "Optional override of POLICY_DESCRIPTION for this call"));
-		this.requiredParameters = new ArrayList<>(Arrays.asList("prompt"));
+	protected void configurePromptGuardrail() {
+		this.defaultPolicyDescription = getRequiredSmssProperty(POLICY_DESCRIPTION_KEY);
 	}
 
 	@Override
-	public GuardrailNounMetadata execute(NounStore ns, GenRowStruct curRow) {
-		Map<String, String> keyValue = organizeKeys(ns, curRow);
-		Object rawPrompt = getRawNounValue(ns, curRow, PROMPT_PARAM, 0);
-		String textToJudge = extractText(rawPrompt);
-		if (textToJudge == null || textToJudge.isEmpty()) {
-			Map<String, Object> details = new HashMap<>();
-			details.put("classification", "SKIPPED_NO_TEXT");
-			return new GuardrailNounMetadata(true, textToJudge, details);
-		}
+	protected String getDefaultSystemPrompt() {
+		return DEFAULT_SYSTEM_PROMPT;
+	}
 
+	@Override
+	protected boolean isFailOpenByDefault() {
+		return true;
+	}
+
+	@Override
+	protected String getPromptGuardrailDescription() {
+		return "Classifies text against a configurable content policy using an LLM judge, returning SAFE/UNSAFE.";
+	}
+
+	@Override
+	protected List<FunctionParameter> getPromptGuardrailParameters() {
+		return List.of(new FunctionParameter(PROMPT_PARAM, "String", "The text to evaluate against the policy"),
+				new FunctionParameter(POLICY_PARAM, "String", "Optional override of POLICY_DESCRIPTION for this call"));
+	}
+
+	@Override
+	protected String resolveSystemPrompt(Map<String, String> keyValue) {
 		String policyDescription = keyValue.containsKey(POLICY_PARAM) && !keyValue.get(POLICY_PARAM).isEmpty()
 				? keyValue.get(POLICY_PARAM)
 				: this.defaultPolicyDescription;
+		return getConfiguredSystemPrompt().replace("${POLICY_DESCRIPTION}", policyDescription);
+	}
 
-		classLogger.info("PolicyComplianceGuardrail: classifying text (length={}) via model={}",
-				textToJudge.length(), this.modelEngineId);
-
-		String classification;
-		try {
-			classification = classify(textToJudge, policyDescription);
-		} catch (Exception e) {
-			classLogger.error("PolicyComplianceGuardrail: judge call failed, passing by default (fail-open): {}",
-					e.getMessage());
-			Map<String, Object> details = new HashMap<>();
-			details.put("classification", "ERROR_FAIL_OPEN");
-			details.put("error", e.getMessage());
-			return new GuardrailNounMetadata(true, textToJudge, details);
-		}
-
-		boolean pass = !classification.toUpperCase().contains("UNSAFE");
-		classLogger.info("PolicyComplianceGuardrail: classification='{}', pass={}", classification, pass);
-
+	@Override
+	protected GuardrailNounMetadata handleMissingText(String textToJudge) {
 		Map<String, Object> details = new HashMap<>();
-		details.put("classification", classification);
-		details.put("modelEngineId", this.modelEngineId);
-
-		String returnPrompt = pass ? textToJudge : (this.blockedMessage != null ? this.blockedMessage : textToJudge);
-		return new GuardrailNounMetadata(pass, returnPrompt, details);
-	}
-
-	private String classify(String textToJudge, String policyDescription) throws Exception {
-		IModelEngine judgeEngine = Utility.getModel(this.modelEngineId);
-		if (judgeEngine == null) {
-			throw new IllegalStateException("Could not find model engine with id: " + this.modelEngineId);
-		}
-
-		// Room/model calls require an Insight to be registered, this one is never tied to a real user session.
-		Insight classificationInsight = new Insight();
-		InsightStore.getInstance().put(classificationInsight);
-		String savedJobId = ThreadStore.getJobId();
-		ThreadStore.setJobId(null);
-		try {
-			Room room = RoomUtils.createRoomIfNotExists(UUID.randomUUID().toString(), classificationInsight,
-					judgeEngine, textToJudge);
-			Map<String, Object> params = new HashMap<>();
-			params.put("use_history", false);
-			InputMessage msg = InputMessage.builder(room)
-					.withSystemPrompt(buildSystemPrompt(policyDescription))
-					.withText(textToJudge)
-					.withModelType(judgeEngine.getModelType())
-					.withParamMap(params)
-					.build();
-			ResponseMessage response = room.ask(msg, judgeEngine);
-			Object responseObj = response.getModelEngineResponse().toMap().get("response");
-			return responseObj != null ? responseObj.toString().trim() : "";
-		} finally {
-			ThreadStore.setJobId(savedJobId);
-			InsightStore.getInstance().remove(classificationInsight.getInsightId());
-		}
-	}
-
-	private String buildSystemPrompt(String policyDescription) {
-		return SYSTEM_PROMPT_TEMPLATE.replace("${POLICY_DESCRIPTION}", policyDescription);
-	}
-
-	@SuppressWarnings("unchecked")
-	private String extractText(Object rawValue) {
-		if (rawValue == null) {
-			return null;
-		}
-		if (rawValue instanceof String) {
-			return (String) rawValue;
-		}
-		if (rawValue instanceof AbstractModelEngineResponse) {
-			Object resp = ((AbstractModelEngineResponse) rawValue).toMap().get("response");
-			return resp != null ? resp.toString() : null;
-		}
-		if (rawValue instanceof Map) {
-			Object resp = ((Map<String, Object>) rawValue).get("response");
-			return resp != null ? resp.toString() : null;
-		}
-		return rawValue.toString();
-	}
-
-	private Object getRawNounValue(NounStore ns, GenRowStruct curRow, String key, int positionalIndexIfMissing) {
-		if (ns != null) {
-			GenRowStruct grs = ns.getGenRowStruct(key);
-			if (grs != null && !grs.isEmpty()) {
-				return grs.get(0);
-			}
-		}
-		if (curRow != null && !curRow.isEmpty() && positionalIndexIfMissing < curRow.size()) {
-			return curRow.get(positionalIndexIfMissing);
-		}
-		return null;
+		details.put("classification", "SKIPPED_NO_TEXT");
+		return new GuardrailNounMetadata(true, textToJudge, details);
 	}
 
 	@Override
 	public GuardrailTypeEnum getGuardrailType() {
 		return GuardrailTypeEnum.EMBEDDED_POLICY_COMPLIANCE;
+	}
+
+	@Override
+	public String getDefaultMarkdown() {
+		return """
+				# Policy Compliance guardrail
+
+				This guardrail sends selected text and a policy to the configured model engine. The judge must answer `SAFE` or `UNSAFE`; an unsafe result prevents the guarded result from being returned.
+
+				The SMSS `POLICY_DESCRIPTION` is the default policy. A pipeline may supply a `policy` in `directParameters` for one use case. `SYSTEM_PROMPT` can replace the default judge instructions; include `${POLICY_DESCRIPTION}` where the policy should be inserted. `BLOCKED_MESSAGE` and `FAIL_OPEN` are also optional. `FAIL_OPEN` defaults to `true`; use `false` before irreversible actions such as sending mail.
+
+				## Example: review model responses
+
+				Save this as `pipeline.json` in the model engine's assets folder, set `PIPELINE pipeline.json` in that model engine's SMSS, and restart or reload the model engine:
+
+				```json
+				{
+				  "pipelines": {
+				    "askRoom": {
+				      "output": [
+				        {
+				          "reactorClass": "prerna.reactor.interceptor.GenericGuardrailOutputReactor",
+				          "params": {
+				            "guardrailEngineId": "%s",
+				            "inputMapping": {
+				              "prompt": "result"
+				            },
+				            "directParameters": {
+				              "policy": "Classify the response as UNSAFE if it exposes secrets, invents unsupported claims, or gives instructions outside the approved scope."
+				            },
+				            "blockOnGuardrailFailure": true,
+				            "blockErrorMessage": "The response did not pass policy review."
+				          }
+				        }
+				      ]
+				    }
+				  }
+				}
+				```
+
+				The output reactor maps the completed model response to `prompt`, supplies a use-case-specific policy, and withholds the result if the judge returns `UNSAFE`. Omit `directParameters` to use the engine's default policy. Do not attach a pipeline that invokes this guardrail to its judge model, because that would recurse.
+				"""
+				.formatted(getEngineId());
 	}
 }

--- a/src/prerna/engine/impl/guardrail/PromptGuardrailEngine.java
+++ b/src/prerna/engine/impl/guardrail/PromptGuardrailEngine.java
@@ -1,0 +1,253 @@
+package prerna.engine.impl.guardrail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import prerna.engine.api.IModelEngine;
+import prerna.engine.impl.function.FunctionParameter;
+import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.RoomUtils;
+import prerna.engine.impl.model.message.InputMessage;
+import prerna.engine.impl.model.message.ResponseMessage;
+import prerna.engine.impl.model.responses.AbstractModelEngineResponse;
+import prerna.om.Insight;
+import prerna.om.InsightStore;
+import prerna.om.ThreadStore;
+import prerna.sablecc2.om.GenRowStruct;
+import prerna.sablecc2.om.NounStore;
+import prerna.sablecc2.om.nounmeta.GuardrailNounMetadata;
+import prerna.util.Utility;
+
+/**
+ * Base for guardrails that ask a model to classify text as SAFE or UNSAFE.
+ */
+public abstract class PromptGuardrailEngine extends AbstractGuardrailReactorFunctionEngine {
+
+	private static final Logger classLogger = LogManager.getLogger(PromptGuardrailEngine.class);
+
+	public static final String MODEL_ENGINE_ID_KEY = "MODEL_ENGINE_ID";
+	public static final String SYSTEM_PROMPT_KEY = "SYSTEM_PROMPT";
+	public static final String BLOCKED_MESSAGE_KEY = "BLOCKED_MESSAGE";
+	public static final String FAIL_OPEN_KEY = "FAIL_OPEN";
+
+	protected static final String PROMPT_PARAM = "prompt";
+
+	private String modelEngineId;
+	private String systemPrompt;
+	private String blockedMessage;
+	private boolean failOpen;
+
+	protected PromptGuardrailEngine(String... additionalParameters) {
+		this.keysToGet = new String[additionalParameters.length + 1];
+		this.keysToGet[0] = PROMPT_PARAM;
+		System.arraycopy(additionalParameters, 0, this.keysToGet, 1, additionalParameters.length);
+	}
+
+	@Override
+	public void open(Properties smssProp) throws Exception {
+		super.open(smssProp);
+
+		this.modelEngineId = getRequiredSmssProperty(MODEL_ENGINE_ID_KEY);
+		configurePromptGuardrail();
+		this.systemPrompt = getPropertyOrDefault(SYSTEM_PROMPT_KEY, getDefaultSystemPrompt());
+		this.blockedMessage = getPropertyOrDefault(BLOCKED_MESSAGE_KEY, getDefaultBlockedMessage());
+		this.failOpen = getBooleanProperty(FAIL_OPEN_KEY, isFailOpenByDefault());
+
+		this.functionDescription = getPromptGuardrailDescription();
+		this.parameters = new ArrayList<>(getPromptGuardrailParameters());
+		this.requiredParameters = new ArrayList<>(getRequiredPromptGuardrailParameters());
+	}
+
+	@Override
+	public GuardrailNounMetadata execute(NounStore ns, GenRowStruct curRow) {
+		Map<String, String> keyValue = organizeKeys(ns, curRow);
+		String textToJudge = extractText(getRawNounValue(ns, curRow, PROMPT_PARAM, 0));
+		if (textToJudge == null || textToJudge.isEmpty()) {
+			return handleMissingText(textToJudge);
+		}
+
+		classLogger.info("{}: classifying text (length={}) via model={}", getClass().getSimpleName(),
+				textToJudge.length(), this.modelEngineId);
+
+		String classification;
+		try {
+			classification = classify(textToJudge, resolveSystemPrompt(keyValue));
+		} catch (Exception e) {
+			classLogger.error("{}: judge call failed, failing {}: {}", getClass().getSimpleName(),
+					this.failOpen ? "open" : "closed", e.getMessage(), e);
+			Map<String, Object> details = new HashMap<>();
+			details.put("classification", this.failOpen ? "ERROR_FAIL_OPEN" : "ERROR_FAIL_CLOSED");
+			details.put("error", e.getMessage());
+			details.put("modelEngineId", this.modelEngineId);
+			return new GuardrailNounMetadata(this.failOpen, textToJudge, details);
+		}
+
+		boolean pass = !classification.toUpperCase().contains("UNSAFE");
+		classLogger.info("{}: classification='{}', pass={}", getClass().getSimpleName(), classification, pass);
+
+		Map<String, Object> details = new HashMap<>();
+		details.put("classification", classification);
+		details.put("modelEngineId", this.modelEngineId);
+
+		String returnPrompt = pass || this.blockedMessage == null ? textToJudge : this.blockedMessage;
+		return new GuardrailNounMetadata(pass, returnPrompt, details);
+	}
+
+	protected void configurePromptGuardrail() {
+		// Most prompt guardrails need no additional configuration.
+	}
+
+	protected abstract String getDefaultSystemPrompt();
+
+	protected String getDefaultBlockedMessage() {
+		return null;
+	}
+
+	protected boolean isFailOpenByDefault() {
+		return false;
+	}
+
+	protected abstract String getPromptGuardrailDescription();
+
+	protected List<FunctionParameter> getPromptGuardrailParameters() {
+		return List.of(new FunctionParameter(PROMPT_PARAM, "String", "The text to evaluate"));
+	}
+
+	protected List<String> getRequiredPromptGuardrailParameters() {
+		return List.of(PROMPT_PARAM);
+	}
+
+	protected String resolveSystemPrompt(Map<String, String> keyValue) {
+		return this.systemPrompt;
+	}
+
+	protected String getConfiguredSystemPrompt() {
+		return this.systemPrompt;
+	}
+
+	protected GuardrailNounMetadata handleMissingText(String textToJudge) {
+		throw new IllegalArgumentException("No prompt has been defined");
+	}
+
+	private String classify(String textToJudge, String classificationPrompt) throws Exception {
+		IModelEngine judgeEngine = Utility.getModel(this.modelEngineId);
+		if (judgeEngine == null) {
+			throw new IllegalStateException("Could not find model engine with id: " + this.modelEngineId);
+		}
+
+		Insight classificationInsight = new Insight();
+		InsightStore.getInstance().put(classificationInsight);
+		String savedJobId = ThreadStore.getJobId();
+		ThreadStore.setJobId(null);
+		try {
+			Room room = RoomUtils.createRoomIfNotExists(UUID.randomUUID().toString(), classificationInsight,
+					judgeEngine, textToJudge);
+			Map<String, Object> params = new HashMap<>();
+			params.put("use_history", false);
+			InputMessage msg = InputMessage.builder(room).withSystemPrompt(classificationPrompt).withText(textToJudge)
+					.withModelType(judgeEngine.getModelType()).withParamMap(params).build();
+			ResponseMessage response = room.ask(msg, judgeEngine);
+			Object responseObj = response.getModelEngineResponse().toMap().get("response");
+			return responseObj != null ? responseObj.toString().trim() : "";
+		} finally {
+			ThreadStore.setJobId(savedJobId);
+			InsightStore.getInstance().remove(classificationInsight.getInsightId());
+		}
+	}
+
+	protected String getRequiredSmssProperty(String key) {
+		String value = this.smssProp.getProperty(key);
+		if (value == null || (value = value.trim()).isEmpty()) {
+			throw new IllegalArgumentException(key + " is required for " + getClass().getSimpleName());
+		}
+		return value;
+	}
+
+	private String getPropertyOrDefault(String key, String defaultValue) {
+		String value = this.smssProp.getProperty(key);
+		return value != null && !(value = value.trim()).isEmpty() ? value : defaultValue;
+	}
+
+	private boolean getBooleanProperty(String key, boolean defaultValue) {
+		String value = this.smssProp.getProperty(key);
+		return value != null && !(value = value.trim()).isEmpty() ? Boolean.parseBoolean(value) : defaultValue;
+	}
+
+	@SuppressWarnings("unchecked")
+	static String extractText(Object rawValue) {
+		if (rawValue == null) {
+			return null;
+		}
+		if (rawValue instanceof String) {
+			return (String) rawValue;
+		}
+		if (rawValue instanceof InputMessage) {
+			return ((InputMessage) rawValue).getFullInputPrompt();
+		}
+		if (rawValue instanceof AbstractModelEngineResponse) {
+			Object response = ((AbstractModelEngineResponse) rawValue).toMap().get("response");
+			return response != null ? response.toString() : null;
+		}
+		if (rawValue instanceof Map) {
+			Map<String, Object> valueMap = (Map<String, Object>) rawValue;
+			Object response = valueMap.get("response");
+			if (response != null) {
+				return extractText(response);
+			}
+			Object body = valueMap.get("body");
+			Object subject = valueMap.get("subject");
+			if (body != null || subject != null) {
+				return joinText(Arrays.asList(subject, body));
+			}
+			return extractText(valueMap.get("messages"));
+		}
+		if (rawValue instanceof Collection) {
+			return joinText((Collection<?>) rawValue);
+		}
+		return rawValue.toString();
+	}
+
+	private static String joinText(Collection<?> values) {
+		StringBuilder combined = new StringBuilder();
+		for (Object value : values) {
+			String text = extractText(value);
+			if (text == null || text.isEmpty()) {
+				continue;
+			}
+			if (combined.length() > 0) {
+				combined.append('\n');
+			}
+			combined.append(text);
+		}
+		return combined.toString();
+	}
+
+	private Object getRawNounValue(NounStore ns, GenRowStruct curRow, String key, int positionalIndexIfMissing) {
+		if (ns != null) {
+			GenRowStruct grs = ns.getGenRowStruct(key);
+			if (grs != null && !grs.isEmpty()) {
+				if (grs.size() == 1) {
+					return grs.get(0);
+				}
+				List<Object> values = new ArrayList<>();
+				for (int i = 0; i < grs.size(); i++) {
+					values.add(grs.get(i));
+				}
+				return values;
+			}
+		}
+		if (curRow != null && !curRow.isEmpty() && positionalIndexIfMissing < curRow.size()) {
+			return curRow.get(positionalIndexIfMissing);
+		}
+		return null;
+	}
+}

--- a/src/prerna/engine/impl/guardrail/PromptInjectionGuardrailEngine.java
+++ b/src/prerna/engine/impl/guardrail/PromptInjectionGuardrailEngine.java
@@ -354,4 +354,48 @@ public class PromptInjectionGuardrailEngine extends AbstractPythonGuardrailReact
 		return GuardrailTypeEnum.EMBEDDED_PROMPT_INJECTION;
 	}
 
+	@Override
+	public String getDefaultMarkdown() {
+		return """
+				# Prompt-injection guardrail
+
+				This guardrail runs a local Hugging Face text-classification model and evaluates its label scores using `LABEL_DECISION_MAP`. A label mapped to `BLOCK` fails when its score is at or above the threshold.
+
+				`MODEL_NAME` and `LABEL_DECISION_MAP` are required in the guardrail SMSS. Match the map keys to the exact labels produced by that model, for example `{"SAFE":"ALLOW","INJECTION":"BLOCK"}`. `DEFAULT_DECISION` is used for unmapped or missing labels and defaults to block. Optional settings include `DEFAULT_THRESHOLD`, `DEFAULT_MAX_LENGTH`, `DEVICE`, `USE_CUDA`, and `TRUST_REMOTE_CODE`. Enable remote code only for a model repository you trust.
+
+				## Example: block injection attempts before model inference
+
+				Save this as `pipeline.json` in the model engine's assets folder, set `PIPELINE pipeline.json` in that model engine's SMSS, and restart or reload the model engine:
+
+				```json
+				{
+				  "pipelines": {
+				    "askRoom": {
+				      "input": [
+				        {
+				          "reactorClass": "prerna.reactor.interceptor.GenericGuardrailInputReactor",
+				          "params": {
+				            "guardrailEngineId": "%s",
+				            "inputMapping": {
+				              "prompt": "arg0"
+				            },
+				            "directParameters": {
+				              "threshold": 0.75,
+				              "maxLength": 512
+				            },
+				            "blockOnGuardrailFailure": true,
+				            "blockErrorMessage": "The request was blocked because it may contain prompt-injection instructions."
+				          }
+				        }
+				      ]
+				    }
+				  }
+				}
+				```
+
+				The classifier sees the text from the actual `InputMessage`, and a failed check prevents the model call. This guardrail returns the original prompt, so use it to block rather than mask.
+				"""
+				.formatted(getEngineId());
+	}
+
 }

--- a/src/prerna/engine/impl/model/AbstractModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractModelEngine.java
@@ -106,41 +106,40 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	protected boolean inferenceLogsEnbaled = Utility.isModelInferenceLogsEnabled();
 
 	/**
-	 * The engine's saved built-in tool selection from MODELMETADATA - a JSON
-	 * object keyed by tool name. The security database is its only source of
-	 * truth (the value is deliberately kept out of the smss), and it rides
-	 * along on ask calls as the built_in_tools param unless the caller
-	 * supplies their own.
+	 * The engine's saved built-in tool selection from MODELMETADATA - a JSON object
+	 * keyed by tool name. The security database is its only source of truth (the
+	 * value is deliberately kept out of the smss), and it rides along on ask calls
+	 * as the built_in_tools param unless the caller supplies their own.
 	 */
 	protected Object builtinTools = null;
 
 	/**
-	 * The max output tokens to request when the caller does not name one -
-	 * the smss value when defined, otherwise the MODELMETADATA row's
-	 * maxOutputTokens. Null when neither names one, in which case the python
-	 * clients fall back to the model's own output cap.
+	 * The max output tokens to request when the caller does not name one - the smss
+	 * value when defined, otherwise the MODELMETADATA row's maxOutputTokens. Null
+	 * when neither names one, in which case the python clients fall back to the
+	 * model's own output cap.
 	 */
 	protected Long maxTokens = null;
 
 	/**
-	 * Whether the model is capable of thinking/reasoning per the MODELMETADATA
-	 * row. Null when the table does not say either way - only an explicit
-	 * false blocks a caller from requesting thinking.
+	 * Whether the model is capable of thinking/reasoning per the MODELMETADATA row.
+	 * Null when the table does not say either way - only an explicit false blocks a
+	 * caller from requesting thinking.
 	 */
 	protected Boolean reasoning = null;
 
 	/**
-	 * The model's reasoning config from MODELMETADATA - the catalog object
-	 * holding default_enabled, default_effort, mandatory and supported_efforts.
-	 * Null when the table does not define one, in which case caller-supplied
-	 * efforts are passed through unchecked.
+	 * The model's reasoning config from MODELMETADATA - the catalog object holding
+	 * default_enabled, default_effort, mandatory and supported_efforts. Null when
+	 * the table does not define one, in which case caller-supplied efforts are
+	 * passed through unchecked.
 	 */
 	protected Map<String, Object> reasoningConfig = null;
 
 	/**
-	 * Whether the model accepts a temperature per the MODELMETADATA row. Null
-	 * when the table does not say either way - only an explicit false makes us
-	 * drop a caller supplied temperature.
+	 * Whether the model accepts a temperature per the MODELMETADATA row. Null when
+	 * the table does not say either way - only an explicit false makes us drop a
+	 * caller supplied temperature.
 	 */
 	protected Boolean temperatureSupported = null;
 
@@ -170,10 +169,10 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	}
 
 	/**
-	 * The effective max output tokens after the metadata merge: the smss file
-	 * wins under either key casing, then the metadata backfill placed under
-	 * the lowercase param key. A value that does not parse reads as unset
-	 * rather than failing engine open.
+	 * The effective max output tokens after the metadata merge: the smss file wins
+	 * under either key casing, then the metadata backfill placed under the
+	 * lowercase param key. A value that does not parse reads as unset rather than
+	 * failing engine open.
 	 */
 	private Long resolveMaxTokens() {
 		String value = this.smssProp.getProperty(Constants.MAX_TOKENS);
@@ -233,10 +232,10 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	}
 
 	/**
-	 * The smss file wins over the MODELMETADATA row for input modalities, same
-	 * as the other metadata-backed settings. An INPUT_MODALITIES property that
-	 * is present but blank disables enforcement entirely - the per-engine
-	 * escape hatch when stored metadata is wrong.
+	 * The smss file wins over the MODELMETADATA row for input modalities, same as
+	 * the other metadata-backed settings. An INPUT_MODALITIES property that is
+	 * present but blank disables enforcement entirely - the per-engine escape hatch
+	 * when stored metadata is wrong.
 	 */
 	private void applySmssInputModalitiesOverride() {
 		String smssModalities = this.smssProp.getProperty(Constants.INPUT_MODALITIES);
@@ -248,9 +247,9 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	}
 
 	/**
-	 * Normalize a stored modality list. Unrecognized values are logged and
-	 * skipped rather than thrown - a dirty metadata row must not stop the
-	 * engine from opening (strict validation happens at the write path).
+	 * Normalize a stored modality list. Unrecognized values are logged and skipped
+	 * rather than thrown - a dirty metadata row must not stop the engine from
+	 * opening (strict validation happens at the write path).
 	 */
 	private Set<ModelModalityEnum> toModalitySet(Object value) {
 		if (!(value instanceof Collection<?>)) {
@@ -287,13 +286,13 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	}
 
 	/**
-	 * Resolve the thinking params for an ask call against the model's
-	 * reasoning metadata. Caller-supplied values win, but a caller cannot turn
-	 * thinking on when the metadata marks reasoning false, and a named effort
-	 * must sit inside the config's supported_efforts list. When the caller
-	 * says nothing, the config's defaults (default_enabled/mandatory and
-	 * default_effort) ride along instead. Without a reasoning config the
-	 * caller's effort is passed through unchecked.
+	 * Resolve the thinking params for an ask call against the model's reasoning
+	 * metadata. Caller-supplied values win, but a caller cannot turn thinking on
+	 * when the metadata marks reasoning false, and a named effort must sit inside
+	 * the config's supported_efforts list. When the caller says nothing, the
+	 * config's defaults (default_enabled/mandatory and default_effort) ride along
+	 * instead. Without a reasoning config the caller's effort is passed through
+	 * unchecked.
 	 *
 	 * @return the parameters map, created when metadata defaults need a home
 	 */
@@ -339,11 +338,11 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	}
 
 	/**
-	 * Drop a caller supplied temperature when the MODELMETADATA row marks the
-	 * model as not accepting one - the reasoning models in particular reject the
-	 * param outright, and callers (including our own reactors that hardcode a
-	 * temperature) should not have to know which model is behind the engine. A
-	 * null or true metadata value leaves the parameters untouched.
+	 * Drop a caller supplied temperature when the MODELMETADATA row marks the model
+	 * as not accepting one - the reasoning models in particular reject the param
+	 * outright, and callers (including our own reactors that hardcode a
+	 * temperature) should not have to know which model is behind the engine. A null
+	 * or true metadata value leaves the parameters untouched.
 	 *
 	 * @return the same parameters map, minus the temperature when unsupported
 	 */
@@ -357,7 +356,8 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 			Map.Entry<String, Object> entry = entries.next();
 			if (entry.getKey() != null && TEMPERATURE.equalsIgnoreCase(entry.getKey().trim())) {
 				entries.remove();
-				classLogger.info("Dropping the temperature param for model {} - the model metadata says it is not supported",
+				classLogger.info(
+						"Dropping the temperature param for model {} - the model metadata says it is not supported",
 						Utility.cleanLogString(this.engineId));
 			}
 		}
@@ -365,9 +365,9 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	}
 
 	/**
-	 * Whether a caller-supplied thinking param asks for thinking to be on -
-	 * either a truthy flag (mirroring the python string_to_bool values) or an
-	 * anthropic style config map whose type is enabled/adaptive.
+	 * Whether a caller-supplied thinking param asks for thinking to be on - either
+	 * a truthy flag (mirroring the python string_to_bool values) or an anthropic
+	 * style config map whose type is enabled/adaptive.
 	 */
 	private static boolean isThinkingRequested(Object thinkingParam) {
 		if (thinkingParam == null) {
@@ -389,9 +389,9 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	}
 
 	/**
-	 * A caller-named effort must be one of the config's supported_efforts when
-	 * the config defines that list. Numeric token budgets are left for the
-	 * python side to bucket onto the effort ladder.
+	 * A caller-named effort must be one of the config's supported_efforts when the
+	 * config defines that list. Numeric token budgets are left for the python side
+	 * to bucket onto the effort ladder.
 	 */
 	private void validateEffortAllowed(Object effortParam) {
 		if (effortParam == null || effortParam instanceof Number) {
@@ -411,13 +411,13 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 				return;
 			}
 		}
-		throw new IllegalArgumentException("Effort '" + effort
-				+ "' is not supported for this model. Supported efforts: " + supported);
+		throw new IllegalArgumentException(
+				"Effort '" + effort + "' is not supported for this model. Supported efforts: " + supported);
 	}
 
 	/**
-	 * The config's default_effort as a canonical lowercase string, or null
-	 * when the config does not name one.
+	 * The config's default_effort as a canonical lowercase string, or null when the
+	 * config does not name one.
 	 */
 	private String getDefaultEffort() {
 		if (this.reasoningConfig == null) {
@@ -431,23 +431,74 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	}
 
 	/**
-	 * This is an abstract method for the implementation class such that tracking
-	 * occurs
+	 * Executes a model request using the current input message.
 	 *
-	 * @param question
-	 * @param fullPrompt
-	 * @param context
-	 * @param insight
-	 * @param roomId
-	 * @param hyperParameters
-	 * @return
+	 * @param inputMessage    current input sent to the model
+	 * @param insight         current insight
+	 * @param roomId          current room identifier
+	 * @param hyperParameters model request parameters
+	 * @return model response
 	 */
-	protected abstract AskModelEngineResponse askCall(String question, Object fullPrompt, String context,
-			Insight insight, String roomId, Map<String, Object> hyperParameters);
+	protected abstract AskModelEngineResponse askCall(InputMessage inputMessage, Insight insight, String roomId,
+			Map<String, Object> hyperParameters);
+
+	/**
+	 * Adapts the legacy model request arguments to an {@link InputMessage}.
+	 *
+	 * @param question        input text
+	 * @param fullPrompt      optional full prompt
+	 * @param context         optional system prompt
+	 * @param insight         current insight
+	 * @param roomId          current room identifier
+	 * @param hyperParameters model request parameters
+	 * @return model response
+	 * @deprecated override and call
+	 *             {@link #askCall(InputMessage, Insight, String, Map)} instead
+	 */
+	@Deprecated
+	public AskModelEngineResponse askCall(String question, Object fullPrompt, String context, Insight insight,
+			String roomId, Map<String, Object> hyperParameters) {
+		Room room = new Room();
+		room.setId(roomId);
+		room.setInsight(insight);
+
+		Map<String, Object> messageParameters = hyperParameters == null ? new HashMap<>()
+				: new HashMap<>(hyperParameters);
+		if (fullPrompt != null) {
+			messageParameters.put(FULL_PROMPT, fullPrompt);
+		}
+
+		InputMessage inputMessage = InputMessage.builder(room).withText(question).withSystemPrompt(context)
+				.withParamMap(messageParameters).build();
+		return askCall(inputMessage, insight, roomId, hyperParameters);
+	}
+
+	/**
+	 * Returns the final message in a full prompt as the input that owns the next
+	 * model response.
+	 *
+	 * @param messages normalized messages created from the full prompt
+	 * @return the final input message
+	 * @throws IllegalArgumentException when the full prompt does not end with an
+	 *                                  input message
+	 */
+	static InputMessage requireFinalInputMessage(List<AbstractMessage> messages) {
+		if (messages == null || messages.isEmpty()) {
+			throw new IllegalArgumentException("Full prompt must end with an input message");
+		}
+		AbstractMessage finalMessage = messages.get(messages.size() - 1);
+		if (!(finalMessage instanceof InputMessage)) {
+			throw new IllegalArgumentException("Full prompt must end with an input message");
+		}
+		return (InputMessage) finalMessage;
+	}
 
 	@Override
-	public AskModelEngineResponse askRoom(String question, Room room, AbstractMessage inputMessage,
-			Map<String, Object> parameters) {
+	public AskModelEngineResponse askRoom(InputMessage inputMessage, Room room, Map<String, Object> parameters) {
+		if (inputMessage == null) {
+			throw new IllegalArgumentException("Input message cannot be null");
+		}
+
 		/*
 		 * We will check if there are any restrictions for the user's current token
 		 * usage There might be a value set on the user-engine permission which takes
@@ -463,10 +514,8 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 			parameters = new HashMap<String, Object>();
 		}
 
-		String context = null;
-		if (inputMessage instanceof InputMessage) {
-			context = ((InputMessage) inputMessage).getSystemPrompt();
-		}
+		String promptForLogs = inputMessage.getFullInputPrompt();
+		InputMessage inferenceInputMessage = inputMessage;
 
 		// if full prompt is being sent, convert the full prompt to a set of
 		// AbstractMessages
@@ -476,6 +525,7 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 				.acquireMutationLock(fullPrompt != null ? room : null)) {
 			if (fullPrompt != null) {
 				List<AbstractMessage> messageList = MessageUtils.convertFullPrompt(fullPrompt, room, this);
+				inferenceInputMessage = requireFinalInputMessage(messageList);
 				Object appendFullPrompt = parameters.remove(APPEND_FULL_PROMPT);
 				if (appendFullPrompt != null && Boolean.parseBoolean(appendFullPrompt + "")) {
 					String userId = room.getInsight().getUser().getPrimaryLoginToken().getId();
@@ -492,9 +542,7 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 					validateInputModalities(messageList);
 					room.setMessages(messageList);
 				}
-				String messageJson = RoomMessageStore.providerMessageHistory(room, messageList);
-				question = messageJson;
-				parameters.put("message_json", messageJson);
+				parameters.put("message_json", RoomMessageStore.providerMessageHistory(room, messageList));
 
 				Object toolChoiceObj = parameters.get("tool_choice");
 				if (toolChoiceObj != null) {
@@ -524,23 +572,20 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 					}
 				}
 
-				// when we convert from fullPrompt to semoss message structure
-				// inputMessage in the method is not the same as the message array of the room
-				// so update to the last message of the array
-				inputMessage = room.getMessages().getLast();
-
 				fullPrompt = MessageUtils.toJsonArray(room.getMessages());
-				question = MessageUtils.toJsonArray(room.getMessages());
+				promptForLogs = (String) fullPrompt;
 			}
 
 			if (fullPrompt == null) {
 				// incremental ask: the provider payload is the branch ending at
 				// inputMessage (the fullPrompt path validated its list above)
-				validateInputModalities(room.getMessages(), inputMessage);
+				validateInputModalities(room.getMessages(), inferenceInputMessage);
+				parameters.put("message_json",
+						RoomMessageStore.messageHistoryWithNewMessage(room, inferenceInputMessage));
 			}
 
 			ZonedDateTime inputTime = ZonedDateTime.now();
-			AskModelEngineResponse askModelResponse = askCall(question, null, context, room.getInsight(), room.getId(),
+			AskModelEngineResponse askModelResponse = askCall(inferenceInputMessage, room.getInsight(), room.getId(),
 					parameters);
 			ZonedDateTime outputTime = ZonedDateTime.now();
 
@@ -570,7 +615,7 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 			// @formatter:off
 			if (inferenceLogsEnbaled) {
 				Thread inferenceRecorder = new Thread(new ModelEngineInferenceLogsWorker (
-						/*messageId*/ inputMessage.getMessageId(),
+						/*messageId*/ inferenceInputMessage.getMessageId(),
 						/*transactionId*/askModelResponse.getMessageId(),
 						/*messageMethod*/inferenceLogMessageMethod("ask"),
 						/*engine*/this,
@@ -580,8 +625,8 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 						/*user*/room.getInsight().getUser(),
 						/*sessionId*/ThreadStore.getSessionId(),
 						/*roomId*/room.getId(),
-						/*context*/context,
-						/*prompt*/question,
+						/*context*/inferenceInputMessage.getSystemPrompt(),
+						/*prompt*/promptForLogs,
 						/*fullPrompt*/fullPrompt,
 						/*promptTokens*/askModelResponse.getNumberOfTokensInPrompt(),
 						/*inputTime*/inputTime,
@@ -628,14 +673,14 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 				room.getMessages().add(response);
 
 				// set transaction id for both pieces
-				inputMessage.setTransactionId(response.getMessageId());
-				inputMessage.setTokensInMessage(askModelResponse.getNumberOfTokensInPrompt());
-				inputMessage.setCacheReadTokens(askModelResponse.getNumberOfCacheReadTokens());
+				inferenceInputMessage.setTransactionId(response.getMessageId());
+				inferenceInputMessage.setTokensInMessage(askModelResponse.getNumberOfTokensInPrompt());
+				inferenceInputMessage.setCacheReadTokens(askModelResponse.getNumberOfCacheReadTokens());
 				response.setTransactionId(response.getMessageId());
 
 				// Create the assistant's response message and add to history
 				response.setModel(this);
-				response.setParentMessageId(inputMessage.getMessageId());
+				response.setParentMessageId(inferenceInputMessage.getMessageId());
 				response.setTokensInMessage(askModelResponse.getNumberOfTokensInResponse());
 
 				RoomMessageStore.persist(room, room.getInsight().getUser().getPrimaryLoginToken().getId());
@@ -646,15 +691,15 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	}
 
 	/**
-	 * Enforce the configured input modalities on the exact outbound message
-	 * list. The rules, chosen so enforcement never rejects content the model is
-	 * not actually asked to accept:
+	 * Enforce the configured input modalities on the exact outbound message list.
+	 * The rules, chosen so enforcement never rejects content the model is not
+	 * actually asked to accept:
 	 * <ul>
-	 * <li>Only INPUT-direction messages are checked - the model's own responses
-	 * in history are its output, not caller input.</li>
-	 * <li>Only MEDIA parts are checked - a text command is required on every
-	 * ask and system prompts are platform-injected, so TEXT is never a basis
-	 * for rejection.</li>
+	 * <li>Only INPUT-direction messages are checked - the model's own responses in
+	 * history are its output, not caller input.</li>
+	 * <li>Only MEDIA parts are checked - a text command is required on every ask
+	 * and system prompts are platform-injected, so TEXT is never a basis for
+	 * rejection.</li>
 	 * <li>Media whose modality cannot be determined (no MIME type, opaque URL)
 	 * passes - enforcement fails open on unknowns; strict typing belongs to the
 	 * metadata write path.</li>
@@ -672,9 +717,8 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 
 	/**
 	 * Branch-scoped variant for the incremental ask path: validates the
-	 * root-to-leaf branch ending at {@code inputMessage} (or at the current
-	 * tail when null), matching the payload the provider history builders
-	 * serialize.
+	 * root-to-leaf branch ending at {@code inputMessage} (or at the current tail
+	 * when null), matching the payload the provider history builders serialize.
 	 */
 	void validateInputModalities(List<AbstractMessage> messages, AbstractMessage inputMessage) {
 		if (this.inputModalities == null) {
@@ -692,9 +736,9 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	}
 
 	/**
-	 * Lightweight root-to-leaf parent walk. Unlike the payload builders this
-	 * only needs to read part types, so it skips their tool-pruning deep
-	 * copies. Broken parent links end the walk; cycles are guarded.
+	 * Lightweight root-to-leaf parent walk. Unlike the payload builders this only
+	 * needs to read part types, so it skips their tool-pruning deep copies. Broken
+	 * parent links end the walk; cycles are guarded.
 	 */
 	private static List<AbstractMessage> messageBranch(List<AbstractMessage> messages, AbstractMessage leaf) {
 		Map<String, AbstractMessage> messagesById = new HashMap<>();
@@ -766,9 +810,9 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 
 	/**
 	 * messageMethod recorded on inference log rows written by this engine.
-	 * Delegating engines (e.g. the model router) override this to tag their
-	 * rows, so ask-history queries and usage aggregations can separate the
-	 * delegating row from the actual model call.
+	 * Delegating engines (e.g. the model router) override this to tag their rows,
+	 * so ask-history queries and usage aggregations can separate the delegating row
+	 * from the actual model call.
 	 */
 	protected String inferenceLogMessageMethod(String method) {
 		return method;
@@ -841,7 +885,6 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 
 		return embeddingsResponse;
 	}
-
 
 	/**
 	 *

--- a/src/prerna/engine/impl/model/AbstractPythonModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractPythonModelEngine.java
@@ -49,6 +49,7 @@ import prerna.engine.api.ModelModalityEnum;
 import prerna.engine.api.ModelTypeEnum;
 import prerna.engine.impl.SmssUtilities;
 import prerna.engine.impl.model.inferencetracking.ModelInferenceLogsUtils;
+import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.responses.AskErrorModelEngineResponse;
 import prerna.engine.impl.model.responses.AskModelEngineResponse;
 import prerna.engine.impl.model.responses.BatchListResponse;
@@ -279,8 +280,8 @@ public abstract class AbstractPythonModelEngine extends AbstractModelEngine {
 	}
 
 	@Override
-	public AskModelEngineResponse askCall(String question, Object fullPrompt, String context, Insight insight,
-			String roomId, Map<String, Object> parameters) {
+	public AskModelEngineResponse askCall(InputMessage inputMessage, Insight insight, String roomId,
+			Map<String, Object> parameters) {
 		if (ModelInferenceLogsUtils.isRoomInActive(insight.getUserId(), roomId)) {
 			throw new IllegalArgumentException(
 					"The room being referenced has been permanently closed. Please open a new room");

--- a/src/prerna/engine/impl/model/AbstractRemoteModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractRemoteModelEngine.java
@@ -56,6 +56,7 @@ import prerna.cluster.util.ZKClientFactory;
 import prerna.engine.api.ModelTypeEnum;
 import prerna.engine.api.RemoteModelStateEnum;
 import prerna.engine.impl.model.kserve.KServeAdapter;
+import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.responses.AskModelEngineResponse;
 import prerna.engine.impl.model.responses.EmbeddingsModelEngineResponse;
 import prerna.om.Insight;
@@ -70,6 +71,7 @@ import prerna.util.Settings;
  */
 
 public class AbstractRemoteModelEngine extends AbstractModelEngine {
+
 	private static final Logger classLogger = LogManager.getLogger(AbstractRemoteModelEngine.class);
 
 	protected String model;
@@ -482,8 +484,8 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 	}
 
 	@Override
-	protected AskModelEngineResponse askCall(String question, Object fullPrompt, String context, Insight insight,
-			String roomId, Map<String, Object> hyperParameters) {
+	protected AskModelEngineResponse askCall(InputMessage inputMessage, Insight insight, String roomId,
+			Map<String, Object> hyperParameters) {
 		try {
 			checkModelUp();
 			String modelUrl = getModelUrl();
@@ -502,7 +504,7 @@ public class AbstractRemoteModelEngine extends AbstractModelEngine {
 			}
 
 			hyperParameters.put("stream", false);
-			return implementingEngineClass.askCall(question, fullPrompt, context, insight, roomId, hyperParameters);
+			return implementingEngineClass.askCall(inputMessage, insight, roomId, hyperParameters);
 		} catch (Exception e) {
 			classLogger.error("Error getting model URL or deploying model", e);
 			return null;

--- a/src/prerna/engine/impl/model/KServeImageEngine.java
+++ b/src/prerna/engine/impl/model/KServeImageEngine.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 
 import prerna.engine.api.ModelTypeEnum;
+import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.responses.AskImageModelEngineResponse;
 import prerna.om.Insight;
 
@@ -43,13 +44,13 @@ public class KServeImageEngine extends AbstractRemoteModelEngine {
 	private static final Logger classLogger = LogManager.getLogger(KServeImageEngine.class);
 
 	@Override
-	public AskImageModelEngineResponse askCall(String question, Object fullPrompt, String context, Insight insight,
-			String roomId, Map<String, Object> hyperParameters) {
+	public AskImageModelEngineResponse askCall(InputMessage inputMessage, Insight insight, String roomId,
+			Map<String, Object> hyperParameters) {
 		classLogger.debug("Handling KServeImage Request..");
 
 		JSONObject payload = new JSONObject();
 
-		payload.put("prompt", question);
+		payload.put("prompt", inputMessage.getFullInputPrompt());
 
 		if (hyperParameters != null) {
 			if (hyperParameters.containsKey("negative_prompt")) {

--- a/src/prerna/engine/impl/model/KServeTTSEngine.java
+++ b/src/prerna/engine/impl/model/KServeTTSEngine.java
@@ -35,6 +35,7 @@ import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 
 import prerna.engine.api.ModelTypeEnum;
+import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.responses.AskTTSModelEngineResponse;
 import prerna.om.Insight;
 
@@ -43,13 +44,14 @@ public class KServeTTSEngine extends AbstractRemoteModelEngine {
 	private static final Logger classLogger = LogManager.getLogger(KServeTTSEngine.class);
 
 	@Override
-	public AskTTSModelEngineResponse askCall(String question, Object fullPrompt, String context, Insight insight,
-			String roomId, Map<String, Object> parameters) {
-		classLogger.debug("Handling KServeTTS Request for text: {}", question);
+	public AskTTSModelEngineResponse askCall(InputMessage inputMessage, Insight insight, String roomId,
+			Map<String, Object> parameters) {
+		String inputText = inputMessage.getFullInputPrompt();
+		classLogger.debug("Handling KServeTTS Request for text: {}", inputText);
 
 		JSONObject payload = new JSONObject();
 
-		payload.put("text", question);
+		payload.put("text", inputText);
 
 		if (parameters != null) {
 			if (parameters.containsKey("voice")) {

--- a/src/prerna/engine/impl/model/KServeVisionEngine.java
+++ b/src/prerna/engine/impl/model/KServeVisionEngine.java
@@ -34,6 +34,7 @@ import org.apache.logging.log4j.Logger;
 import org.json.JSONObject;
 
 import prerna.engine.api.ModelTypeEnum;
+import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.responses.AskStringModelEngineResponse;
 import prerna.om.Insight;
 
@@ -42,8 +43,8 @@ public class KServeVisionEngine extends AbstractRemoteModelEngine {
 	private static final Logger classLogger = LogManager.getLogger(KServeVisionEngine.class);
 
 	@Override
-	public AskStringModelEngineResponse askCall(String question, Object fullPrompt, String context, Insight insight,
-			String roomId, Map<String, Object> hyperParameters) {
+	public AskStringModelEngineResponse askCall(InputMessage inputMessage, Insight insight, String roomId,
+			Map<String, Object> hyperParameters) {
 		classLogger.debug("Handling KServeVision Request..");
 
 		JSONObject payload = new JSONObject();
@@ -59,7 +60,7 @@ public class KServeVisionEngine extends AbstractRemoteModelEngine {
 			return response;
 		}
 
-		payload.put("text", question);
+		payload.put("text", inputMessage.getFullInputPrompt());
 
 		classLogger.debug("KServeVision askCall payload: {}", payload.toString(2));
 

--- a/src/prerna/engine/impl/model/ModelRouterEngine.java
+++ b/src/prerna/engine/impl/model/ModelRouterEngine.java
@@ -70,29 +70,35 @@ import prerna.util.EngineUtility;
 import prerna.util.Utility;
 
 /**
- * ModelRouterEngine is a routing {@link IModelEngine} that dispatches each
- * request to one of several backing model engines.
+ * <p>
+ * Routes each model request to one of several backing {@link IModelEngine model
+ * engines}.
+ * </p>
  *
- * <p>All routing configuration lives in a JSON file in the engine's assets
- * folder. By convention the engine loads <b>router.json</b>; the optional SMSS
- * property ROUTER_CONFIG overrides the file name. Beyond that, the SMSS file
- * only needs the standard engine identity keys:
+ * <p>
+ * Routing configuration lives in a JSON file in the engine's assets folder. By
+ * convention, the engine loads {@code router.json}. The optional
+ * {@value #ROUTER_CONFIG} SMSS property overrides the file name. The SMSS file
+ * otherwise needs only the standard engine identity keys:
+ * </p>
+ *
  * <pre>
  * ENGINE_TYPE = prerna.engine.impl.model.ModelRouterEngine
  * MODEL_TYPE  = MODEL_ROUTER
  * </pre>
  *
  * <h3>router.json schema</h3>
+ *
  * <pre>
  * {
  *   "mode": "keyword",                 // "keyword" | "llm" | "weighted"
- *   "sticky": true,                    // pin a conversation to the route that first serves it (default true)
+ *   "sticky": true,                    // pin a room to its first route (default true)
  *   "default_route": "&lt;engineId&gt;",     // used when no route matches (defaults to route 0)
  *   "fallbacks": ["&lt;engineId&gt;"],       // tried in order when the chosen target fails
  *   "classifier_engine": "&lt;engineId&gt;", // required for "llm" mode
  *   "embeddings_engine": "&lt;engineId&gt;", // required for the router to serve embeddings
  *   "routes": [
- *     { "name": "code",   "engine_id": "aa876e7e-...", "keywords": ["java", "python", "debug"],
+ *     { "name": "code", "engine_id": "aa876e7e-...", "keywords": ["java", "python", "debug"],
  *       "description": "Programming questions: debugging, writing and reviewing code", "weight": 70 },
  *     { "name": "sports", "engine_id": "8380e91f-...", "keywords": ["nba", "nfl", "score"],
  *       "description": "Sports questions: scores, players, teams and schedules", "weight": 30 }
@@ -100,58 +106,83 @@ import prerna.util.Utility;
  * }
  * </pre>
  *
- * <h3>Modes</h3>
+ * <h3>Routing modes</h3>
+ *
  * <ul>
- * <li><b>keyword</b> - first route with a whole-word keyword match on the
- * latest user message wins; otherwise the default route.</li>
- * <li><b>llm</b> - the classifier engine picks a route by reading each route's
- * description (required on every route in this mode); falls back to keyword
- * matching when classification fails, so keywords are the optional safety
- * net here.</li>
- * <li><b>weighted</b> - deterministic weighted round-robin across routes with
- * weight &gt; 0 (weights 30/70 give an exact 30/70 split every cycle).</li>
+ * <li><b>keyword</b>: The first route with a whole-word keyword match on the
+ * latest input wins. Otherwise, the default route is used.</li>
+ * <li><b>llm</b>: The classifier engine selects a route from each route's
+ * description. Every route requires a description. Keyword matching is used as
+ * a fallback when classification fails.</li>
+ * <li><b>weighted</b>: Deterministic weighted round-robin is applied across
+ * routes whose weight is greater than zero. For example, weights of 30 and 70
+ * produce an exact 30/70 split during each cycle.</li>
  * </ul>
  *
  * <h3>Sticky routing</h3>
- * When sticky is on (the default), the first turn of a room selects a route
- * and later turns reuse it, so a conversation stays on one model and llm mode
- * pays the classifier cost only once per room. Under weighted mode this makes
- * the traffic split per-conversation rather than per-request. A pin is dropped
- * when its engine fails and the turn is served by a failover candidate. Pins
- * are held in a bounded in-memory map per router instance, so they reset on
- * engine reload and are not shared across nodes.
+ *
+ * <p>
+ * Sticky routing is enabled by default. The first turn selects a route, and
+ * later turns in that room reuse it. This keeps a conversation on one model and
+ * avoids repeated classifier calls in {@code llm} mode. In {@code weighted}
+ * mode, traffic is therefore divided by conversation rather than by request.
+ * </p>
+ *
+ * <p>
+ * A pin is removed when its engine fails and a fallback serves the request.
+ * Pins are stored in a bounded in-memory map per router instance. They reset
+ * when the engine reloads and are not shared across nodes.
+ * </p>
  *
  * <h3>Failover</h3>
- * When the chosen target fails (engine will not load, or the ask errors), the
- * router tries the fallbacks list in order and finally the default route. The
- * last failure is rethrown when every candidate fails.
+ *
+ * <p>
+ * When the selected engine cannot load or its request fails, the router tries
+ * the configured fallbacks in order and then the default route. The last error
+ * is rethrown when every candidate fails.
+ * </p>
  *
  * <h3>Access control</h3>
- * Access to the router does NOT implicitly grant its backing engines: each
- * candidate target (ask and embeddings) is checked with
- * {@link SecurityEngineUtils#userCanViewEngine(User, String)} for the calling
- * user, and denied candidates are skipped. The classifier engine is exempt -
- * it is internal plumbing whose output the user never sees directly.
  *
- * <h3>Inference logs</h3>
- * Requests are logged twice by design: once under this router's engine id
- * (user-facing attribution) and once under the delegated engine's id (actual
- * model usage). The router's rows are tagged with messageMethod "route_ask" /
- * "route_embeddings" so ask-history queries and usage aggregations only count
- * the delegated engine's "ask" / "embeddings" rows.
+ * <p>
+ * Access to the router does not grant access to its backing engines. Every ask
+ * and embeddings candidate is checked with
+ * {@link SecurityEngineUtils#userCanViewEngine(User, String)}. Candidates the
+ * caller cannot access are skipped. The classifier engine is exempt because it
+ * is internal routing infrastructure and its output is not returned directly.
+ * </p>
  *
- * <p>The chosen target is surfaced on the response metadata under the
- * router_engine_id / routed_engine_id / routed_route_name keys.
+ * <h3>Inference logging</h3>
  *
- * <p>The configuration can be edited at runtime through the
- * GetModelRouterConfig / UpdateModelRouterConfig reactors, which read and
- * rewrite the config file and then {@link #reloadConfig()} the live instance.
+ * <p>
+ * Requests are logged once under the router for user-facing attribution and
+ * once under the delegated engine for actual model usage. Router rows use
+ * {@code route_ask} or {@code route_embeddings}; usage and history queries
+ * count only the delegated engine's {@code ask} or {@code embeddings} rows.
+ * </p>
+ *
+ * <h3>Response metadata</h3>
+ *
+ * <p>
+ * The selected target is returned under {@code router_engine_id},
+ * {@code routed_engine_id}, and {@code routed_route_name}.
+ * </p>
+ *
+ * <h3>Runtime updates</h3>
+ *
+ * <p>
+ * The {@code GetModelRouterConfig} and {@code UpdateModelRouterConfig} reactors
+ * read and update the configuration file. Updates call {@link #reloadConfig()}
+ * on the live router instance.
+ * </p>
  */
 public class ModelRouterEngine extends AbstractModelEngine implements IModelRouterEngine {
 
 	private static final Logger classLogger = LogManager.getLogger(ModelRouterEngine.class);
 
-	/** Optional SMSS property overriding the config file name in the assets folder. */
+	/**
+	 * Optional SMSS property overriding the config file name in the assets folder.
+	 */
 	public static final String ROUTER_CONFIG = "ROUTER_CONFIG";
 	/** Conventional config file name looked up when ROUTER_CONFIG is not set. */
 	public static final String DEFAULT_CONFIG_FILE = "router.json";
@@ -168,8 +199,8 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 	public static final String METADATA_ROUTED_ENGINE_ID = "routed_engine_id";
 	public static final String METADATA_ROUTED_ROUTE_NAME = "routed_route_name";
 
-	private static final String MODE_KEYWORD  = "keyword";
-	private static final String MODE_LLM      = "llm";
+	private static final String MODE_KEYWORD = "keyword";
+	private static final String MODE_LLM = "llm";
 	private static final String MODE_WEIGHTED = "weighted";
 
 	private static final String MESSAGE_JSON = "message_json";
@@ -207,13 +238,20 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 	private volatile String classifierEngineId;
 	private volatile String embeddingsEngineId;
 	private volatile int totalWeight = 0;
-	/** Round-robin counter for weighted mode - increments on every weighted call. */
+	/**
+	 * Round-robin counter for weighted mode - increments on every weighted call.
+	 */
 	private final AtomicInteger rrCounter = new AtomicInteger(0);
-	/** Lazily computed min context window across serving targets; null = not yet computed. */
+	/**
+	 * Lazily computed min context window across serving targets; null = not yet
+	 * computed.
+	 */
 	private volatile Integer derivedContextWindow;
-	/** LRU of roomId -> engineId that last served the room, used when sticky is on. */
-	private final Map<String, String> roomRoutePins = Collections.synchronizedMap(
-			new LinkedHashMap<String, String>(128, 0.75f, true) {
+	/**
+	 * LRU of roomId -> engineId that last served the room, used when sticky is on.
+	 */
+	private final Map<String, String> roomRoutePins = Collections
+			.synchronizedMap(new LinkedHashMap<String, String>(128, 0.75f, true) {
 				@Override
 				protected boolean removeEldestEntry(Map.Entry<String, String> eldest) {
 					return size() > MAX_STICKY_ROOMS;
@@ -230,16 +268,16 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 	}
 
 	@Override
-	public void close() throws IOException {}
+	public void close() throws IOException {
+	}
 
 	/**
-	 * Callers sizing work off this engine (e.g. agent auto-compaction) cannot
-	 * know which route will serve them, so answer with the smallest context
-	 * window among the serving targets: routes, default route, and fallbacks.
-	 * An explicit CONTEXT_WINDOW in the smss/metadata still wins. Targets that
-	 * fail to load or do not report a window are skipped; when none report one,
-	 * 0 is returned and callers treat it as unknown. Computed once per config
-	 * (re)load.
+	 * Callers sizing work off this engine (e.g. agent auto-compaction) cannot know
+	 * which route will serve them, so answer with the smallest context window among
+	 * the serving targets: routes, default route, and fallbacks. An explicit
+	 * CONTEXT_WINDOW in the smss/metadata still wins. Targets that fail to load or
+	 * do not report a window are skipped; when none report one, 0 is returned and
+	 * callers treat it as unknown. Computed once per config (re)load.
 	 */
 	@Override
 	public int getContextWindow() {
@@ -293,18 +331,21 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 	public void open(Properties smssProp) throws Exception {
 		super.open(smssProp);
 		reloadConfig();
-		classLogger.info("ModelRouterEngine '{}' loaded: {} route(s), mode={}, sticky={}",
-				this.engineId, this.routes.size(), this.routingMode, this.sticky);
+		classLogger.info("ModelRouterEngine '{}' loaded: {} route(s), mode={}, sticky={}", this.engineId,
+				this.routes.size(), this.routingMode, this.sticky);
 	}
 
-	/** The config file this router reads: assets/&lt;ROUTER_CONFIG or router.json&gt;. */
+	/**
+	 * The config file this router reads: assets/&lt;ROUTER_CONFIG or
+	 * router.json&gt;.
+	 */
 	public File resolveConfigFile() {
 		String configFileName = this.smssProp.getProperty(ROUTER_CONFIG);
 		if (configFileName == null || configFileName.trim().isEmpty()) {
 			configFileName = DEFAULT_CONFIG_FILE;
 		}
-		String assetsFolder = EngineUtility.getSpecificEngineAssetsFolder(
-				IEngine.CATALOG_TYPE.MODEL, this.engineId, this.engineName);
+		String assetsFolder = EngineUtility.getSpecificEngineAssetsFolder(IEngine.CATALOG_TYPE.MODEL, this.engineId,
+				this.engineName);
 		return new File((assetsFolder + "/" + configFileName.trim()).replace("\\", "/"));
 	}
 
@@ -319,8 +360,8 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 	}
 
 	/**
-	 * Re-reads and applies the config file on the live instance. Used at open
-	 * and after {@link #updateConfig(String)} rewrites the file.
+	 * Re-reads and applies the config file on the live instance. Used at open and
+	 * after {@link #updateConfig(String)} rewrites the file.
 	 */
 	@Override
 	public synchronized void reloadConfig() throws IOException {
@@ -330,8 +371,8 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 		}
 		if (!configFile.exists()) {
 			throw new IOException("ModelRouterEngine: routing config not found at " + configFile.getAbsolutePath()
-					+ ". Place a " + DEFAULT_CONFIG_FILE + " in the engine assets folder"
-					+ " (or set " + ROUTER_CONFIG + " in the SMSS to use a different file name).");
+					+ ". Place a " + DEFAULT_CONFIG_FILE + " in the engine assets folder" + " (or set " + ROUTER_CONFIG
+					+ " in the SMSS to use a different file name).");
 		}
 		String json = new String(Files.readAllBytes(configFile.toPath()), StandardCharsets.UTF_8);
 		RouterConfig cfg = parseAndValidateConfig(json, configFile.getName(), this.engineId);
@@ -339,9 +380,9 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 	}
 
 	/**
-	 * Seed the config file from the ROUTER_CONFIG_JSON smss property when the
-	 * file does not exist yet - engine creation opens the engine before any
-	 * asset can be uploaded. Never overwrites an existing file.
+	 * Seed the config file from the ROUTER_CONFIG_JSON smss property when the file
+	 * does not exist yet - engine creation opens the engine before any asset can be
+	 * uploaded. Never overwrites an existing file.
 	 */
 	private void bootstrapConfigFileIfNeeded(File configFile) throws IOException {
 		String bootstrapJson = this.smssProp.getProperty(ROUTER_CONFIG_JSON);
@@ -350,18 +391,19 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 		}
 		File parentFolder = configFile.getParentFile();
 		if (parentFolder != null && !parentFolder.exists() && !parentFolder.mkdirs()) {
-			throw new IOException("ModelRouterEngine: could not create assets folder " + parentFolder.getAbsolutePath());
+			throw new IOException(
+					"ModelRouterEngine: could not create assets folder " + parentFolder.getAbsolutePath());
 		}
 		try (Writer writer = new OutputStreamWriter(new FileOutputStream(configFile), StandardCharsets.UTF_8)) {
 			writer.write(bootstrapJson.trim());
 		}
-		classLogger.info("ModelRouterEngine '{}' seeded {} from the {} smss property",
-				this.engineId, configFile.getName(), ROUTER_CONFIG_JSON);
+		classLogger.info("ModelRouterEngine '{}' seeded {} from the {} smss property", this.engineId,
+				configFile.getName(), ROUTER_CONFIG_JSON);
 	}
 
 	/**
-	 * Validates the given JSON, persists it to the config file, and applies it
-	 * to the live instance. Nothing is written when validation fails.
+	 * Validates the given JSON, persists it to the config file, and applies it to
+	 * the live instance. Nothing is written when validation fails.
 	 */
 	@Override
 	public synchronized void updateConfig(String json) throws IOException {
@@ -371,16 +413,16 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 			writer.write(json);
 		}
 		applyConfig(cfg);
-		classLogger.info("ModelRouterEngine '{}' config updated: {} route(s), mode={}, sticky={}",
-				this.engineId, this.routes.size(), this.routingMode, this.sticky);
+		classLogger.info("ModelRouterEngine '{}' config updated: {} route(s), mode={}, sticky={}", this.engineId,
+				this.routes.size(), this.routingMode, this.sticky);
 	}
 
 	/**
-	 * Parses and validates router config JSON without touching any engine
-	 * state, so both engine open and the update reactor share one set of
-	 * rules. Fails on configurations that would otherwise silently degrade at
-	 * request time (unknown mode, llm without a classifier or descriptions,
-	 * weighted without weights, a route pointing back at the router).
+	 * Parses and validates router config JSON without touching any engine state, so
+	 * both engine open and the update reactor share one set of rules. Fails on
+	 * configurations that would otherwise silently degrade at request time (unknown
+	 * mode, llm without a classifier or descriptions, weighted without weights, a
+	 * route pointing back at the router).
 	 *
 	 * @param json           the raw config JSON
 	 * @param configName     file/source name used in error messages
@@ -392,7 +434,8 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 		try {
 			cfg = new Gson().fromJson(json, RouterConfig.class);
 		} catch (JsonSyntaxException e) {
-			throw new IllegalArgumentException("ModelRouterEngine: " + configName + " is not valid JSON - " + e.getMessage(), e);
+			throw new IllegalArgumentException(
+					"ModelRouterEngine: " + configName + " is not valid JSON - " + e.getMessage(), e);
 		}
 		if (cfg == null || cfg.routes == null || cfg.routes.isEmpty()) {
 			throw new IllegalArgumentException("ModelRouterEngine: " + configName + " must define at least one route");
@@ -410,30 +453,36 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 		for (int i = 0; i < cfg.routes.size(); i++) {
 			RouteConfig rc = cfg.routes.get(i);
 			if (rc.engine_id == null || rc.engine_id.trim().isEmpty()) {
-				throw new IllegalArgumentException("ModelRouterEngine: route " + i + " in " + configName + " is missing engine_id");
+				throw new IllegalArgumentException(
+						"ModelRouterEngine: route " + i + " in " + configName + " is missing engine_id");
 			}
 			String name = resolvedRouteName(rc, i);
 			if (!seenNames.add(name.toLowerCase())) {
-				throw new IllegalArgumentException("ModelRouterEngine: duplicate route name '" + name + "' in " + configName);
+				throw new IllegalArgumentException(
+						"ModelRouterEngine: duplicate route name '" + name + "' in " + configName);
 			}
 			rejectSelfReference(rc.engine_id.trim(), "route '" + name + "'", configName, routerEngineId);
 			totalWeight += Math.max(0, rc.weight);
 			anyKeywords = anyKeywords || (rc.keywords != null && !rc.keywords.isEmpty());
 
 			if (MODE_LLM.equals(mode) && trimOrNull(rc.description) == null) {
-				throw new IllegalArgumentException("ModelRouterEngine: mode 'llm' requires a description on every route - route '"
-						+ name + "' in " + configName + " is missing one");
+				throw new IllegalArgumentException(
+						"ModelRouterEngine: mode 'llm' requires a description on every route - route '" + name + "' in "
+								+ configName + " is missing one");
 			}
 		}
 
 		if (MODE_LLM.equals(mode) && trimOrNull(cfg.classifier_engine) == null) {
-			throw new IllegalArgumentException("ModelRouterEngine: mode 'llm' requires classifier_engine in " + configName);
+			throw new IllegalArgumentException(
+					"ModelRouterEngine: mode 'llm' requires classifier_engine in " + configName);
 		}
 		if (MODE_WEIGHTED.equals(mode) && totalWeight <= 0) {
-			throw new IllegalArgumentException("ModelRouterEngine: mode 'weighted' requires at least one route with weight > 0 in " + configName);
+			throw new IllegalArgumentException(
+					"ModelRouterEngine: mode 'weighted' requires at least one route with weight > 0 in " + configName);
 		}
 		if (MODE_KEYWORD.equals(mode) && !anyKeywords) {
-			classLogger.warn("ModelRouterEngine ({}): mode is 'keyword' but no route defines keywords - every request will use the default route",
+			classLogger.warn(
+					"ModelRouterEngine ({}): mode is 'keyword' but no route defines keywords - every request will use the default route",
 					configName);
 		}
 
@@ -515,8 +564,8 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 	}
 
 	/**
-	 * Case-insensitive whole-word alternation over the route's keywords. Word
-	 * edges are checked with alphanumeric lookarounds instead of \b so keywords
+	 * Case-insensitive whole-word alternation over the route's keywords. Word edges
+	 * are checked with alphanumeric lookarounds instead of \b so keywords
 	 * containing symbols (e.g. "c++") still match.
 	 */
 	private static Pattern buildKeywordPattern(List<String> keywords) {
@@ -564,47 +613,17 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 	}
 
 	/**
-	 * Internal parameter key handing the caller's real input message from
-	 * askRoom to askCall so each routing candidate can be validated against the
-	 * actual conversation content. Removed before anything reaches a provider.
-	 */
-	private static final String ROUTED_INPUT_MESSAGE = "__routedInputMessage";
-
-	@Override
-	public AskModelEngineResponse askRoom(String question, Room room, AbstractMessage inputMessage,
-			Map<String, Object> parameters) {
-		if (parameters != null && inputMessage != null) {
-			parameters.put(ROUTED_INPUT_MESSAGE, inputMessage);
-		}
-		try {
-			return super.askRoom(question, room, inputMessage, parameters);
-		} finally {
-			// never let the stash outlive the call - the caller's map may be
-			// reused or serialized
-			if (parameters != null) {
-				parameters.remove(ROUTED_INPUT_MESSAGE);
-			}
-		}
-	}
-
-	/**
 	 * The router delegates - its own metadata row does not restrict content.
-	 * Enforcement runs in askCall against each routed target's configured
-	 * input modalities.
+	 * Enforcement runs in askCall against each routed target's configured input
+	 * modalities.
 	 */
 	@Override
 	public void validateInputModalities(List<AbstractMessage> outboundMessages) {
 	}
 
 	@Override
-	protected AskModelEngineResponse askCall(String question, Object fullPrompt, String context,
-			Insight insight, String roomId, Map<String, Object> hyperParameters) {
-
-		AbstractMessage routedInputMessage = null;
-		if (hyperParameters != null
-				&& hyperParameters.remove(ROUTED_INPUT_MESSAGE) instanceof AbstractMessage stashed) {
-			routedInputMessage = stashed;
-		}
+	protected AskModelEngineResponse askCall(InputMessage inputMessage, Insight insight, String roomId,
+			Map<String, Object> hyperParameters) {
 
 		// Reuses the caller's already-loaded room; the stateless lookup avoids
 		// re-acquiring the room mutation lock this request may already hold.
@@ -616,16 +635,15 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 			String pinned = roomRoutePins.get(roomId);
 			if (pinned != null && userCanUseTarget(user, pinned)) {
 				primaryEngineId = pinned;
-				classLogger.debug("ModelRouterEngine '{}' room {} reusing pinned engineId={}",
-						this.engineId, roomId, pinned);
+				classLogger.debug("ModelRouterEngine '{}' room {} reusing pinned engineId={}", this.engineId, roomId,
+						pinned);
 			}
 		}
 		if (primaryEngineId == null) {
-			String routingText = extractRoutingText(question, room);
+			String routingText = extractRoutingText(inputMessage, room);
 			primaryEngineId = selectRoute(routingText, insight, room);
 			if (classLogger.isDebugEnabled()) {
-				classLogger.debug("ModelRouterEngine '{}' routing text: {}",
-						this.engineId, truncate(routingText, 200));
+				classLogger.debug("ModelRouterEngine '{}' routing text: {}", this.engineId, truncate(routingText, 200));
 			}
 		}
 
@@ -633,7 +651,8 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 		Exception lastFailure = null;
 		for (String candidateId : candidates) {
 			if (!userCanUseTarget(user, candidateId)) {
-				classLogger.warn("ModelRouterEngine '{}': user does not have access to engineId={} - skipping candidate",
+				classLogger.warn(
+						"ModelRouterEngine '{}': user does not have access to engineId={} - skipping candidate",
 						this.engineId, candidateId);
 				continue;
 			}
@@ -648,27 +667,15 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 				continue;
 			}
 
-			classLogger.info("ModelRouterEngine '{}' routing room {} to engineId={}",
-					this.engineId, roomId, candidateId);
+			classLogger.info("ModelRouterEngine '{}' routing room {} to engineId={}", this.engineId, roomId,
+					candidateId);
 			try {
 				if (targetEngine instanceof AbstractModelEngine targetModel) {
-					if (routedInputMessage != null) {
-						targetModel.validateInputModalities(room.getMessages(), routedInputMessage);
-					} else {
-						targetModel.validateInputModalities(room.getMessages());
-					}
+					targetModel.validateInputModalities(room.getMessages(), inputMessage);
 				}
 
-				Map<String, Object> params = hyperParameters != null
-						? new HashMap<>(hyperParameters)
-						: new HashMap<>();
-				InputMessage msg = InputMessage.builder(room)
-						.withSystemPrompt(context)
-						.withText(question)
-						.withModelType(targetEngine.getModelType())
-						.withParamMap(params)
-						.build();
-				AskModelEngineResponse response = targetEngine.askRoom(question, room, msg, params);
+				Map<String, Object> params = hyperParameters != null ? new HashMap<>(hyperParameters) : new HashMap<>();
+				AskModelEngineResponse response = targetEngine.askRoom(inputMessage, room, params);
 
 				if (this.sticky && roomId != null) {
 					roomRoutePins.put(roomId, candidateId);
@@ -676,7 +683,8 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 				attachRouteMetadata(response, candidateId);
 				return response;
 			} catch (Exception e) {
-				classLogger.warn("ModelRouterEngine '{}': engineId={} failed to serve the request - trying next candidate",
+				classLogger.warn(
+						"ModelRouterEngine '{}': engineId={} failed to serve the request - trying next candidate",
 						this.engineId, candidateId, e);
 				lastFailure = e;
 				if (this.sticky && roomId != null) {
@@ -695,8 +703,8 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 	}
 
 	@Override
-	protected EmbeddingsModelEngineResponse embeddingsCall(List<String> stringsToEmbed,
-			Insight insight, Map<String, Object> parameters) {
+	protected EmbeddingsModelEngineResponse embeddingsCall(List<String> stringsToEmbed, Insight insight,
+			Map<String, Object> parameters) {
 
 		String engId = this.embeddingsEngineId;
 		if (engId == null) {
@@ -717,16 +725,17 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 	// -------------------------------------------------------------------------
 
 	/**
-	 * On the full-prompt path askCall receives the serialized conversation JSON
-	 * as the question; routing on that blob would match keywords in the system
-	 * prompt, tool definitions, and stale turns. Pull the latest user-authored
-	 * message off the room instead, and fall back to the raw question text.
+	 * Routes on the resolved input message, preferring the UI prompt when present.
+	 * Falls back to the latest input in the room when the resolved message has no
+	 * text.
 	 */
-	private static String extractRoutingText(String question, Room room) {
-		String raw = question != null ? question.trim() : "";
-		if (!raw.startsWith("[")) {
-			// plain-question path: askCall already received the user's text
-			return raw;
+	private static String extractRoutingText(InputMessage inputMessage, Room room) {
+		String raw = inputMessage.getInputUIPrompt();
+		if (raw == null || raw.trim().isEmpty()) {
+			raw = inputMessage.getFullInputPrompt();
+		}
+		if (raw != null && !raw.trim().isEmpty()) {
+			return raw.trim();
 		}
 		List<AbstractMessage> messages = room.getMessages();
 		for (int i = messages.size() - 1; i >= 0; i--) {
@@ -736,14 +745,14 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 				// tool-result input messages in agent loops
 				String text = im.getInputUIPrompt();
 				if (text == null || text.trim().isEmpty()) {
-					text = im.getInputPrompt();
+					text = im.getFullInputPrompt();
 				}
 				if (text != null && !text.trim().isEmpty()) {
 					return text.trim();
 				}
 			}
 		}
-		return raw;
+		return "";
 	}
 
 	private String selectRoute(String routingText, Insight insight, Room room) {
@@ -757,10 +766,10 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 	}
 
 	/**
-	 * Weighted round-robin routing: distributes traffic in strict proportion to
-	 * the route weights. A counter cycles 0..total-1 and each route owns a slice.
-	 * e.g. weights 30/70 give positions 0-29 to route 0 and 30-99 to route 1,
-	 * repeating exactly, so the split is exact over every full cycle.
+	 * Weighted round-robin routing: distributes traffic in strict proportion to the
+	 * route weights. A counter cycles 0..total-1 and each route owns a slice. e.g.
+	 * weights 30/70 give positions 0-29 to route 0 and 30-99 to route 1, repeating
+	 * exactly, so the split is exact over every full cycle.
 	 */
 	private String selectRouteByWeight() {
 		final int total = this.totalWeight;
@@ -776,8 +785,8 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 			}
 			cumulative += r.weight;
 			if (pos < cumulative) {
-				classLogger.info("ModelRouterEngine round-robin pos {}/{} -> route '{}' (weight {})",
-						pos, total, r.name, r.weight);
+				classLogger.info("ModelRouterEngine round-robin pos {}/{} -> route '{}' (weight {})", pos, total,
+						r.name, r.weight);
 				return r.engineId;
 			}
 		}
@@ -785,8 +794,8 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 	}
 
 	/**
-	 * Keyword routing: returns the first route with a whole-word keyword match
-	 * in the routing text. Falls back to the default engine.
+	 * Keyword routing: returns the first route with a whole-word keyword match in
+	 * the routing text. Falls back to the default engine.
 	 */
 	private String selectRouteByKeyword(String routingText) {
 		for (Route route : this.routes) {
@@ -817,30 +826,22 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 					routeList.append(": ").append(r.description);
 				} else if (!r.keywords.isEmpty()) {
 					// defensive only - llm mode validates descriptions at open
-					routeList.append(" (for questions about: ")
-							.append(String.join(", ", r.keywords))
-							.append(")");
+					routeList.append(" (for questions about: ").append(String.join(", ", r.keywords)).append(")");
 				}
 				routeList.append("\n");
 			}
 
-			String classificationPrompt =
-					"You are a routing classifier. Given the user question below, "
+			String classificationPrompt = "You are a routing classifier. Given the user question below, "
 					+ "reply with ONLY the single route name that best matches - no explanation, no punctuation, no quotes.\n\n"
-					+ "Available routes:\n" + routeList
-					+ "\nUser question: " + routingText
-					+ "\n\nRoute name:";
+					+ "Available routes:\n" + routeList + "\nUser question: " + routingText + "\n\nRoute name:";
 
 			IModelEngine classifierEngine = resolveEngine(this.classifierEngineId);
 
 			Map<String, Object> params = new HashMap<>();
-			InputMessage msg = InputMessage.builder(room)
-					.withText(classificationPrompt)
-					.withModelType(classifierEngine.getModelType())
-					.withParamMap(params)
-					.build();
+			InputMessage msg = InputMessage.builder(room).withText(classificationPrompt)
+					.withModelType(classifierEngine.getModelType()).withParamMap(params).build();
 			params.put(MESSAGE_JSON, MessageUtils.toJsonArrayWithImageData(Arrays.asList(msg)));
-			AskModelEngineResponse response = classifierEngine.askRoom(classificationPrompt, room, msg, params);
+			AskModelEngineResponse response = classifierEngine.askRoom(msg, room, params);
 
 			String routeName = response.getStringResponse();
 			routeName = routeName != null ? routeName.trim() : "";
@@ -890,8 +891,8 @@ public class ModelRouterEngine extends AbstractModelEngine implements IModelRout
 
 	/**
 	 * Access to the router does not implicitly grant its backing engines; the
-	 * caller must be able to view the target engine. Internal calls without a
-	 * user are allowed through.
+	 * caller must be able to view the target engine. Internal calls without a user
+	 * are allowed through.
 	 */
 	private boolean userCanUseTarget(User user, String engineId) {
 		if (user == null) {

--- a/src/prerna/engine/impl/model/Room.java
+++ b/src/prerna/engine/impl/model/Room.java
@@ -271,7 +271,7 @@ public class Room implements Serializable {
 
 			// if it is full prompt, process that first.
 			if (kwArgMap.containsKey(AbstractModelEngine.FULL_PROMPT)) {
-				AskModelEngineResponse llmResponse = modelEngine.askRoom(msg.getInputPrompt(), this, msg, kwArgMap);
+				AskModelEngineResponse llmResponse = modelEngine.askRoom(msg, this, kwArgMap);
 				applyInputUsageFromModelResponse(msg, llmResponse);
 				return buildAssistantResponseFromModelResponse(llmResponse, modelEngine, msg);
 			}
@@ -301,7 +301,7 @@ public class Room implements Serializable {
 				String singleMessageJson = MessageUtils.toJsonArrayWithImageData(Arrays.asList(msg));
 				kwArgMap.put("message_json", singleMessageJson);
 
-				AskModelEngineResponse llmResponse = modelEngine.askRoom(msg.getInputPrompt(), this, msg, kwArgMap);
+				AskModelEngineResponse llmResponse = modelEngine.askRoom(msg, this, kwArgMap);
 				applyInputUsageFromModelResponse(msg, llmResponse);
 				return buildAssistantResponseFromModelResponse(llmResponse, modelEngine, msg);
 			}
@@ -342,7 +342,7 @@ public class Room implements Serializable {
 					String messageJsonString = RoomMessageStore.messageHistoryWithNewMessage(this, msg);
 					kwArgMap.put("message_json", messageJsonString);
 
-					AskModelEngineResponse llmResponse = modelEngine.askRoom(msg.getInputPrompt(), this, msg, kwArgMap);
+					AskModelEngineResponse llmResponse = modelEngine.askRoom(msg, this, kwArgMap);
 					applyInputUsageFromModelResponse(msg, llmResponse);
 					response = buildAssistantResponseFromModelResponse(llmResponse, modelEngine, msg);
 				} catch (Exception e) {
@@ -451,8 +451,7 @@ public class Room implements Serializable {
 
 				if (hiddenMessage != null && !hiddenMessage.isEmpty()
 						&& response.getMessageType() == MessageType.RESPONSE_TEXT) {
-					MessageUtils.appendHiddenPair(this, modelEngine, hiddenMessage, response.getMessageId(),
-							extrasOut);
+					MessageUtils.appendHiddenPair(this, modelEngine, hiddenMessage, response.getMessageId(), extrasOut);
 				}
 
 				String prevRoomName = roomName;
@@ -515,7 +514,8 @@ public class Room implements Serializable {
 		}
 	}
 
-	// Cancel-persistence overload: when all tools are answered, slots in prebuiltResponse instead of calling the LLM.
+	// Cancel-persistence overload: when all tools are answered, slots in
+	// prebuiltResponse instead of calling the LLM.
 	public AskModelEngineResponse addToolExecutionResult(String toolCallId, String toolName,
 			String toolExecutionResponse, Map<String, Object> toolParameterValues, Map<String, Object> paramValuesMap,
 			String parentMessageId, IModelEngine modelEngine, Insight insight, String toolStatus,
@@ -611,7 +611,8 @@ public class Room implements Serializable {
 			boolean isToolResultsInputMessage = false;
 			boolean appendedPartThisCall = false;
 
-			// Idempotency guard: reuse the existing carrier if toolCallId was already answered, to avoid duplicate tool_result blocks.
+			// Idempotency guard: reuse the existing carrier if toolCallId was already
+			// answered, to avoid duplicate tool_result blocks.
 			InputMessage existingCarrier = null;
 			for (int i = context.toolResponseIdx + 1; i < messages.size(); ++i) {
 				AbstractMessage m = messages.get(i);
@@ -635,7 +636,8 @@ public class Room implements Serializable {
 			}
 
 			if (existingCarrier != null) {
-				// Duplicate submission - reuse the existing message instead of appending a second part.
+				// Duplicate submission - reuse the existing message instead of appending a
+				// second part.
 				toolResultsMessage = existingCarrier;
 			} else if (toolResultsMessage == null) {
 				isToolResultsInputMessage = true;
@@ -817,31 +819,18 @@ public class Room implements Serializable {
 		paramValuesMap.put("message_json", messageJsonString);
 		appendToolsToParams(paramValuesMap, modelEngine);
 
-		StringBuilder toolResultsForLogging = new StringBuilder();
-		for (MessagePart part : toolResultsMessage.getParts()) {
-			if (part instanceof ToolResultMessagePart) {
-				ToolResultPart tr = ((ToolResultMessagePart) part).getToolResult();
-				if (tr != null && tr.getOutput() != null) {
-					if (toolResultsForLogging.length() > 0) {
-						toolResultsForLogging.append("\n");
-					}
-					toolResultsForLogging.append(tr.getOutput());
-				}
-			}
-		}
-
 		AskModelEngineResponse llmResponse = null;
 		ResponseMessage nextAssistant = null;
 		if (prebuiltResponse != null) {
-			// Cancel-persistence path: skip the LLM call, slot in the caller-supplied response.
+			// Cancel-persistence path: skip the LLM call, slot in the caller-supplied
+			// response.
 			nextAssistant = prebuiltResponse;
 			nextAssistant.setModel(modelEngine);
 			nextAssistant.setRoom(this);
 			nextAssistant.setParentMessageId(toolResultsMessage.getMessageId());
 		} else {
 			try {
-				llmResponse = modelEngine.askRoom(toolResultsForLogging.toString(), this, toolResultsMessage,
-						paramValuesMap);
+				llmResponse = modelEngine.askRoom(toolResultsMessage, this, paramValuesMap);
 				applyInputUsageFromModelResponse(toolResultsMessage, llmResponse);
 				nextAssistant = buildAssistantResponseFromModelResponse(llmResponse, modelEngine, toolResultsMessage);
 			} catch (Exception e) {

--- a/src/prerna/engine/impl/model/TextEmbeddingsEngine.java
+++ b/src/prerna/engine/impl/model/TextEmbeddingsEngine.java
@@ -41,6 +41,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 
 import prerna.engine.api.ModelTypeEnum;
+import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.responses.AskModelEngineResponse;
 import prerna.engine.impl.model.responses.AskStringModelEngineResponse;
 import prerna.engine.impl.model.responses.EmbeddingsModelEngineResponse;
@@ -113,8 +114,8 @@ public class TextEmbeddingsEngine extends AbstractRESTModelEngine {
 	}
 
 	@Override
-	protected AskModelEngineResponse askCall(String question, Object fullPrompt, String context, Insight insight,
-			String roomId, Map<String, Object> parameters) {
+	protected AskModelEngineResponse askCall(InputMessage inputMessage, Insight insight, String roomId,
+			Map<String, Object> parameters) {
 		return new AskStringModelEngineResponse("This model does not support text generation.", 0, 0);
 	}
 

--- a/src/prerna/engine/impl/model/message/InputMessage.java
+++ b/src/prerna/engine/impl/model/message/InputMessage.java
@@ -96,16 +96,46 @@ public class InputMessage extends AbstractMessage {
 	}
 
 	/**
-	 * Get the effective prompt to send to the LLM (RAG: includes user + chunks).
+	 * Returns only the text portion of this input message.
+	 *
+	 * @return text input, or the legacy text value when no text part exists
 	 */
-	public String getInputPrompt() {
-
+	public String getInputText() {
 		// assuming input messages have only 1 text part for now
 		TextMessagePart textPart = getFirstTextPart();
 		if (textPart != null && textPart.getText() != null) {
 			return textPart.getText();
 		}
 		return inputPrompt;
+	}
+
+	/**
+	 * Returns the effective prompt sent to the model. Text input takes precedence;
+	 * a tool-result-only message returns its combined tool output.
+	 *
+	 * @return model-bound input text or tool output
+	 */
+	public String getFullInputPrompt() {
+		String inputText = getInputText();
+		if (inputText != null) {
+			return inputText;
+		}
+		StringBuilder toolOutput = new StringBuilder();
+		for (MessagePart part : getParts()) {
+			if (part instanceof ToolResultMessagePart) {
+				ToolResultPart result = ((ToolResultMessagePart) part).getToolResult();
+				if (result != null && result.getOutput() != null) {
+					if (toolOutput.length() > 0) {
+						toolOutput.append('\n');
+					}
+					toolOutput.append(result.getOutput());
+				}
+			}
+		}
+		if (toolOutput.length() > 0) {
+			return toolOutput.toString();
+		}
+		return null;
 	}
 
 	public String getInputUIPrompt() {
@@ -184,7 +214,7 @@ public class InputMessage extends AbstractMessage {
 		}
 
 		// ---- text ----
-		String effective = getInputPrompt();
+		String effective = getFullInputPrompt();
 		if (effective != null && !effective.trim().isEmpty()) {
 			if (inputUIPrompt != null && !inputUIPrompt.equals(effective)) {
 				addPart(new TextMessagePart(effective, inputUIPrompt));
@@ -195,7 +225,7 @@ public class InputMessage extends AbstractMessage {
 
 		// ---- tool execution ----
 		if (type == MessageType.INPUT_TOOL_EXEC || toolCallId != null || toolName != null) {
-			addPart(new ToolResultMessagePart(new ToolResultPart(toolCallId, toolName, getInputPrompt(),
+			addPart(new ToolResultMessagePart(new ToolResultPart(toolCallId, toolName, getFullInputPrompt(),
 					toolParameterValues, toolStatus, false)));
 		}
 	}
@@ -706,5 +736,37 @@ public class InputMessage extends AbstractMessage {
 			}
 		}
 		return medias;
+	}
+
+	/**
+	 * Replaces this message's model-bound textual content. Input guardrails use
+	 * this method so the exact message object supplied by the caller, retained by
+	 * the room, and sent to the model all contain the masked value.
+	 *
+	 * @param prompt replacement text sent to the model
+	 */
+	public void setFullInputPrompt(String prompt) {
+		this.inputPrompt = prompt;
+		this.inputUIPrompt = prompt;
+
+		boolean replacedContent = false;
+		for (MessagePart part : getParts()) {
+			if (part instanceof TextMessagePart) {
+				TextMessagePart textPart = (TextMessagePart) part;
+				textPart.setText(prompt);
+				textPart.setUiText(prompt);
+				replacedContent = true;
+			} else if (part instanceof ToolResultMessagePart) {
+				ToolResultPart result = ((ToolResultMessagePart) part).getToolResult();
+				if (result != null) {
+					result.setOutput(prompt);
+					replacedContent = true;
+				}
+			}
+		}
+		if (!replacedContent && prompt != null && !prompt.isEmpty()) {
+			addPart(new TextMessagePart(prompt));
+		}
+		normalizeForWrite();
 	}
 }

--- a/src/prerna/engine/impl/pipeline/PipelineInvocationHandler.java
+++ b/src/prerna/engine/impl/pipeline/PipelineInvocationHandler.java
@@ -43,6 +43,7 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -234,6 +235,7 @@ public class PipelineInvocationHandler implements InvocationHandler {
 					&& (outputPipelines == null || outputPipelines.isEmpty()))) {
 				// No pipeline defined for this method, so just invoke the real method
 				// But wrap for logging purposes
+				String requestSnapshot = keepInputOutput ? serializeAuditPayload(method, args, null, false) : null;
 				Instant start = Instant.now();
 				try {
 					result = this.engineInvoker.invoke(method, args);
@@ -244,13 +246,12 @@ public class PipelineInvocationHandler implements InvocationHandler {
 					throw e.getTargetException();
 				} finally {
 					Instant end = Instant.now();
-					processedArguments = mapArguments(null, method, args, processedArguments);
 					String request = null;
 					String response = null;
 					Integer tokensInPrompt = null;
 					Integer tokensInResponse = null;
 					if (keepInputOutput) {
-						request = GSON.toJson(processedArguments);
+						request = requestSnapshot;
 						response = result == null ? "" : GSON.toJson(result);
 					} else {
 						request = REQUEST_NOT_TRACKED;
@@ -274,14 +275,12 @@ public class PipelineInvocationHandler implements InvocationHandler {
 			// === INPUT PIPELINE EXECUTION ===
 			{
 				int size = inputPipelines.size();
-				if (size == 0) {
-					// need to map the arguments even if no input pipeline
-					mapArguments(null, method, args, processedArguments);
-				}
 				for (int pipelineIndex = 0; pipelineIndex < size; pipelineIndex++) {
 					IInputReactor reactor = inputPipelines.get(pipelineIndex);
-					// mapArguments will now also add argN parameters and set Insight
-					processedArguments = mapArguments(reactor, method, args, processedArguments);
+					// Each reactor receives only the current method arguments plus the
+					// context added below. Internal state from the previous reactor must not
+					// leak into this handoff or its audit record.
+					processedArguments = mapArguments(reactor, method, args, new LinkedHashMap<>());
 
 					NounStore inputNouns = new NounStore("input-pipeline");
 					GenRowStruct grs = new GenRowStruct();
@@ -295,12 +294,6 @@ public class PipelineInvocationHandler implements InvocationHandler {
 					grs.add(new NounMetadata(processedArguments, PixelDataType.MAP));
 					inputNouns.addNoun(PipelineReactorUtils.ARGUMENTS, grs);
 					reactor.setNounStore(inputNouns);
-
-					// Snapshot the request as this reactor RECEIVES it (only when tracking
-					// I/O), before execute() can mutate the shared arguments (e.g. mask arg0).
-					// Without this the audit row serializes the post-mask value and the
-					// original input is lost.
-					String requestSnapshot = keepInputOutput ? GSON.toJson(processedArguments) : null;
 
 					Instant start = Instant.now();
 					NounMetadata resultNoun = reactor.execute();
@@ -329,9 +322,9 @@ public class PipelineInvocationHandler implements InvocationHandler {
 					String request = null;
 					String response = null;
 					if (keepInputOutput || !pass) {
-						// requestSnapshot holds the pre-mask input; fall back to the current
-						// args only for the block case when I/O tracking is off.
-						request = requestSnapshot != null ? requestSnapshot : GSON.toJson(processedArguments);
+						// Log the clean, possibly rewritten arguments that this guardrail sends
+						// to the next input guardrail or the engine.
+						request = serializeAuditPayload(method, args, null, false);
 						response = GSON.toJson(resultMap);
 					} else {
 						request = REQUEST_NOT_TRACKED;
@@ -365,10 +358,10 @@ public class PipelineInvocationHandler implements InvocationHandler {
 
 			// === ACTUAL METHOD EXECUTION ===
 			{
+				String requestSnapshot = keepInputOutput ? serializeAuditPayload(method, args, null, false) : null;
 				Instant start = Instant.now();
 				try {
 					result = this.engineInvoker.invoke(method, args);
-					processedArguments.put(PipelineReactorUtils.RESULT, result);
 				} catch (InvocationTargetException e) {
 					success = false;
 					result = e.getTargetException();
@@ -381,7 +374,7 @@ public class PipelineInvocationHandler implements InvocationHandler {
 					Integer tokensInPrompt = null;
 					Integer tokensInResponse = null;
 					if (keepInputOutput) {
-						request = GSON.toJson(processedArguments);
+						request = requestSnapshot;
 						response = result == null ? "" : GSON.toJson(result);
 					} else {
 						request = REQUEST_NOT_TRACKED;
@@ -407,10 +400,10 @@ public class PipelineInvocationHandler implements InvocationHandler {
 				int size = outputPipelines.size();
 				for (int pipelineIndex = 0; pipelineIndex < size; pipelineIndex++) {
 					IOutputReactor reactor = outputPipelines.get(pipelineIndex);
-					// mapArguments will now also add argN parameters and set Insight
-					// For output reactors, we need to ensure Insight is set if present.
-					// We can reuse mapArguments, but it will re-map the original args.
-					// It's better to just set Insight directly here if mapArguments is not called.
+					processedArguments = mapArguments(null, method, args, new LinkedHashMap<>());
+					processedArguments.put(PipelineReactorUtils.RESULT, result);
+					// Output reactors also receive the Insight directly when the intercepted
+					// method includes it as an argument.
 					for (int argsIndex = 0; argsIndex < args.length; argsIndex++) {
 						if (args[argsIndex] instanceof Insight) {
 							reactor.setInsight((Insight) args[argsIndex]);
@@ -447,7 +440,10 @@ public class PipelineInvocationHandler implements InvocationHandler {
 					String request = null;
 					String response = null;
 					if (keepInputOutput || !pass) {
-						request = GSON.toJson(processedArguments);
+						// Log the clean response payload this guardrail sends to the next
+						// output guardrail or back to the caller.
+						request = serializeAuditPayload(method, args,
+								processedArguments.get(PipelineReactorUtils.RESULT), true);
 						response = GSON.toJson(resultMap);
 					} else {
 						request = REQUEST_NOT_TRACKED;
@@ -462,10 +458,12 @@ public class PipelineInvocationHandler implements InvocationHandler {
 						throw new SemossPixelException(blockMessageOrDefault(resultMap,
 								"Unable to process this request due to content policy (guardrail output exception)"));
 					}
+
+					result = processedArguments.get(PipelineReactorUtils.RESULT);
 				}
 			}
 
-			return processedArguments.get(PipelineReactorUtils.RESULT);
+			return result;
 		}
 	}
 
@@ -564,6 +562,29 @@ public class PipelineInvocationHandler implements InvocationHandler {
 	}
 
 	/**
+	 * Serializes only the payload crossing a pipeline boundary. Serializing at the
+	 * boundary creates an immutable audit snapshot even when a later step mutates a
+	 * referenced argument object.
+	 *
+	 * @param method        The intercepted method.
+	 * @param args          The current method arguments.
+	 * @param result        The current result, when logging an output boundary.
+	 * @param includeResult Whether the result is part of the boundary payload.
+	 * @return JSON containing method arguments and, for output boundaries, result.
+	 */
+	static String serializeAuditPayload(Method method, Object[] args, Object result, boolean includeResult) {
+		Map<String, Object> payload = new LinkedHashMap<>();
+		Parameter[] parameters = method.getParameters();
+		for (int i = 0; i < parameters.length; i++) {
+			payload.put(parameters[i].getName(), args[i]);
+		}
+		if (includeResult) {
+			payload.put(PipelineReactorUtils.RESULT, result);
+		}
+		return GSON.toJson(payload);
+	}
+
+	/**
 	 * 
 	 * @param pipelineFile
 	 * @return
@@ -649,7 +670,7 @@ public class PipelineInvocationHandler implements InvocationHandler {
 	}
 
 	/**
-	 * 
+	 *
 	 * @param <T>
 	 * @param config
 	 * @param reactorType

--- a/src/prerna/engine/impl/remotesemoss/RemoteModelEngine.java
+++ b/src/prerna/engine/impl/remotesemoss/RemoteModelEngine.java
@@ -38,7 +38,7 @@ import prerna.engine.api.IEngine;
 import prerna.engine.api.IModelEngine;
 import prerna.engine.api.ModelTypeEnum;
 import prerna.engine.impl.model.Room;
-import prerna.engine.impl.model.message.AbstractMessage;
+import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.responses.AskModelEngineResponse;
 import prerna.engine.impl.model.responses.EmbeddingsModelEngineResponse;
 import prerna.om.Insight;
@@ -54,7 +54,6 @@ public class RemoteModelEngine implements IModelEngine {
 	public void setEngineId(String engineId) {
 		// TODO Auto-generated method stub
 		smssProp.put(Constants.ENGINE, engineId);
-
 	}
 
 	@Override
@@ -183,8 +182,7 @@ public class RemoteModelEngine implements IModelEngine {
 	}
 
 	@Override
-	public AskModelEngineResponse askRoom(String question, Room room, AbstractMessage inputMessage,
-			Map<String, Object> parameters) {
+	public AskModelEngineResponse askRoom(InputMessage inputMessage, Room room, Map<String, Object> parameters) {
 		// TODO Auto-generated method stub
 		return null;
 	}

--- a/src/prerna/reactor/frame/ConvertFrameToVegaVizReactor.java
+++ b/src/prerna/reactor/frame/ConvertFrameToVegaVizReactor.java
@@ -236,14 +236,14 @@ public class ConvertFrameToVegaVizReactor extends AbstractFrameReactor {
 		room.setInsight(this.insight);
 		// room.setModelId((String) this.keyValue.get(ReactorKeysEnum.MODEL.getKey()));
 		// // try this?
-		InputMessage msg = InputMessage.builder(room).withSystemPrompt(context).build();
-
 		HashMap<String, Object> paramMap = new HashMap<String, Object>();
 		paramMap.put("use_history", USE_HISTORY);
 		paramMap.put("temperature", TEMPERATURE);
 
 		IModelEngine modelEngine = Utility.getModel(modelId);
-		AskModelEngineResponse<?> modelResponse = modelEngine.askRoom(question, room, null, paramMap);
+		InputMessage msg = InputMessage.builder(room).withSystemPrompt(context).withText(question)
+				.withModelType(modelEngine.getModelType()).withParamMap(paramMap).build();
+		AskModelEngineResponse<?> modelResponse = room.ask(msg, modelEngine).getModelEngineResponse();
 		String response = null;
 
 		if (modelResponse != null) {

--- a/src/prerna/reactor/guardrail/upload/CreateGuardrailEngineReactor.java
+++ b/src/prerna/reactor/guardrail/upload/CreateGuardrailEngineReactor.java
@@ -155,6 +155,7 @@ public class CreateGuardrailEngineReactor extends AbstractReactor {
 			guardrail.setSmssFilePath(smssFile.getAbsolutePath());
 			UploadUtilities.addEngineToDIHelper(guardrailId, guardrailName, guardrail, smssFile);
 			SecurityEngineUtils.addEngine(guardrailId, global, user);
+			SecurityEngineUtils.setDefaultEngineMarkdown(guardrailId, guardrail.getDefaultMarkdown());
 
 			List<AuthProvider> logins = user.getLogins();
 			for (AuthProvider ap : logins) {

--- a/src/prerna/reactor/interceptor/GenericGuardrailInputReactor.java
+++ b/src/prerna/reactor/interceptor/GenericGuardrailInputReactor.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import prerna.engine.api.IGuardrailReactorFunctionEngine;
+import prerna.engine.impl.model.message.InputMessage;
 import prerna.reactor.AbstractReactor;
 import prerna.sablecc2.om.GenRowStruct;
 import prerna.sablecc2.om.NounStore;
@@ -46,12 +47,20 @@ import prerna.sablecc2.om.nounmeta.NounMetadata;
 import prerna.util.Constants;
 import prerna.util.Utility;
 
+/**
+ * Screens the arguments of an intercepted engine method before it runs. On
+ * failure the call is blocked, or the guarded argument is replaced with the
+ * guardrail's masked text, or the guardrail's message is returned in place of
+ * calling the method at all.
+ *
+ * Any engine type can attach this to a pipeline slot. The intercepted method's
+ * arguments are exposed under the names the runtime resolves for them, and a
+ * mapped argument that wraps its text is unwrapped before the guardrail sees
+ * it, so a guardrail always receives content rather than an object.
+ */
 public class GenericGuardrailInputReactor extends AbstractReactor implements IInputReactor {
 
 	private static final Logger classLogger = LogManager.getLogger(GenericGuardrailInputReactor.class);
-
-	// default guardrail input param whose mapped argument gets overwritten when masking
-	private static final String DEFAULT_MASK_TARGET_PARAM = "prompt";
 
 	public GenericGuardrailInputReactor() {
 		// No keysToGet needed as we use ReactorInputHelper
@@ -85,6 +94,10 @@ public class GenericGuardrailInputReactor extends AbstractReactor implements IIn
 
 		// A temporary map to hold the values for the current guardrail engine call
 		Map<String, Object> guardrailEngineParams = new HashMap<>();
+		// The values that came from the intercepted call, kept apart from the
+		// configured direct parameters so a canned response can be compared
+		// against what the guardrail was actually given to screen
+		List<Object> mappedInputValues = new ArrayList<>();
 
 		// Process the inputMapping to get parameters from the intercepted method's
 		// arguments
@@ -93,9 +106,9 @@ public class GenericGuardrailInputReactor extends AbstractReactor implements IIn
 			Object mappedValue = entry.getValue();
 
 			if (mappedValue instanceof String) {
-				String argName = (String) mappedValue;
-				Object argValue = helper.getMethodArgument(argName);
+				Object argValue = resolveArgument(helper, (String) mappedValue);
 				guardrailEngineParams.put(guardrailParamName, argValue);
+				mappedInputValues.add(argValue);
 			} else if (mappedValue instanceof List) {
 				List<?> argNames = (List<?>) mappedValue;
 				StringBuilder combinedPrompt = new StringBuilder();
@@ -103,7 +116,7 @@ public class GenericGuardrailInputReactor extends AbstractReactor implements IIn
 
 				for (Object name : argNames) {
 					if (name instanceof String) {
-						Object argValue = helper.getMethodArgument((String) name);
+						Object argValue = resolveArgument(helper, (String) name);
 						if (argValue instanceof String) {
 							combinedPrompt.append(argValue).append(" ");
 						}
@@ -114,15 +127,18 @@ public class GenericGuardrailInputReactor extends AbstractReactor implements IIn
 				}
 
 				if (isStringCombination && combinedPrompt.length() > 0) {
-					guardrailEngineParams.put(guardrailParamName, combinedPrompt.toString().trim());
+					String combined = combinedPrompt.toString().trim();
+					guardrailEngineParams.put(guardrailParamName, combined);
+					mappedInputValues.add(combined);
 				} else {
 					List<Object> values = new ArrayList<>();
 					for (Object name : argNames) {
 						if (name instanceof String) {
-							values.add(helper.getMethodArgument((String) name));
+							values.add(resolveArgument(helper, (String) name));
 						}
 					}
 					guardrailEngineParams.put(guardrailParamName, values);
+					mappedInputValues.add(values);
 				}
 			} else {
 				// This case should ideally not happen for inputMapping
@@ -163,43 +179,36 @@ public class GenericGuardrailInputReactor extends AbstractReactor implements IIn
 
 		Map<String, Object> processedArguments = helper.getArgumentsMap();
 
-		// If this filter is configured to mask (rather than block) on failure, overwrite
-		// the guarded argument with the masked prompt the engine produced so the masked
-		// text - not the original - flows downstream to the model.
+		// If this filter is configured to mask (rather than block) on failure,
+		// overwrite the guarded argument with the masked text the guardrail
+		// produced, so the masked text - not the original - is what the
+		// intercepted method receives.
 		boolean masked = false;
 		Boolean maskOnGuardrailFailure = helper.getConfigParameter("maskOnGuardrailFailure", Boolean.class);
 		if (maskOnGuardrailFailure != null && maskOnGuardrailFailure && !output.isPass()) {
-			String maskTargetParam = helper.getConfigParameter("maskTargetParam", String.class);
-			if (maskTargetParam == null || maskTargetParam.isEmpty()) {
-				maskTargetParam = DEFAULT_MASK_TARGET_PARAM;
-			}
-			// inputMapping maps the guardrail param (e.g. "prompt") to the intercepted
-			// method argument name (e.g. "arg0"); that argument is what we overwrite
-			Object mappedArg = inputMapping.get(maskTargetParam);
-			String maskedPrompt = output.getReturnPrompt();
-			if (mappedArg instanceof String && maskedPrompt != null) {
-				processedArguments.put((String) mappedArg, maskedPrompt);
+			if (replaceGuardedInput(helper, inputMapping, output.getReturnPrompt())) {
 				masked = true;
 			} else {
-				// cannot safely write the masked value back (e.g. a combined multi-arg
-				// mapping) - leave pass as-is so the request is blocked rather than
-				// leaking unmasked content downstream
+				// cannot safely write the masked value back (no single text argument
+				// to write to, more than one candidate, or an unresolvable path) -
+				// leave pass as-is so the call is blocked rather than letting
+				// unmasked content through
 				classLogger.warn(
-						"maskOnGuardrailFailure is enabled but mask target '{}' is not mapped to a single argument; "
-								+ "blocking instead of masking.",
-						maskTargetParam);
+						"maskOnGuardrailFailure is enabled but no single text argument could be identified to receive "
+								+ "the masked value; blocking instead of masking.");
 			}
 		}
 
 		// When configured to respond (rather than mask or block), hand the guardrail's
-		// message back as the model's answer. The real model call is skipped entirely,
-		// so no version of the prompt reaches the provider.
+		// message back as the call's return value. The intercepted method is skipped
+		// entirely, so no version of the guarded input reaches it.
 		String cannedResponse = null;
 		Boolean respondWithGuardrailMessage = helper.getConfigParameter("respondWithGuardrailMessage", Boolean.class);
 		if (Boolean.TRUE.equals(respondWithGuardrailMessage) && !output.isPass()) {
 			String candidate = output.getReturnPrompt();
-			Object original = guardrailEngineParams.get(DEFAULT_MASK_TARGET_PARAM);
-			if (candidate != null && !candidate.equals(original)) {
+			// unchanged against any screened input means the guardrail produced no
+			// message of its own, so there is nothing to answer with
+			if (candidate != null && !mappedInputValues.contains(candidate)) {
 				cannedResponse = candidate;
 			} else {
 				classLogger.warn("respondWithGuardrailMessage is enabled but guardrail engine '{}' returned the input "
@@ -210,12 +219,92 @@ public class GenericGuardrailInputReactor extends AbstractReactor implements IIn
 		Boolean closeRoomOnBlock = helper.getConfigParameter("closeRoomOnBlock", Boolean.class);
 		String blockErrorMessage = helper.getConfigParameter("blockErrorMessage", String.class);
 
-		Map<String, Object> resultMap = createInterimResult(output, this.getClass().getName(), masked,
-				cannedResponse, closeRoomOnBlock, blockErrorMessage);
+		Map<String, Object> resultMap = createInterimResult(output, this.getClass().getName(), masked, cannedResponse,
+				closeRoomOnBlock, blockErrorMessage);
 
 		// Update the processedArguments with the interim result
 		processedArguments.put(PipelineReactorUtils.INTERIM_RESULT, resultMap);
 		return new NounMetadata(processedArguments, PixelDataType.MAP);
+	}
+
+	/**
+	 * Reads a mapped argument, reduced to the content a guardrail screens. This
+	 * reduction is keyed on the argument's type rather than on the guardrail
+	 * parameter's name, since a guardrail declares its own parameter names and any
+	 * of them may be pointed at an argument that carries its text inside an object.
+	 *
+	 * @param helper  reader for the intercepted call's arguments
+	 * @param argName argument name, optionally followed by a dot path
+	 * @return the value for the guardrail, or null when the path does not exist
+	 */
+	static Object resolveArgument(ReactorInputHelper helper, String argName) {
+		return GuardrailValueReader.screenableValue(helper.getMethodArgument(argName));
+	}
+
+	/**
+	 * Writes the guardrail's masked text back to the argument that supplied it.
+	 *
+	 * @param helper       reader and writer for the intercepted call's arguments
+	 * @param inputMapping guardrail parameter to argument mapping
+	 * @param maskedPrompt the text the guardrail returned
+	 * @return whether the masked text was written back
+	 */
+	static boolean replaceGuardedInput(ReactorInputHelper helper, Map<String, Object> inputMapping,
+			String maskedPrompt) {
+		if (maskedPrompt == null) {
+			return false;
+		}
+		String argumentName = resolveMaskTarget(helper, inputMapping);
+		if (argumentName == null) {
+			return false;
+		}
+
+		Object guardedInput = helper.getMethodArgument(argumentName);
+		Object replacement = maskedPrompt;
+		if (guardedInput instanceof InputMessage) {
+			InputMessage inputMessage = (InputMessage) guardedInput;
+			inputMessage.setFullInputPrompt(maskedPrompt);
+			replacement = inputMessage;
+		}
+		return helper.setMethodArgument(argumentName, replacement);
+	}
+
+	/**
+	 * The argument a masked value can be written back to. The guardrail returns a
+	 * single string, so the target is the one mapped argument that currently holds
+	 * text: a String, or a message object carrying text. Which guardrail parameter
+	 * reads it does not matter, so masking works for any engine whose call carries
+	 * text worth screening.
+	 *
+	 * A mapping that combines several arguments is skipped, since a single returned
+	 * string cannot be split back across them. Arguments holding anything other
+	 * than text are skipped too, because replacing them would hand the method a
+	 * value of the wrong type. More than one candidate is treated as no candidate
+	 * rather than guessed at.
+	 *
+	 * @param helper       reader for the intercepted call's arguments
+	 * @param inputMapping guardrail parameter to argument mapping
+	 * @return the argument name to write to, or null when there is not exactly one
+	 */
+	static String resolveMaskTarget(ReactorInputHelper helper, Map<String, Object> inputMapping) {
+		String target = null;
+		for (Object mappedValue : inputMapping.values()) {
+			if (!(mappedValue instanceof String)) {
+				continue;
+			}
+			String argumentName = (String) mappedValue;
+			Object argValue = helper.getMethodArgument(argumentName);
+			if (!(argValue instanceof String) && !(argValue instanceof InputMessage)) {
+				continue;
+			}
+			if (target != null && !target.equals(argumentName)) {
+				// two different text arguments were screened and the guardrail's
+				// single returned value gives no way to tell them apart
+				return null;
+			}
+			target = argumentName;
+		}
+		return target;
 	}
 
 	/**
@@ -229,7 +318,8 @@ public class GenericGuardrailInputReactor extends AbstractReactor implements IIn
 			boolean masked, String cannedResponse, Boolean closeRoomOnBlock, String blockErrorMessage) {
 		Map<String, Object> resultMap = new HashMap<>();
 		resultMap.put(PipelineReactorUtils.INTERCEPTOR, interceptorName);
-		// when we masked the input we neutralized the failure, so let it pass downstream
+		// when we masked the input we neutralized the failure, so let it pass
+		// downstream
 		resultMap.put(PipelineReactorUtils.PASS, masked || results.isPass());
 		resultMap.put(PipelineReactorUtils.PASS_DETAILS, results.getValue());
 		resultMap.put(PipelineReactorUtils.MASKED, masked);

--- a/src/prerna/reactor/interceptor/GenericGuardrailOutputReactor.java
+++ b/src/prerna/reactor/interceptor/GenericGuardrailOutputReactor.java
@@ -33,13 +33,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-
 import prerna.engine.api.IGuardrailReactorFunctionEngine;
+import prerna.engine.impl.model.responses.AbstractModelEngineResponse;
 import prerna.reactor.AbstractReactor;
 import prerna.sablecc2.om.GenRowStruct;
 import prerna.sablecc2.om.NounStore;
@@ -49,14 +44,27 @@ import prerna.sablecc2.om.nounmeta.NounMetadata;
 import prerna.util.Constants;
 import prerna.util.Utility;
 
-public class GenericGuardrailInputOutputReactor extends AbstractReactor implements IInputReactor, IOutputReactor {
-
-	private static final Logger classLogger = LogManager.getLogger(GenericGuardrailInputOutputReactor.class);
+/**
+ * Screens the return value of an intercepted engine method. A failing guardrail
+ * blocks that return value, which is the only outcome available once the method
+ * has run - there is no pending call left to mask or to answer on the caller's
+ * behalf.
+ *
+ * Any engine type can attach this to a pipeline slot. The intercepted method's
+ * return value is exposed as {@code result}, alongside the method's arguments.
+ *
+ * A return value that wraps its payload is unwrapped before the guardrail sees
+ * it, so a mapping to {@code result} resolves to the payload rather than to the
+ * wrapper; without that step the guardrail receives the object's default string
+ * form and passes everything. A dot path continues into the payload once it is
+ * unwrapped.
+ */
+public class GenericGuardrailOutputReactor extends AbstractReactor implements IOutputReactor {
 
 	public static final String RETURN_PROMPT_KEY = "returnPrompt";
 	public static final String FULL_DETAILS_KEY = "fullDetails";
 
-	public GenericGuardrailInputOutputReactor() {
+	public GenericGuardrailOutputReactor() {
 		// No keysToGet needed as we use ReactorInputHelper
 		this.keysToGet = new String[] {};
 	}
@@ -64,43 +72,30 @@ public class GenericGuardrailInputOutputReactor extends AbstractReactor implemen
 	@Override
 	public NounMetadata execute() {
 		ReactorInputHelper helper = new ReactorInputHelper(this.getNounStore());
-		// A temporary map to hold the values for the current guardrail engine call
-		Map<String, Object> guardrailEngineParams = new HashMap<>();
 		String guardrailEngineId = helper.getConfigParameter("guardrailEngineId", String.class);
 		if (guardrailEngineId == null || guardrailEngineId.isEmpty()) {
 			throw new SecurityException(
-					"GenericGuardrailInputReactor is not configured correctly. Missing 'guardrailEngineId'.");
+					"GenericGuardrailOutputReactor is not configured correctly. Missing 'guardrailEngineId'.");
 		}
 		IGuardrailReactorFunctionEngine guardrailEngine = Utility.getGuardrailEngine(guardrailEngineId);
 		if (guardrailEngine == null) {
 			throw new SecurityException("Guardrail engine with ID '" + guardrailEngineId + "' not found.");
 		}
 
-		guardrailEngineParams.put(guardrailEngineId, guardrailEngine.getEngineName());
-
-		// Get the input mapping for the guardrail engine
 		Map<String, Object> inputMapping = helper.getConfigParameter("inputMapping", Map.class);
 		if (inputMapping == null) {
 			inputMapping = new HashMap<>();
 		}
 
-		// TODO: how to incorporate masking ... or do we generate a new guardrail
-		// instead...
-		Boolean blockOnGuardrailFailure = helper.getConfigParameter("blockOnGuardrailFailure", Boolean.class);
-		if (blockOnGuardrailFailure == null) {
-			blockOnGuardrailFailure = true; // Default value
-		}
-
-		// Process the inputMapping to get parameters from the intercepted method's
-		// arguments
+		// The values for this guardrail engine call, keyed by the parameter name the
+		// guardrail reads.
+		Map<String, Object> guardrailEngineParams = new HashMap<>();
 		for (Map.Entry<String, Object> entry : inputMapping.entrySet()) {
 			String guardrailParamName = entry.getKey();
 			Object mappedValue = entry.getValue();
 
 			if (mappedValue instanceof String) {
-				String argName = (String) mappedValue;
-				Object argValue = helper.getMethodArgument(argName);
-				guardrailEngineParams.put(guardrailParamName, argValue);
+				guardrailEngineParams.put(guardrailParamName, resolveArgument(helper, (String) mappedValue));
 			} else if (mappedValue instanceof List) {
 				List<?> argNames = (List<?>) mappedValue;
 				StringBuilder combinedPrompt = new StringBuilder();
@@ -108,7 +103,7 @@ public class GenericGuardrailInputOutputReactor extends AbstractReactor implemen
 
 				for (Object name : argNames) {
 					if (name instanceof String) {
-						Object argValue = helper.getMethodArgument((String) name);
+						Object argValue = resolveArgument(helper, (String) name);
 						if (argValue instanceof String) {
 							combinedPrompt.append(argValue).append(" ");
 						}
@@ -124,13 +119,14 @@ public class GenericGuardrailInputOutputReactor extends AbstractReactor implemen
 					List<Object> values = new ArrayList<>();
 					for (Object name : argNames) {
 						if (name instanceof String) {
-							values.add(helper.getMethodArgument((String) name));
+							values.add(resolveArgument(helper, (String) name));
 						}
 					}
 					guardrailEngineParams.put(guardrailParamName, values);
 				}
 			} else {
-				// This case should ideally not happen for inputMapping
+				// a mapping value is a name or a list of names, so anything else is
+				// passed through as the literal it appears to be
 				guardrailEngineParams.put(guardrailParamName, mappedValue);
 			}
 		}
@@ -149,7 +145,7 @@ public class GenericGuardrailInputOutputReactor extends AbstractReactor implemen
 
 			GenRowStruct nounGrs = guardrailInputNounStore.makeGenRowStruct(paramName);
 			if (paramValue instanceof Collection) {
-				Collection<Object> paramValueCollection = (Collection<Object>) paramValue;
+				Collection<?> paramValueCollection = (Collection<?>) paramValue;
 				for (Object paramValueEle : paramValueCollection) {
 					nounGrs.add(NounMetadata.predictNounMetadata(paramValueEle));
 				}
@@ -176,22 +172,48 @@ public class GenericGuardrailInputOutputReactor extends AbstractReactor implemen
 		Map<String, Object> processedArguments = helper.getArgumentsMap();
 		processedArguments.put(PipelineReactorUtils.INTERIM_RESULT, resultMap);
 		return new NounMetadata(processedArguments, PixelDataType.MAP);
-
-	}
-
-	private String convertResponseToGson(Object obj) {
-		Gson gson = new GsonBuilder().disableHtmlEscaping().create();
-		String json = gson.toJson(obj);
-		return json;
 	}
 
 	/**
-	 * Helper method to create the interim result map (already exists)
-	 * 
-	 * @param guardrailEngineParams
-	 * @param pass
-	 * @param interceptorName
-	 * @return
+	 * Reads a mapped argument, unwrapping a wrapped return value so the guardrail
+	 * receives the payload rather than the wrapper. A dot path continues into that
+	 * payload, so {@code result.url} reads inside a map shaped payload even though
+	 * the wrapper itself is not a map.
+	 *
+	 * @param helper  reader for the intercepted call's arguments
+	 * @param argName argument name, optionally followed by a dot path
+	 * @return the value for the guardrail, or null when the path does not exist
+	 */
+	static Object resolveArgument(ReactorInputHelper helper, String argName) {
+		Object direct = helper.getMethodArgument(argName);
+		if (direct != null) {
+			return GuardrailValueReader.screenableValue(direct);
+		}
+
+		// A response object is not a map, so the helper cannot walk a path through
+		// it. Resolve the root on its own and read the rest from the payload.
+		int split = argName == null ? -1 : argName.indexOf('.');
+		if (split <= 0) {
+			return null;
+		}
+		Object root = helper.getMethodArgument(argName.substring(0, split));
+		if (!(root instanceof AbstractModelEngineResponse)) {
+			return null;
+		}
+		return ReactorInputHelper.resolveValuePath(((AbstractModelEngineResponse<?>) root).getResponse(),
+				argName.substring(split + 1));
+	}
+
+	/**
+	 * Builds the interim result the invocation handler reads to decide whether the
+	 * response is allowed through, and to audit what the guardrail saw.
+	 *
+	 * @param guardrailEngineParams values handed to the guardrail engine
+	 * @param output                the guardrail engine's verdict
+	 * @param interceptorName       class name recorded on the audit row
+	 * @param closeRoomOnBlock      whether a block also closes the room
+	 * @param blockErrorMessage     message returned in place of the response
+	 * @return the interim result map
 	 */
 	private Map<String, Object> createInterimResult(Map<String, Object> guardrailEngineParams,
 			GuardrailNounMetadata output, String interceptorName, Boolean closeRoomOnBlock, String blockErrorMessage) {

--- a/src/prerna/reactor/interceptor/GuardrailValueReader.java
+++ b/src/prerna/reactor/interceptor/GuardrailValueReader.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright 2015 Defense Health Agency (DHA)
+ *
+ * If your use of this software does not include any GPLv2 components:
+ * 	Licensed under the Apache License, Version 2.0 (the "License");
+ * 	you may not use this file except in compliance with the License.
+ * 	You may obtain a copy of the License at
+ *
+ * 	  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * 	Unless required by applicable law or agreed to in writing, software
+ * 	distributed under the License is distributed on an "AS IS" BASIS,
+ * 	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * 	See the License for the specific language governing permissions and
+ * 	limitations under the License.
+ * ----------------------------------------------------------------------------
+ * If your use of this software includes any GPLv2 components:
+ * 	This program is free software; you can redistribute it and/or
+ * 	modify it under the terms of the GNU General Public License
+ * 	as published by the Free Software Foundation; either version 2
+ * 	of the License, or (at your option) any later version.
+ *
+ * 	This program is distributed in the hope that it will be useful,
+ * 	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * 	GNU General Public License for more details.
+ *******************************************************************************/
+package prerna.reactor.interceptor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+import prerna.engine.impl.model.message.AbstractMessage;
+import prerna.engine.impl.model.message.InputMessage;
+import prerna.engine.impl.model.message.MessagePart;
+import prerna.engine.impl.model.message.ResponseMessage;
+import prerna.engine.impl.model.message.TextMessagePart;
+import prerna.engine.impl.model.responses.AbstractModelEngineResponse;
+
+/**
+ * Reduces an intercepted value to the content a guardrail can screen.
+ *
+ * An engine call carries its text inside whatever objects that engine's API
+ * uses - a message, a response wrapper, a map of request fields, or a
+ * collection of any of those. A guardrail reads parameters as text, so a value
+ * handed over as its own object reaches the guardrail as the object's default
+ * string form. Reducing the value first is what makes a guardrail able to
+ * screen it.
+ */
+public final class GuardrailValueReader {
+
+	private static final Logger classLogger = LogManager.getLogger(GuardrailValueReader.class);
+
+	private static final Gson GSON = new GsonBuilder().disableHtmlEscaping().create();
+
+	private GuardrailValueReader() {
+	}
+
+	/**
+	 * Reduces a value to the content a guardrail screens. Messages become their
+	 * text, response wrappers become their payload, and a collection is reduced
+	 * item by item so a list of messages arrives as a list of text. Anything else
+	 * is returned as it is.
+	 *
+	 * @param value value read from the intercepted call
+	 * @return the content to hand the guardrail
+	 */
+	public static Object screenableValue(Object value) {
+		if (value instanceof AbstractMessage) {
+			return messageText((AbstractMessage) value);
+		}
+		if (value instanceof AbstractModelEngineResponse) {
+			return screenableValue(((AbstractModelEngineResponse<?>) value).getResponse());
+		}
+		if (value instanceof Map) {
+			return toJson(value);
+		}
+		if (value instanceof Collection) {
+			return screenableCollection((Collection<?>) value);
+		}
+		return value;
+	}
+
+	/**
+	 * Reduces every item of a collection. Items that all reduce to text are joined
+	 * into one value, because a guardrail reads a text parameter as a single value
+	 * and would otherwise screen only the first item. A collection whose items are
+	 * not all text keeps its shape, so a guardrail parameter that genuinely wants a
+	 * list still receives one.
+	 *
+	 * @param values collection read from the intercepted call
+	 * @return the joined text, or the reduced collection
+	 */
+	private static Object screenableCollection(Collection<?> values) {
+		List<Object> screenable = new ArrayList<>();
+		boolean allText = true;
+		for (Object item : values) {
+			Object reduced = screenableValue(item);
+			allText = allText && reduced instanceof String;
+			screenable.add(reduced);
+		}
+		if (!allText || screenable.isEmpty()) {
+			return screenable;
+		}
+		StringBuilder joined = new StringBuilder();
+		for (Object item : screenable) {
+			if (joined.length() > 0) {
+				joined.append('\n');
+			}
+			joined.append((String) item);
+		}
+		return joined.toString();
+	}
+
+	/**
+	 * Serializes a value so a guardrail reads its fields rather than the shape Java
+	 * prints by default. A value that cannot be serialized falls back to that
+	 * default rather than failing the intercepted call, since a guardrail refusing
+	 * to run would block traffic over a formatting problem.
+	 *
+	 * @param value value to serialize
+	 * @return the value as JSON, or its default string form
+	 */
+	private static String toJson(Object value) {
+		try {
+			return GSON.toJson(value);
+		} catch (RuntimeException e) {
+			classLogger.warn("Unable to serialize a guardrail input of type {}; using its default string form",
+					value.getClass().getName(), e);
+			return String.valueOf(value);
+		}
+	}
+
+	/**
+	 * The text of a message. Each message type already knows which of its parts
+	 * carries the text a model would see, so those accessors are used rather than
+	 * re-deriving it; a message type with neither falls back to collecting its text
+	 * parts.
+	 *
+	 * @param message message to read
+	 * @return the message text, or null when it carries none
+	 */
+	public static String messageText(AbstractMessage message) {
+		if (message == null) {
+			return null;
+		}
+		if (message instanceof InputMessage) {
+			return ((InputMessage) message).getFullInputPrompt();
+		}
+		if (message instanceof ResponseMessage) {
+			return ((ResponseMessage) message).getContent();
+		}
+
+		List<MessagePart> parts = message.getParts();
+		if (parts == null) {
+			return null;
+		}
+		StringBuilder text = new StringBuilder();
+		for (MessagePart part : parts) {
+			if (!(part instanceof TextMessagePart)) {
+				continue;
+			}
+			String partText = ((TextMessagePart) part).getText();
+			if (partText == null || partText.isEmpty()) {
+				continue;
+			}
+			if (text.length() > 0) {
+				text.append('\n');
+			}
+			text.append(partText);
+		}
+		return text.length() > 0 ? text.toString() : null;
+	}
+}

--- a/src/prerna/reactor/interceptor/ReactorInputHelper.java
+++ b/src/prerna/reactor/interceptor/ReactorInputHelper.java
@@ -28,6 +28,9 @@
 package prerna.reactor.interceptor;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 import prerna.sablecc2.om.GenRowStruct;
@@ -35,8 +38,11 @@ import prerna.sablecc2.om.NounStore;
 
 public class ReactorInputHelper {
 
+	private static final Object PATH_NOT_FOUND = new Object();
+
 	private final NounStore nounStore;
-	private final Map<String, Object> argumentsMap; // The map containing ENGINE, METHOD_NAME, CONFIG, etc.
+	// The map containing ENGINE, METHOD_NAME, CONFIG, etc.
+	private final Map<String, Object> argumentsMap;
 
 	public ReactorInputHelper(NounStore nounStore) {
 		this.nounStore = nounStore;
@@ -83,17 +89,63 @@ public class ReactorInputHelper {
 	}
 
 	/**
-	 * Retrieves a method argument by its name (e.g., "arg0", "question"). This
-	 * relies on how arguments are mapped in PipelineInvocationHandler.
+	 * Retrieves a method argument by its name (e.g., {@code arg0} or
+	 * {@code question}). A dot-separated path can select values inside map-shaped
+	 * arguments and results. Numeric segments index lists, while {@code *} projects
+	 * the rest of the path across every item in a list.
+	 *
+	 * <p>
+	 * Examples are {@code arg0.message}, {@code result.messages.0.subject} and
+	 * {@code result.messages.*.body}. This relies on how arguments are mapped in
+	 * {@link prerna.engine.impl.pipeline.PipelineInvocationHandler}.
 	 * 
 	 * @param argName The name of the argument.
 	 * @return The argument value, or null if not found.
 	 */
 	public Object getMethodArgument(String argName) {
-		if (argumentsMap != null && argumentsMap.containsKey(argName)) {
+		if (argumentsMap == null || argName == null || argName.isEmpty()) {
+			return null;
+		}
+		if (argumentsMap.containsKey(argName)) {
 			return argumentsMap.get(argName);
 		}
-		return null;
+
+		String[] path = argName.split("\\.");
+		if (path.length < 2 || !argumentsMap.containsKey(path[0])) {
+			return null;
+		}
+		Object resolved = resolvePath(argumentsMap.get(path[0]), path, 1);
+		return resolved == PATH_NOT_FOUND ? null : resolved;
+	}
+
+	/**
+	 * Replaces a method argument or a value nested inside one. Nested containers
+	 * are copied on the way down, so masking a function parameter does not mutate
+	 * the map supplied by its caller.
+	 *
+	 * @param argName argument name or dot-separated path
+	 * @param value   replacement value
+	 * @return whether the path existed and was replaced
+	 */
+	public boolean setMethodArgument(String argName, Object value) {
+		if (argumentsMap == null || argName == null || argName.isEmpty()) {
+			return false;
+		}
+		if (argumentsMap.containsKey(argName)) {
+			argumentsMap.put(argName, value);
+			return true;
+		}
+
+		String[] path = argName.split("\\.");
+		if (path.length < 2 || !argumentsMap.containsKey(path[0])) {
+			return false;
+		}
+		Object replacement = replacePath(argumentsMap.get(path[0]), path, 1, value);
+		if (replacement == PATH_NOT_FOUND) {
+			return false;
+		}
+		argumentsMap.put(path[0], replacement);
+		return true;
 	}
 
 	/**
@@ -118,6 +170,151 @@ public class ReactorInputHelper {
 	 */
 	public Map<String, Object> getArgumentsMap() {
 		return argumentsMap;
+	}
+
+	/**
+	 * Walks a dot-separated path into a map or list shaped value. Numeric segments
+	 * index lists and {@code *} projects the rest of the path across every item in
+	 * a list, matching the paths {@link #getMethodArgument(String)} accepts.
+	 *
+	 * <p>
+	 * This reads a path relative to a value the caller already holds, which is how
+	 * a guardrail reaches inside a payload that is not itself a method argument.
+	 *
+	 * @param value value to read from
+	 * @param path  dot-separated path relative to value, or null/empty for the
+	 *              value itself
+	 * @return the resolved value, or null when the path does not exist
+	 */
+	public static Object resolveValuePath(Object value, String path) {
+		if (value == null) {
+			return null;
+		}
+		if (path == null || path.isEmpty()) {
+			return value;
+		}
+		Object resolved = resolvePath(value, path.split("\\."), 0);
+		return resolved == PATH_NOT_FOUND ? null : resolved;
+	}
+
+	/**
+	 * Reads one segment of an already split path and recurses into the rest. Maps
+	 * are read by key and lists by numeric index, so the walk can only step into a
+	 * map or a list; a String, a POJO, or null ends it.
+	 *
+	 * <p>
+	 * A {@code *} segment projects the remaining path across every item of a list
+	 * and collects the results, skipping items the rest of the path does not
+	 * resolve for and flattening one level when an item resolves to a list of its
+	 * own. A projection therefore reports an empty list rather than a missing path
+	 * when nothing matched.
+	 *
+	 * @param current   the value this segment is read from
+	 * @param path      the whole path, already split on dots
+	 * @param pathIndex the segment to read now, equal to the path length once every
+	 *                  segment has been walked
+	 * @return the resolved value, or {@code PATH_NOT_FOUND} when the path does not
+	 *         exist. The sentinel is returned instead of null so callers can tell a
+	 *         missing path apart from a path that resolves to null.
+	 */
+	private static Object resolvePath(Object current, String[] path, int pathIndex) {
+		if (pathIndex == path.length) {
+			return current;
+		}
+		if (current instanceof Map) {
+			Map<?, ?> currentMap = (Map<?, ?>) current;
+			String segment = path[pathIndex];
+			if (!currentMap.containsKey(segment)) {
+				return PATH_NOT_FOUND;
+			}
+			return resolvePath(currentMap.get(segment), path, pathIndex + 1);
+		}
+		if (current instanceof List) {
+			List<?> currentList = (List<?>) current;
+			String segment = path[pathIndex];
+			if ("*".equals(segment)) {
+				List<Object> projected = new ArrayList<>();
+				for (Object item : currentList) {
+					Object resolved = resolvePath(item, path, pathIndex + 1);
+					if (resolved == PATH_NOT_FOUND) {
+						continue;
+					}
+					if (resolved instanceof List) {
+						projected.addAll((List<?>) resolved);
+					} else {
+						projected.add(resolved);
+					}
+				}
+				return projected;
+			}
+			try {
+				int listIndex = Integer.parseInt(segment);
+				if (listIndex < 0 || listIndex >= currentList.size()) {
+					return PATH_NOT_FOUND;
+				}
+				return resolvePath(currentList.get(listIndex), path, pathIndex + 1);
+			} catch (NumberFormatException e) {
+				return PATH_NOT_FOUND;
+			}
+		}
+		return PATH_NOT_FOUND;
+	}
+
+	/**
+	 * Rebuilds the path with a new value at the end of it. Nested containers are
+	 * copied rather than modified, so the map or list a caller passed into the
+	 * intercepted method is left alone; each copy is returned to the level above to
+	 * be stored in place of the original.
+	 *
+	 * <p>
+	 * A {@code *} segment is refused, since one value cannot be written back across
+	 * every item of a list.
+	 *
+	 * @param current   the value this segment is read from
+	 * @param path      the whole path, already split on dots
+	 * @param pathIndex the segment to replace now
+	 * @param value     the replacement for the value at the end of the path
+	 * @return a copy of {@code current} carrying the replacement, or
+	 *         {@code PATH_NOT_FOUND} when the path does not exist, in which case
+	 *         nothing has been copied or changed
+	 */
+	private Object replacePath(Object current, String[] path, int pathIndex, Object value) {
+		if (pathIndex == path.length) {
+			return value;
+		}
+		String segment = path[pathIndex];
+		if (current instanceof Map) {
+			Map<?, ?> currentMap = (Map<?, ?>) current;
+			if (!currentMap.containsKey(segment)) {
+				return PATH_NOT_FOUND;
+			}
+			Object replacement = replacePath(currentMap.get(segment), path, pathIndex + 1, value);
+			if (replacement == PATH_NOT_FOUND) {
+				return PATH_NOT_FOUND;
+			}
+			Map<Object, Object> copy = new LinkedHashMap<>(currentMap);
+			copy.put(segment, replacement);
+			return copy;
+		}
+		if (current instanceof List && !"*".equals(segment)) {
+			List<?> currentList = (List<?>) current;
+			try {
+				int listIndex = Integer.parseInt(segment);
+				if (listIndex < 0 || listIndex >= currentList.size()) {
+					return PATH_NOT_FOUND;
+				}
+				Object replacement = replacePath(currentList.get(listIndex), path, pathIndex + 1, value);
+				if (replacement == PATH_NOT_FOUND) {
+					return PATH_NOT_FOUND;
+				}
+				List<Object> copy = new ArrayList<>(currentList);
+				copy.set(listIndex, replacement);
+				return copy;
+			} catch (NumberFormatException e) {
+				return PATH_NOT_FOUND;
+			}
+		}
+		return PATH_NOT_FOUND;
 	}
 
 }

--- a/src/prerna/reactor/model/CompactRoomMessagesReactor.java
+++ b/src/prerna/reactor/model/CompactRoomMessagesReactor.java
@@ -495,7 +495,7 @@ public class CompactRoomMessagesReactor extends AbstractReactor {
 	private static String getMessageText(AbstractMessage m) {
 		if (m instanceof InputMessage) {
 			InputMessage input = (InputMessage) m;
-			String text = input.getInputPrompt();
+			String text = input.getInputText();
 			if (text == null || text.isBlank()) {
 				text = input.getInputUIPrompt();
 			}

--- a/src/prerna/reactor/model/GetModelGuardrailConfigReactor.java
+++ b/src/prerna/reactor/model/GetModelGuardrailConfigReactor.java
@@ -29,14 +29,25 @@ package prerna.reactor.model;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
 
@@ -44,9 +55,13 @@ import prerna.auth.User;
 import prerna.auth.utils.SecurityEngineUtils;
 import prerna.engine.api.IEngine;
 import prerna.engine.api.IModelEngine;
+import prerna.engine.impl.model.message.AbstractMessage;
+import prerna.engine.impl.model.responses.AbstractModelEngineResponse;
+import prerna.logging.IgnoreEngineLogging;
 import prerna.reactor.AbstractReactor;
-import prerna.reactor.interceptor.GenericGuardrailInputOutputReactor;
 import prerna.reactor.interceptor.GenericGuardrailInputReactor;
+import prerna.reactor.interceptor.GenericGuardrailOutputReactor;
+import prerna.reactor.interceptor.PipelineReactorUtils;
 import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.PixelOperationType;
 import prerna.sablecc2.om.ReactorKeysEnum;
@@ -57,17 +72,31 @@ import prerna.util.Utility;
 /**
  * Returns a model engine's guardrail pipeline configuration (the file the
  * PIPELINE smss key points at) so the settings UI can load it. Missing or
- * malformed configuration is reported in the response instead of thrown so
- * the UI can offer to create or reset it. Requires edit access - the config
- * exposes the engine ids of the attached guardrail engines.
+ * malformed configuration is reported in the response instead of thrown so the
+ * UI can offer to create or reset it. The response also carries the model
+ * engine methods a pipeline can intercept, so the editor can offer the method
+ * and argument names the runtime actually resolves rather than asking for them
+ * as free text. Requires edit access - the config exposes the engine ids of the
+ * attached guardrail engines.
  */
 public class GetModelGuardrailConfigReactor extends AbstractReactor {
+
+	private static final Logger classLogger = LogManager.getLogger(GetModelGuardrailConfigReactor.class);
 
 	private static final String PIPELINES_KEY = "pipelines";
 	private static final String INPUT_KEY = "input";
 	private static final String OUTPUT_KEY = "output";
 	private static final String PARAMS_KEY = "params";
 	private static final String GUARDRAIL_ENGINE_ID_KEY = "guardrailEngineId";
+
+	/**
+	 * Method names surfaced first so the picker leads with the calls that carry
+	 * user content. Everything else follows alphabetically.
+	 */
+	private static final List<String> METHOD_DISPLAY_ORDER = Arrays.asList("askRoom", "embeddings",
+			"multiModalEmbeddings");
+
+	private static final List<Map<String, Object>> INTERCEPTABLE_METHODS = buildInterceptableMethods();
 
 	public GetModelGuardrailConfigReactor() {
 		this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey() };
@@ -79,7 +108,8 @@ public class GetModelGuardrailConfigReactor extends AbstractReactor {
 		String engineId = this.keyValue.get(this.keysToGet[0]);
 		User user = this.insight.getUser();
 		if (!SecurityEngineUtils.userCanEditEngine(user, engineId)) {
-			throw new IllegalArgumentException("Engine " + engineId + " does not exist or user does not have edit access to it");
+			throw new IllegalArgumentException(
+					"Engine " + engineId + " does not exist or user does not have edit access to it");
 		}
 		Object[] typeAndSubtype = SecurityEngineUtils.getEngineTypeAndSubtype(engineId);
 		if (typeAndSubtype[0] != IEngine.CATALOG_TYPE.MODEL) {
@@ -130,20 +160,134 @@ public class GetModelGuardrailConfigReactor extends AbstractReactor {
 		response.put("guardrailEngines", getGuardrailEngineDetails(user, pipelines));
 
 		Map<String, Object> allowedReactorClasses = new HashMap<>();
-		allowedReactorClasses.put(INPUT_KEY, Arrays.asList(
-				GenericGuardrailInputReactor.class.getName(),
-				GenericGuardrailInputOutputReactor.class.getName()));
-		allowedReactorClasses.put(OUTPUT_KEY, Arrays.asList(
-				GenericGuardrailInputOutputReactor.class.getName()));
+		allowedReactorClasses.put(INPUT_KEY, Arrays.asList(GenericGuardrailInputReactor.class.getName()));
+		allowedReactorClasses.put(OUTPUT_KEY, Arrays.asList(GenericGuardrailOutputReactor.class.getName()));
 		response.put("allowedReactorClasses", allowedReactorClasses);
+
+		response.put("interceptableMethods", INTERCEPTABLE_METHODS);
+		response.put("resultArgumentName", PipelineReactorUtils.RESULT);
 
 		return new NounMetadata(response, PixelDataType.MAP, PixelOperationType.OPERATION);
 	}
 
 	/**
-	 * Resolve name/type details for every guardrail engine referenced in the
-	 * config so the UI can label them without extra pixel calls. Referenced
-	 * engines that no longer exist are reported with exists=false.
+	 * The model engine methods a guardrail pipeline can intercept, each with the
+	 * argument names a guardrail maps its parameters from. Methods annotated with
+	 * {@link IgnoreEngineLogging} are left out because
+	 * {@link prerna.engine.impl.pipeline.PipelineInvocationHandler} invokes the
+	 * real engine directly for them, so no pipeline runs.
+	 *
+	 * Argument names come from {@link Parameter#getName()}, the same lookup the
+	 * invocation handler uses to build its argument map. That yields arg0, arg1,
+	 * ... unless the interface was compiled with -parameters, in which case the
+	 * source names are returned; nameIsFromSource reports which one the running
+	 * build produced.
+	 *
+	 * @return one entry per interceptable method, ordered for display
+	 */
+	private static List<Map<String, Object>> buildInterceptableMethods() {
+		List<Map<String, Object>> interceptable = new ArrayList<>();
+		try {
+			List<Method> methods = new ArrayList<>();
+			for (Method method : IModelEngine.class.getDeclaredMethods()) {
+				if (method.isSynthetic() || Modifier.isStatic(method.getModifiers())
+						|| method.isAnnotationPresent(IgnoreEngineLogging.class)) {
+					continue;
+				}
+				methods.add(method);
+			}
+			methods.sort(Comparator.comparingInt((Method method) -> {
+				int rank = METHOD_DISPLAY_ORDER.indexOf(method.getName());
+				return rank < 0 ? METHOD_DISPLAY_ORDER.size() : rank;
+			}).thenComparing(Method::getName));
+
+			for (Method method : methods) {
+				Map<String, Object> entry = new LinkedHashMap<>();
+				entry.put("name", method.getName());
+				entry.put("deprecated", method.isAnnotationPresent(Deprecated.class));
+				entry.put("returnType", readableTypeName(method.getGenericReturnType()));
+				entry.put("returnsModelResponse",
+						AbstractModelEngineResponse.class.isAssignableFrom(method.getReturnType()));
+
+				List<Map<String, Object>> arguments = new ArrayList<>();
+				Parameter[] parameters = method.getParameters();
+				for (int i = 0; i < parameters.length; i++) {
+					Map<String, Object> argument = new LinkedHashMap<>();
+					argument.put("name", parameters[i].getName());
+					argument.put("position", i);
+					argument.put("nameIsFromSource", parameters[i].isNamePresent());
+					argument.put("type", readableTypeName(parameters[i].getParameterizedType()));
+					argument.put("guardable", isGuardableArgument(parameters[i]));
+					arguments.add(argument);
+				}
+				entry.put("arguments", arguments);
+				interceptable.add(entry);
+			}
+		} catch (RuntimeException e) {
+			// the settings UI falls back to free-text entry when this list is empty,
+			// so a reflection problem must not take the whole reactor down
+			classLogger.error("Unable to reflect the interceptable model engine methods", e);
+		}
+		return interceptable;
+	}
+
+	/**
+	 * Whether a guardrail can screen this argument's value. The interceptors reduce
+	 * strings, messages, and collections of either to text; every other argument is
+	 * call plumbing such as the Insight, the Room, or the provider parameter map,
+	 * which a guardrail has no text to read from.
+	 *
+	 * @param parameter
+	 * @return
+	 */
+	private static boolean isGuardableArgument(Parameter parameter) {
+		Type generic = parameter.getParameterizedType();
+		if (isScreenableType(generic)) {
+			return true;
+		}
+		if (Collection.class.isAssignableFrom(parameter.getType()) && generic instanceof ParameterizedType) {
+			Type[] typeArguments = ((ParameterizedType) generic).getActualTypeArguments();
+			return typeArguments.length == 1 && isScreenableType(typeArguments[0]);
+		}
+		return false;
+	}
+
+	/**
+	 * Whether {@link prerna.reactor.interceptor.GuardrailValueReader} can reduce
+	 * this type to text: a string, a message, or a map serialized to JSON. A
+	 * wildcard or type variable is reported as unscreenable even though the
+	 * interceptor would still reduce whatever arrives, so the editor understates
+	 * rather than promises.
+	 *
+	 * @param type
+	 * @return
+	 */
+	private static boolean isScreenableType(Type type) {
+		if (type instanceof ParameterizedType) {
+			return isScreenableType(((ParameterizedType) type).getRawType());
+		}
+		if (!(type instanceof Class)) {
+			return false;
+		}
+		Class<?> raw = (Class<?>) type;
+		return raw == String.class || AbstractMessage.class.isAssignableFrom(raw) || Map.class.isAssignableFrom(raw);
+	}
+
+	/**
+	 * Drops package qualifiers so the UI prints List&lt;String&gt; rather than
+	 * java.util.List&lt;java.lang.String&gt;.
+	 *
+	 * @param type
+	 * @return
+	 */
+	private static String readableTypeName(Type type) {
+		return type.getTypeName().replaceAll("(\\w+\\.)+", "");
+	}
+
+	/**
+	 * Resolve name/type details for every guardrail engine referenced in the config
+	 * so the UI can label them without extra pixel calls. Referenced engines that
+	 * no longer exist are reported with exists=false.
 	 *
 	 * @param user
 	 * @param pipelines
@@ -180,9 +324,9 @@ public class GetModelGuardrailConfigReactor extends AbstractReactor {
 	}
 
 	/**
-	 * Walk the parsed pipelines and pull out every guardrailEngineId. The
-	 * walk is defensive - malformed nodes are skipped, not thrown, since this
-	 * reactor reports config problems instead of failing on them.
+	 * Walk the parsed pipelines and pull out every guardrailEngineId. The walk is
+	 * defensive - malformed nodes are skipped, not thrown, since this reactor
+	 * reports config problems instead of failing on them.
 	 *
 	 * @param pipelines
 	 * @return
@@ -221,7 +365,7 @@ public class GetModelGuardrailConfigReactor extends AbstractReactor {
 
 	@Override
 	public String getReactorDescription() {
-		return "Returns the guardrail pipeline configuration (pipeline.json contents) for a model engine, along with name and type details for every referenced guardrail engine. Requires edit access to the engine.";
+		return "Returns the guardrail pipeline configuration (pipeline.json contents) for a model engine, along with name and type details for every referenced guardrail engine and the list of model engine methods a pipeline can intercept. Requires edit access to the engine.";
 	}
 
 	@Override

--- a/src/prerna/reactor/model/UpdateModelGuardrailConfigReactor.java
+++ b/src/prerna/reactor/model/UpdateModelGuardrailConfigReactor.java
@@ -40,10 +40,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.locks.ReentrantLock;
 
-import com.google.gson.GsonBuilder;
-
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import com.google.gson.GsonBuilder;
 
 import prerna.auth.User;
 import prerna.auth.utils.SecurityEngineUtils;
@@ -51,8 +51,8 @@ import prerna.cluster.util.ClusterUtil;
 import prerna.engine.api.IEngine;
 import prerna.engine.api.IModelEngine;
 import prerna.reactor.AbstractReactor;
-import prerna.reactor.interceptor.GenericGuardrailInputOutputReactor;
 import prerna.reactor.interceptor.GenericGuardrailInputReactor;
+import prerna.reactor.interceptor.GenericGuardrailOutputReactor;
 import prerna.sablecc2.om.PixelDataType;
 import prerna.sablecc2.om.PixelOperationType;
 import prerna.sablecc2.om.ReactorKeysEnum;
@@ -69,8 +69,8 @@ import prerna.util.Utility;
  * The PIPELINE smss key is added when missing. An empty pipelines map removes
  * all guardrails. Requires edit access to the engine.
  *
- * Note pixel map literals deliver numeric values as doubles (1 arrives as
- * 1.0); directParameters values are written as provided.
+ * Note pixel map literals deliver numeric values as doubles (1 arrives as 1.0);
+ * directParameters values are written as provided.
  */
 public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 
@@ -82,21 +82,21 @@ public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 	private static final String GUARDRAIL_ENGINE_ID_KEY = "guardrailEngineId";
 	private static final String BLOCK_ON_FAILURE_KEY = "blockOnGuardrailFailure";
 	private static final String MASK_ON_FAILURE_KEY = "maskOnGuardrailFailure";
-	private static final String MASK_TARGET_PARAM_KEY = "maskTargetParam";
+	private static final String RESPOND_WITH_GUARDRAIL_MESSAGE_KEY = "respondWithGuardrailMessage";
+	private static final String CLOSE_ROOM_ON_BLOCK_KEY = "closeRoomOnBlock";
+	private static final String BLOCK_ERROR_MESSAGE_KEY = "blockErrorMessage";
 	private static final String INPUT_MAPPING_KEY = "inputMapping";
 	private static final String DIRECT_PARAMETERS_KEY = "directParameters";
-	private static final String DEFAULT_MASK_TARGET_PARAM = "prompt";
 	private static final String DEFAULT_PIPELINE_FILE = "pipeline.json";
 
-	private static final Set<String> INPUT_REACTOR_WHITELIST = new HashSet<>(Arrays.asList(
-			GenericGuardrailInputReactor.class.getName(),
-			GenericGuardrailInputOutputReactor.class.getName()));
-	private static final Set<String> OUTPUT_REACTOR_WHITELIST = new HashSet<>(Arrays.asList(
-			GenericGuardrailInputOutputReactor.class.getName()));
+	private static final Set<String> INPUT_REACTOR_WHITELIST = new HashSet<>(
+			Arrays.asList(GenericGuardrailInputReactor.class.getName()));
+	private static final Set<String> OUTPUT_REACTOR_WHITELIST = new HashSet<>(
+			Arrays.asList(GenericGuardrailOutputReactor.class.getName()));
 
-	private static final Set<String> ALLOWED_PARAM_KEYS = new HashSet<>(Arrays.asList(
-			GUARDRAIL_ENGINE_ID_KEY, BLOCK_ON_FAILURE_KEY, MASK_ON_FAILURE_KEY,
-			MASK_TARGET_PARAM_KEY, INPUT_MAPPING_KEY, DIRECT_PARAMETERS_KEY));
+	private static final Set<String> ALLOWED_PARAM_KEYS = new HashSet<>(Arrays.asList(GUARDRAIL_ENGINE_ID_KEY,
+			BLOCK_ON_FAILURE_KEY, MASK_ON_FAILURE_KEY, RESPOND_WITH_GUARDRAIL_MESSAGE_KEY, CLOSE_ROOM_ON_BLOCK_KEY,
+			BLOCK_ERROR_MESSAGE_KEY, INPUT_MAPPING_KEY, DIRECT_PARAMETERS_KEY));
 
 	public UpdateModelGuardrailConfigReactor() {
 		this.keysToGet = new String[] { ReactorKeysEnum.ENGINE.getKey(), ReactorKeysEnum.MAP.getKey() };
@@ -108,7 +108,8 @@ public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 		String engineId = this.keyValue.get(this.keysToGet[0]);
 		User user = this.insight.getUser();
 		if (!SecurityEngineUtils.userCanEditEngine(user, engineId)) {
-			throw new IllegalArgumentException("Engine " + engineId + " does not exist or user does not have edit access to it");
+			throw new IllegalArgumentException(
+					"Engine " + engineId + " does not exist or user does not have edit access to it");
 		}
 		Object[] typeAndSubtype = SecurityEngineUtils.getEngineTypeAndSubtype(engineId);
 		if (typeAndSubtype[0] != IEngine.CATALOG_TYPE.MODEL) {
@@ -126,7 +127,8 @@ public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 		try {
 			new JSONObject(json).getJSONObject(PIPELINES_KEY);
 		} catch (JSONException e) {
-			throw new IllegalArgumentException("The guardrail configuration does not serialize to valid pipeline JSON: " + e.getMessage(), e);
+			throw new IllegalArgumentException(
+					"The guardrail configuration does not serialize to valid pipeline JSON: " + e.getMessage(), e);
 		}
 
 		IModelEngine model = Utility.getModel(engineId);
@@ -146,7 +148,8 @@ public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 			File pipelineFile = new File((assetsFolder + "/" + pipelineFileName).replace("\\", "/"));
 			File parentDir = pipelineFile.getParentFile();
 			if (parentDir != null && !parentDir.exists() && !parentDir.mkdirs()) {
-				throw new IllegalStateException("Unable to create the engine assets folder for the guardrail configuration");
+				throw new IllegalStateException(
+						"Unable to create the engine assets folder for the guardrail configuration");
 			}
 			try (Writer writer = new OutputStreamWriter(new FileOutputStream(pipelineFile), StandardCharsets.UTF_8)) {
 				writer.write(json);
@@ -158,7 +161,10 @@ public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 				try {
 					Utility.changePropertiesFileValue(model.getSmssFilePath(), IEngine.PIPELINE, DEFAULT_PIPELINE_FILE);
 				} catch (IOException e) {
-					throw new IllegalStateException("Wrote the guardrail configuration but was unable to add the PIPELINE key to the engine smss file: " + e.getMessage(), e);
+					throw new IllegalStateException(
+							"Wrote the guardrail configuration but was unable to add the PIPELINE key to the engine smss file: "
+									+ e.getMessage(),
+							e);
 				}
 				model.getSmssProp().setProperty(IEngine.PIPELINE, DEFAULT_PIPELINE_FILE);
 				ClusterUtil.pushEngineSmss(engineId);
@@ -172,14 +178,15 @@ public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 		}
 
 		NounMetadata noun = new NounMetadata(true, PixelDataType.BOOLEAN, PixelOperationType.OPERATION);
-		noun.addAdditionalReturn(NounMetadata.getSuccessNounMessage("Successfully updated the guardrail configuration"));
+		noun.addAdditionalReturn(
+				NounMetadata.getSuccessNounMessage("Successfully updated the guardrail configuration"));
 		return noun;
 	}
 
 	/**
-	 * Structural validation with no database access - package visible so unit
-	 * tests can exercise it directly. Returns the pipelines map on success.
-	 * An empty pipelines map is valid and means all guardrails are removed.
+	 * Structural validation with no database access - package visible so unit tests
+	 * can exercise it directly. Returns the pipelines map on success. An empty
+	 * pipelines map is valid and means all guardrails are removed.
 	 *
 	 * @param config
 	 * @return
@@ -187,12 +194,14 @@ public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 	static Map<String, Object> validateConfigStructure(Map<String, Object> config) {
 		for (String key : config.keySet()) {
 			if (!PIPELINES_KEY.equals(key)) {
-				throw new IllegalArgumentException("Unknown key '" + key + "' in the guardrail configuration - only '" + PIPELINES_KEY + "' is allowed");
+				throw new IllegalArgumentException("Unknown key '" + key + "' in the guardrail configuration - only '"
+						+ PIPELINES_KEY + "' is allowed");
 			}
 		}
 		Object pipelinesObj = config.get(PIPELINES_KEY);
 		if (!(pipelinesObj instanceof Map)) {
-			throw new IllegalArgumentException("The guardrail configuration must contain a '" + PIPELINES_KEY + "' map");
+			throw new IllegalArgumentException(
+					"The guardrail configuration must contain a '" + PIPELINES_KEY + "' map");
 		}
 		@SuppressWarnings("unchecked")
 		Map<String, Object> pipelines = (Map<String, Object>) pipelinesObj;
@@ -203,18 +212,21 @@ public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 			}
 			String path = PIPELINES_KEY + "." + method;
 			if (!(pipelineEntry.getValue() instanceof Map)) {
-				throw new IllegalArgumentException(path + " must be a map with '" + INPUT_KEY + "' and/or '" + OUTPUT_KEY + "' lists");
+				throw new IllegalArgumentException(
+						path + " must be a map with '" + INPUT_KEY + "' and/or '" + OUTPUT_KEY + "' lists");
 			}
 			Map<?, ?> pipeline = (Map<?, ?>) pipelineEntry.getValue();
 			for (Object pipelineKey : pipeline.keySet()) {
 				if (!INPUT_KEY.equals(pipelineKey) && !OUTPUT_KEY.equals(pipelineKey)) {
-					throw new IllegalArgumentException(path + " contains unknown key '" + pipelineKey + "' - only '" + INPUT_KEY + "' and '" + OUTPUT_KEY + "' are allowed");
+					throw new IllegalArgumentException(path + " contains unknown key '" + pipelineKey + "' - only '"
+							+ INPUT_KEY + "' and '" + OUTPUT_KEY + "' are allowed");
 				}
 			}
 			int entryCount = validateSlot(path, INPUT_KEY, pipeline.get(INPUT_KEY), INPUT_REACTOR_WHITELIST)
 					+ validateSlot(path, OUTPUT_KEY, pipeline.get(OUTPUT_KEY), OUTPUT_REACTOR_WHITELIST);
 			if (entryCount == 0) {
-				throw new IllegalArgumentException(path + " must define at least one guardrail in '" + INPUT_KEY + "' or '" + OUTPUT_KEY + "'");
+				throw new IllegalArgumentException(
+						path + " must define at least one guardrail in '" + INPUT_KEY + "' or '" + OUTPUT_KEY + "'");
 			}
 		}
 		return pipelines;
@@ -237,26 +249,29 @@ public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 			Map<?, ?> entryMap = (Map<?, ?>) entry;
 			for (Object entryKey : entryMap.keySet()) {
 				if (!REACTOR_CLASS_KEY.equals(entryKey) && !PARAMS_KEY.equals(entryKey)) {
-					throw new IllegalArgumentException(entryPath + " contains unknown key '" + entryKey + "' - only '" + REACTOR_CLASS_KEY + "' and '" + PARAMS_KEY + "' are allowed");
+					throw new IllegalArgumentException(entryPath + " contains unknown key '" + entryKey + "' - only '"
+							+ REACTOR_CLASS_KEY + "' and '" + PARAMS_KEY + "' are allowed");
 				}
 			}
 			Object reactorClass = entryMap.get(REACTOR_CLASS_KEY);
 			if (!(reactorClass instanceof String) || !reactorWhitelist.contains(reactorClass)) {
-				throw new IllegalArgumentException(entryPath + "." + REACTOR_CLASS_KEY + " must be one of " + reactorWhitelist + " for the '" + slotName + "' slot");
+				throw new IllegalArgumentException(entryPath + "." + REACTOR_CLASS_KEY + " must be one of "
+						+ reactorWhitelist + " for the '" + slotName + "' slot");
 			}
 			Object params = entryMap.get(PARAMS_KEY);
 			if (!(params instanceof Map)) {
 				throw new IllegalArgumentException(entryPath + "." + PARAMS_KEY + " must be a map");
 			}
-			validateParams(entryPath + "." + PARAMS_KEY, (Map<?, ?>) params);
+			validateParams(entryPath + "." + PARAMS_KEY, (Map<?, ?>) params, slotName, (String) reactorClass);
 		}
 		return entries.size();
 	}
 
-	private static void validateParams(String path, Map<?, ?> params) {
+	private static void validateParams(String path, Map<?, ?> params, String slotName, String reactorClass) {
 		for (Object paramKey : params.keySet()) {
 			if (!ALLOWED_PARAM_KEYS.contains(paramKey)) {
-				throw new IllegalArgumentException(path + " contains unknown key '" + paramKey + "' - allowed keys are " + ALLOWED_PARAM_KEYS);
+				throw new IllegalArgumentException(
+						path + " contains unknown key '" + paramKey + "' - allowed keys are " + ALLOWED_PARAM_KEYS);
 			}
 		}
 
@@ -273,10 +288,41 @@ public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 		if (maskOnFailure != null && !(maskOnFailure instanceof Boolean)) {
 			throw new IllegalArgumentException(path + "." + MASK_ON_FAILURE_KEY + " must be a boolean");
 		}
+		Object respondWithGuardrailMessage = params.get(RESPOND_WITH_GUARDRAIL_MESSAGE_KEY);
+		if (respondWithGuardrailMessage != null && !(respondWithGuardrailMessage instanceof Boolean)) {
+			throw new IllegalArgumentException(path + "." + RESPOND_WITH_GUARDRAIL_MESSAGE_KEY + " must be a boolean");
+		}
+		Object closeRoomOnBlock = params.get(CLOSE_ROOM_ON_BLOCK_KEY);
+		if (closeRoomOnBlock != null && !(closeRoomOnBlock instanceof Boolean)) {
+			throw new IllegalArgumentException(path + "." + CLOSE_ROOM_ON_BLOCK_KEY + " must be a boolean");
+		}
 
-		Object maskTargetParam = params.get(MASK_TARGET_PARAM_KEY);
-		if (maskTargetParam != null && (!(maskTargetParam instanceof String) || ((String) maskTargetParam).trim().isEmpty())) {
-			throw new IllegalArgumentException(path + "." + MASK_TARGET_PARAM_KEY + " must be a non-empty string");
+		boolean masksOnFailure = Boolean.TRUE.equals(maskOnFailure);
+		boolean respondsOnFailure = Boolean.TRUE.equals(respondWithGuardrailMessage);
+		boolean blocksOnFailure = blockOnFailure == null ? !masksOnFailure && !respondsOnFailure
+				: Boolean.TRUE.equals(blockOnFailure);
+		int activeFailureActions = (blocksOnFailure ? 1 : 0) + (masksOnFailure ? 1 : 0) + (respondsOnFailure ? 1 : 0);
+		if (activeFailureActions != 1) {
+			throw new IllegalArgumentException(path + " must enable exactly one failure action: " + BLOCK_ON_FAILURE_KEY
+					+ ", " + MASK_ON_FAILURE_KEY + ", or " + RESPOND_WITH_GUARDRAIL_MESSAGE_KEY);
+		}
+		if ((masksOnFailure || respondsOnFailure) && (!INPUT_KEY.equals(slotName)
+				|| !GenericGuardrailInputReactor.class.getName().equals(reactorClass))) {
+			throw new IllegalArgumentException(path + ": masking and returning the guardrail message require an '"
+					+ INPUT_KEY + "' guardrail using " + GenericGuardrailInputReactor.class.getName());
+		}
+		if (Boolean.TRUE.equals(closeRoomOnBlock) && !blocksOnFailure) {
+			throw new IllegalArgumentException(
+					path + "." + CLOSE_ROOM_ON_BLOCK_KEY + " can only be enabled when blocking on failure");
+		}
+		Object blockErrorMessage = params.get(BLOCK_ERROR_MESSAGE_KEY);
+		if (blockErrorMessage != null
+				&& (!(blockErrorMessage instanceof String) || ((String) blockErrorMessage).trim().isEmpty())) {
+			throw new IllegalArgumentException(path + "." + BLOCK_ERROR_MESSAGE_KEY + " must be a non-empty string");
+		}
+		if (blockErrorMessage != null && !blocksOnFailure) {
+			throw new IllegalArgumentException(
+					path + "." + BLOCK_ERROR_MESSAGE_KEY + " can only be set when blocking on failure");
 		}
 
 		// without a mapping the interceptor calls the guardrail engine with no
@@ -313,21 +359,35 @@ public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 			throw new IllegalArgumentException(path + "." + DIRECT_PARAMETERS_KEY + " must be a map");
 		}
 
-		// the runtime silently downgrades mask to block when the mask target
-		// maps to multiple arguments - reject the combination up front
+		// A masked value replaces the argument that supplied it, so at least one
+		// mapping has to name a single argument. Combined mappings cannot receive
+		// one returned string, and a direct parameter overriding a mapping means
+		// the guardrail never reads that argument. Which argument gets written is
+		// resolved at request time from the argument's type.
 		if (Boolean.TRUE.equals(maskOnFailure)) {
-			String maskTarget = maskTargetParam == null ? DEFAULT_MASK_TARGET_PARAM : ((String) maskTargetParam).trim();
-			Object maskMapping = ((Map<?, ?>) inputMapping).get(maskTarget);
-			if (!(maskMapping instanceof String)) {
+			boolean hasMaskableMapping = false;
+			for (Map.Entry<?, ?> mappingEntry : ((Map<?, ?>) inputMapping).entrySet()) {
+				if (!(mappingEntry.getValue() instanceof String)) {
+					continue;
+				}
+				if (directParameters instanceof Map
+						&& ((Map<?, ?>) directParameters).containsKey(mappingEntry.getKey())) {
+					continue;
+				}
+				hasMaskableMapping = true;
+				break;
+			}
+			if (!hasMaskableMapping) {
 				throw new IllegalArgumentException(path + ": " + MASK_ON_FAILURE_KEY + " requires " + INPUT_MAPPING_KEY
-						+ " to map '" + maskTarget + "' to a single argument name - otherwise the runtime falls back to blocking");
+						+ " to map at least one guardrail parameter to a single argument name that "
+						+ DIRECT_PARAMETERS_KEY + " does not override, since the masked value is written back to it");
 			}
 		}
 	}
 
 	/**
-	 * Database-backed validation that every referenced guardrail engine
-	 * exists, is a guardrail engine, and is visible to the user.
+	 * Database-backed validation that every referenced guardrail engine exists, is
+	 * a guardrail engine, and is visible to the user.
 	 *
 	 * @param user
 	 * @param pipelines
@@ -350,10 +410,12 @@ public class UpdateModelGuardrailConfigReactor extends AbstractReactor {
 						throw new IllegalArgumentException("Guardrail engine " + guardrailEngineId + " does not exist");
 					}
 					if (typeAndSubtype[0] != IEngine.CATALOG_TYPE.GUARDRAIL) {
-						throw new IllegalArgumentException("Engine " + guardrailEngineId + " is not a guardrail engine");
+						throw new IllegalArgumentException(
+								"Engine " + guardrailEngineId + " is not a guardrail engine");
 					}
 					if (!SecurityEngineUtils.userCanViewEngine(user, guardrailEngineId)) {
-						throw new IllegalArgumentException("User does not have access to guardrail engine " + guardrailEngineId);
+						throw new IllegalArgumentException(
+								"User does not have access to guardrail engine " + guardrailEngineId);
 					}
 				}
 			}

--- a/src/prerna/reactor/playwright/GenerateInputValuesReactor.java
+++ b/src/prerna/reactor/playwright/GenerateInputValuesReactor.java
@@ -280,7 +280,8 @@ public class GenerateInputValuesReactor extends AbstractReactor {
 	 */
 	private Map<String, Object> buildPair(InputMessage question, ResponseMessage answer) {
 		Map<String, Object> pair = new LinkedHashMap<>();
-		String questionText = question != null ? firstNonBlank(question.getInputUIPrompt(), question.getInputPrompt())
+		String questionText = question != null
+				? firstNonBlank(question.getInputUIPrompt(), question.getFullInputPrompt())
 				: null;
 		pair.put("question", questionText);
 

--- a/src/prerna/reactor/playwright/GeneratePlaywrightFieldActionsReactor.java
+++ b/src/prerna/reactor/playwright/GeneratePlaywrightFieldActionsReactor.java
@@ -509,7 +509,7 @@ public class GeneratePlaywrightFieldActionsReactor extends AbstractReactor {
 			String content;
 			if (message instanceof InputMessage input) {
 				role = "User";
-				content = firstNonBlank(input.getInputUIPrompt(), input.getInputPrompt());
+				content = firstNonBlank(input.getInputUIPrompt(), input.getFullInputPrompt());
 			} else if (message instanceof ResponseMessage response) {
 				role = "Assistant";
 				content = responseText(response);

--- a/src/prerna/reactor/playwright/GeneratePlaywrightRecordingMetadataReactor.java
+++ b/src/prerna/reactor/playwright/GeneratePlaywrightRecordingMetadataReactor.java
@@ -317,7 +317,7 @@ public class GeneratePlaywrightRecordingMetadataReactor extends AbstractReactor 
 			String content;
 			if (message instanceof InputMessage input) {
 				role = "User";
-				content = firstNonBlank(input.getInputUIPrompt(), input.getInputPrompt());
+				content = firstNonBlank(input.getInputUIPrompt(), input.getFullInputPrompt());
 			} else if (message instanceof ResponseMessage response) {
 				role = "Assistant";
 				content = response.getContent();

--- a/src/prerna/reactor/playwright/GetRoomConversationHistoryReactor.java
+++ b/src/prerna/reactor/playwright/GetRoomConversationHistoryReactor.java
@@ -234,7 +234,8 @@ public class GetRoomConversationHistoryReactor extends AbstractReactor {
 	 */
 	private static Map<String, Object> buildPair(InputMessage question, ResponseMessage answer, boolean complete) {
 		Map<String, Object> pair = new LinkedHashMap<>();
-		String questionText = question != null ? firstNonBlank(question.getInputUIPrompt(), question.getInputPrompt())
+		String questionText = question != null
+				? firstNonBlank(question.getInputUIPrompt(), question.getFullInputPrompt())
 				: null;
 		pair.put("question", questionText);
 		pair.put("questionId", question != null ? question.getMessageId() : null);

--- a/src/prerna/reactor/utils/GetEngineUsageReactor.java
+++ b/src/prerna/reactor/utils/GetEngineUsageReactor.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import prerna.auth.utils.SecurityEngineUtils;
 import prerna.engine.api.IEngine;
 import prerna.engine.api.IFunctionEngine;
+import prerna.engine.api.IGuardrailReactorFunctionEngine;
 import prerna.engine.impl.function.FunctionParameter;
 import prerna.reactor.AbstractReactor;
 import prerna.sablecc2.om.PixelDataType;
@@ -54,6 +55,7 @@ public class GetEngineUsageReactor extends AbstractReactor {
 	private static final String JAVA = "java";
 	private static final String JAVASCRIPT = "javascript";
 	private static final String PIXEL = "pixel";
+	private static final String GUARDRAIL = "guardrail";
 	private static final String LANGCHAIN = "LANGCHAIN";
 	private static final String OPENAI = "OPENAI";
 	private static final String ANTHROPIC = "ANTHROPIC";
@@ -70,6 +72,7 @@ public class GetEngineUsageReactor extends AbstractReactor {
 	private static final String PYTHON_LABEL = "How to use in Python";
 	private static final String JAVA_LABEL = "How to use in Java";
 	private static final String JAVASCRIPT_LABEL = "How to use in JavaScript/TypeScript with the @semoss/sdk";
+	private static final String GUARDRAIL_LABEL = "How to configure the guardrail pipeline JSON";
 	private static final String LANGCHAIN_LABEL = "How to use with LangChain API";
 	private static final String OPENAI_LABEL = "How to use externally with OpenAI API";
 	private static final String ANTHROPIC_LABEL = "How to use externally with Anthropic API";
@@ -179,6 +182,8 @@ public class GetEngineUsageReactor extends AbstractReactor {
 			return getVectorUsage(engineId);
 		case FUNCTION:
 			return getFunctionUsage(engineId);
+		case GUARDRAIL:
+			return getGuardrailUsage(engineId);
 		default:
 			return getPendingUsage();
 		}
@@ -2216,22 +2221,6 @@ public class GetEngineUsageReactor extends AbstractReactor {
 		return usage;
 	}
 
-	private List<Map<String, Object>> getPendingUsage() {
-		List<Map<String, Object>> usage = new ArrayList<>();
-		addUsage(usage, INTRODUCTION, INTRODUCTION_LABEL,
-				"""
-						Detailed usage examples for this engine type have not been written yet. The platform notes below still apply - every engine is reachable the same way, whichever type it is.
-
-						"""
-						+ PLATFORM_INTRODUCTION,
-				null);
-		addUsage(usage, PIXEL, PIXEL_LABEL, "Documentation pending", null);
-		addUsage(usage, JAVASCRIPT, JAVASCRIPT_LABEL, "Documentation pending", null);
-		addUsage(usage, PYTHON, PYTHON_LABEL, "Documentation pending", null);
-		addUsage(usage, JAVA, JAVA_LABEL, "Documentation pending", null);
-		return usage;
-	}
-
 	private List<FunctionParameter> getFunctionParameters(IFunctionEngine functionEngine) {
 		List<FunctionParameter> parameters = functionEngine.getParameters();
 		return parameters == null ? new ArrayList<>() : parameters;
@@ -2278,6 +2267,104 @@ public class GetEngineUsageReactor extends AbstractReactor {
 			return "\"string\"";
 		}
 		return type;
+	}
+
+	private List<Map<String, Object>> getGuardrailUsage(String engineId) {
+		List<Map<String, Object>> usage = new ArrayList<>();
+		List<FunctionParameter> parameters;
+		List<String> requiredParameters;
+		String pipelineUsage;
+		if (SAMPLE_ENGINE_ID.equals(engineId)) {
+			parameters = List.of(new FunctionParameter("prompt", "String", "The text to evaluate"));
+			requiredParameters = List.of("prompt");
+			pipelineUsage = "Select a guardrail engine to view its default pipeline configuration.";
+		} else {
+			IGuardrailReactorFunctionEngine guardrailEngine = Utility.getGuardrailEngine(engineId);
+			parameters = getFunctionParameters(guardrailEngine);
+			requiredParameters = getRequiredFunctionParameters(guardrailEngine);
+			pipelineUsage = guardrailEngine.getDefaultMarkdown();
+			if (pipelineUsage == null || pipelineUsage.trim().isEmpty()) {
+				pipelineUsage = "This guardrail engine does not define a default pipeline configuration.";
+			}
+		}
+		List<Map<String, Object>> paramInfo = buildFunctionParamInfo(parameters, requiredParameters);
+		String testArguments = buildGuardrailTestArguments(parameters, requiredParameters);
+
+		addUsage(usage, INTRODUCTION, INTRODUCTION_LABEL,
+				"""
+						A **Guardrail** engine evaluates selected input or output from another engine and returns a pass, block, mask, or replacement-response decision. Guardrails are normally referenced from another engine's `pipeline.json` rather than called directly.
+
+						## Pipeline placement
+
+						Save `pipeline.json` in the protected engine's assets folder and set `PIPELINE pipeline.json` in that engine's SMSS. The top-level `pipelines` map is keyed by intercepted Java method name, such as `askRoom` for model chat or `execute` for a function engine. Use `*` to apply a pipeline to every intercepted method.
+
+						## Execution order
+
+						- `input` guardrails run before the protected engine method. They can block, mask an argument, return a guardrail-provided response, or close a model room after a block.
+						- `output` guardrails run after the protected engine method. They can block the result or close a model room after a block.
+						- Entries run in list order. A failed blocking guardrail stops the remaining work.
+						""",
+				engineId);
+
+		addUsage(usage, GUARDRAIL, GUARDRAIL_LABEL, pipelineUsage, engineId, paramInfo);
+		addUsage(usage, PIXEL, PIXEL_LABEL,
+				"""
+						## Test the guardrail directly
+
+						`ExecuteGuardrailEngine` runs the guardrail by itself so you can test its decision and returned details before attaching it to another engine. This call does not exercise the input/output pipeline behavior such as blocking, masking, replacing a response, or closing a room.
+
+						```
+						ExecuteGuardrailEngine(engine = "<engineid>"<testarguments>);
+						```
+						"""
+						.replace("<testarguments>", testArguments),
+				engineId, paramInfo);
+		return usage;
+	}
+
+	private String buildGuardrailTestArguments(List<FunctionParameter> parameters, List<String> requiredParameters) {
+		List<FunctionParameter> testParameters = new ArrayList<>();
+		for (FunctionParameter parameter : parameters) {
+			if (requiredParameters.contains(parameter.getParameterName())) {
+				testParameters.add(parameter);
+			}
+		}
+		if (testParameters.isEmpty() && !parameters.isEmpty()) {
+			testParameters.add(parameters.get(0));
+		}
+
+		StringBuilder arguments = new StringBuilder();
+		for (FunctionParameter parameter : testParameters) {
+			arguments.append(", ").append(parameter.getParameterName()).append(" = ")
+					.append(getGuardrailTestValue(parameter));
+		}
+		return arguments.toString();
+	}
+
+	private String getGuardrailTestValue(FunctionParameter parameter) {
+		String type = parameter.getParameterType();
+		if ("string".equalsIgnoreCase(type)) {
+			if ("prompt".equalsIgnoreCase(parameter.getParameterName())) {
+				return "\"<encode>Sample text to evaluate</encode>\"";
+			}
+			return "\"sample value\"";
+		}
+		if ("boolean".equalsIgnoreCase(type)) {
+			return "true";
+		}
+		if ("double".equalsIgnoreCase(type) || "float".equalsIgnoreCase(type)) {
+			return "0.7";
+		}
+		if ("integer".equalsIgnoreCase(type) || "long".equalsIgnoreCase(type)) {
+			return "1";
+		}
+		if (type != null && type.toLowerCase().startsWith("list")) {
+			return "[\"sample value\"]";
+		}
+		if (type != null && type.toLowerCase().startsWith("map")) {
+			return "{}";
+		}
+		return "null";
 	}
 
 	/**
@@ -2335,17 +2422,33 @@ public class GetEngineUsageReactor extends AbstractReactor {
 		return usageMap;
 	}
 
+	private List<Map<String, Object>> getPendingUsage() {
+		List<Map<String, Object>> usage = new ArrayList<>();
+		addUsage(usage, INTRODUCTION, INTRODUCTION_LABEL,
+				"""
+						Detailed usage examples for this engine type have not been written yet. The platform notes below still apply - every engine is reachable the same way, whichever type it is.
+
+						"""
+						+ PLATFORM_INTRODUCTION,
+				null);
+		addUsage(usage, PIXEL, PIXEL_LABEL, "Documentation pending", null);
+		addUsage(usage, JAVASCRIPT, JAVASCRIPT_LABEL, "Documentation pending", null);
+		addUsage(usage, PYTHON, PYTHON_LABEL, "Documentation pending", null);
+		addUsage(usage, JAVA, JAVA_LABEL, "Documentation pending", null);
+		return usage;
+	}
+
 	@Override
 	public String getReactorDescription() {
 		return """
-				Builds tutorial-style usage snippets for a selected engine across Pixel, JavaScript/TypeScript, Python, Java, and optional integrations (for example LangChain or OpenAI-compatible usage when supported).
+				Builds tutorial-style usage snippets for a selected engine across Pixel, JavaScript/TypeScript, Python, Java, Guardrail pipeline JSON, and optional integrations (for example LangChain or OpenAI-compatible usage when supported).
 
-				Platform context (useful for both human readers and machine consumers): on the Semoss AI Server platform every capability is an *engine* registered in a shared catalog - Model (LLMs), Vector (semantic search), Database (SQL/graph), Storage (files), and Function (callable tools) - addressed by a stable `engineId`. Pixel is the server-side scripting language executed through the `runPixel` REST endpoint; the `@semoss/sdk` JavaScript package, the `ai_server` Python SDK, and the Java `Utility` helpers call the same engines. Model/chat calls are stateful via a *room* (insight) that holds conversation history.
+				Platform context (useful for both human readers and machine consumers): on the Semoss AI Server platform every capability is an *engine* registered in a shared catalog - Model (LLMs), Vector (semantic search), Database (SQL/graph), Storage (files), Function (callable tools), and Guardrail (input/output policy checks) - addressed by a stable `engineId`. Pixel is the server-side scripting language executed through the `runPixel` REST endpoint; the `@semoss/sdk` JavaScript package, the `ai_server` Python SDK, and the Java `Utility` helpers call the same engines. Model/chat calls are stateful via a *room* (insight) that holds conversation history.
 
 				- Input resolution order is: `engine` first, then `type` if `engine` is not provided.
 				- When only `type` is supplied, snippets are generated with `SAMPLE_ENGINE_ID` as the placeholder engine identifier.
 				- The returned vector contains one object per usage channel with `type`, `label`, and `code`.
-				- The first channel is always `type = "introduction"`: a markdown primer explaining what this engine type does plus a shared "how to reach this engine" platform section. The remaining channels (`pixel`, `javascript`, `python`, `java`, ...) are per-integration.
+				- The first channel is always `type = "introduction"`: a markdown primer explaining what this engine type does. The remaining channels (`pixel`, `javascript`, `python`, `java`, `guardrail`, ...) are per-integration or configuration format.
 				- Each integration channel's `code` is markdown with per-operation example calls, each followed by an "Example Output" block showing the JSON/dict payload it returns. Pixel outputs show the full `runPixel` envelope (`pixelReturn[i].output`); Python SDK outputs show the unwrapped payload.
 				- The `javascript` channel covers the `@semoss/sdk` front-end package: `runPixel` (which returns the parsed envelope plus a pre-collected `errors` array), insight sessions, engine discovery via `MyEngines`, and, for Model engines, room-threaded chat, file uploads, and streaming through `runPixelAsync`/`getPixelJobStreaming`.
 				- Model responses are schemaVersion 2: `response` is the convenience concatenated text while `parts` is the full ordered content (text, tool_call, media, etc.) that can mix modalities in one turn.
@@ -2364,7 +2467,8 @@ public class GetEngineUsageReactor extends AbstractReactor {
 		} else if (key.equals(ReactorKeysEnum.TYPE.getKey())) {
 			String validValues = String.join(", ", IEngine.CATALOG_TYPE.DATABASE.toString(),
 					IEngine.CATALOG_TYPE.STORAGE.toString(), IEngine.CATALOG_TYPE.MODEL.toString(),
-					IEngine.CATALOG_TYPE.VECTOR.toString(), IEngine.CATALOG_TYPE.FUNCTION.toString());
+					IEngine.CATALOG_TYPE.VECTOR.toString(), IEngine.CATALOG_TYPE.FUNCTION.toString(),
+					IEngine.CATALOG_TYPE.GUARDRAIL.toString());
 			return """
 					Fallback engine catalog type used only when `engine` is not provided.
 

--- a/src/prerna/util/UploadUtilities.java
+++ b/src/prerna/util/UploadUtilities.java
@@ -559,13 +559,13 @@ public final class UploadUtilities {
 				secretStore.writeEngineSecrets(IEngine.CATALOG_TYPE.DATABASE, databaseId, databaseName, properties);
 			} else {
 				bufferedWriter.write(newLine);
-				bufferedWriter.write(Constants.TINKER_DRIVER + "\t" + tinkerDriverType + "\n");
+				writeSmssProperty(bufferedWriter, Constants.TINKER_DRIVER, tinkerDriverType);
 				// if neo4j, point to the folder
 				if (tinkerDriverType == TINKER_DRIVER.NEO4J) {
-					bufferedWriter.write(Constants.TINKER_FILE + tinkerFilePath + "\n");
+					writeSmssProperty(bufferedWriter, Constants.TINKER_FILE, tinkerFilePath);
 				} else {
 					// basefolder/db/engine/engine.driverTypeExtension
-					bufferedWriter.write(Constants.TINKER_FILE + tinkerFilePath + "." + tinkerDriverType + "\n");
+					writeSmssProperty(bufferedWriter, Constants.TINKER_FILE, tinkerFilePath + "." + tinkerDriverType);
 				}
 			}
 		} catch (IOException ex) {
@@ -649,7 +649,7 @@ public final class UploadUtilities {
 				secretStore.writeEngineSecrets(IEngine.CATALOG_TYPE.DATABASE, databaseId, databaseName, properties);
 			} else {
 				bufferedWriter.write(newLine);
-				bufferedWriter.write(Constants.RDF_FILE_BASE_URI + tab + baseUri + newLine);
+				writeSmssProperty(bufferedWriter, Constants.RDF_FILE_BASE_URI, baseUri);
 
 				if (dbClassName.endsWith("BigDataEngine")) {
 					// get additional RDF default properties
@@ -671,8 +671,8 @@ public final class UploadUtilities {
 						}
 					}
 				} else {
-					bufferedWriter.write(Constants.RDF_FILE_NAME + tab + databaseName + ".xml" + newLine);
-					bufferedWriter.write(Constants.RDF_FILE_TYPE + tab + "RDF/XML" + newLine);
+					writeSmssProperty(bufferedWriter, Constants.RDF_FILE_NAME, databaseName + ".xml");
+					writeSmssProperty(bufferedWriter, Constants.RDF_FILE_TYPE, "RDF/XML");
 				}
 			}
 		} catch (IOException e) {
@@ -751,16 +751,16 @@ public final class UploadUtilities {
 				secretStore.writeEngineSecrets(IEngine.CATALOG_TYPE.DATABASE, databaseId, databaseName, properties);
 			} else {
 				bufferedWriter.write(newLine);
-				bufferedWriter.write(Constants.JANUS_CONF + tab + janusConfPath + newLine);
+				writeSmssProperty(bufferedWriter, Constants.JANUS_CONF, janusConfPath);
 				// type map
 				// if we use the label we do not need the type map
 				if (useLabel) {
-					bufferedWriter.write(Constants.TINKER_USE_LABEL + tab + useLabel + newLine);
+					writeSmssProperty(bufferedWriter, Constants.TINKER_USE_LABEL, useLabel);
 				} else {
-					bufferedWriter.write(Constants.TYPE_MAP + tab + GSON.toJson(typeMap) + newLine);
+					writeSmssProperty(bufferedWriter, Constants.TYPE_MAP, GSON.toJson(typeMap));
 				}
 				// name map
-				bufferedWriter.write(Constants.NAME_MAP + tab + GSON.toJson(nameMap) + newLine);
+				writeSmssProperty(bufferedWriter, Constants.NAME_MAP, GSON.toJson(nameMap));
 			}
 		} catch (IOException ex) {
 			classLogger.error("Failed to write JanusGraph database smss file for database {}: {}", databaseName,
@@ -842,18 +842,18 @@ public final class UploadUtilities {
 				secretStore.writeEngineSecrets(IEngine.CATALOG_TYPE.DATABASE, databaseId, databaseName, properties);
 			} else {
 				bufferedWriter.write(newLine);
-				bufferedWriter.write(Constants.TINKER_FILE + tab + tinkerFilePath + newLine);
+				writeSmssProperty(bufferedWriter, Constants.TINKER_FILE, tinkerFilePath);
 				// tinker driver
-				bufferedWriter.write(Constants.TINKER_DRIVER + tab + tinkerDriverType + newLine);
+				writeSmssProperty(bufferedWriter, Constants.TINKER_DRIVER, tinkerDriverType);
 				// type map
 				// if we use the label we do not need the type map
 				if (useLabel) {
-					bufferedWriter.write(Constants.TINKER_USE_LABEL + tab + useLabel + newLine);
+					writeSmssProperty(bufferedWriter, Constants.TINKER_USE_LABEL, useLabel);
 				} else {
-					bufferedWriter.write(Constants.TYPE_MAP + tab + GSON.toJson(typeMap) + newLine);
+					writeSmssProperty(bufferedWriter, Constants.TYPE_MAP, GSON.toJson(typeMap));
 				}
 				// name map
-				bufferedWriter.write(Constants.NAME_MAP + tab + GSON.toJson(nameMap) + newLine);
+				writeSmssProperty(bufferedWriter, Constants.NAME_MAP, GSON.toJson(nameMap));
 			}
 		} catch (IOException ex) {
 			classLogger.error("Failed to write external Tinker database smss file for database {}: {}", databaseName,
@@ -934,27 +934,24 @@ public final class UploadUtilities {
 			} else {
 				bufferedWriter.write(newLine);
 				// host + port
-				if (host.contains("\\")) {
-					host = host.replace("\\", "\\\\");
-				}
-				bufferedWriter.write("HOST" + tab + host + newLine);
-				bufferedWriter.write(Constants.PORT + "\t" + port + newLine);
+				writeSmssProperty(bufferedWriter, "HOST", host);
+				writeSmssProperty(bufferedWriter, Constants.PORT, port);
 				if (username != null) {
-					bufferedWriter.write(Constants.USERNAME + tab + username + newLine);
+					writeSmssProperty(bufferedWriter, Constants.USERNAME, username);
 				}
 				if (password != null) {
-					bufferedWriter.write(Constants.PASSWORD + tab + password + newLine);
+					writeSmssProperty(bufferedWriter, Constants.PASSWORD, password);
 				}
-				bufferedWriter.write("GRAPH_NAME" + tab + graphName + newLine);
+				writeSmssProperty(bufferedWriter, "GRAPH_NAME", graphName);
 
 				// type map
 				if (useLabel) {
-					bufferedWriter.write(Constants.TINKER_USE_LABEL + tab + useLabel + newLine);
+					writeSmssProperty(bufferedWriter, Constants.TINKER_USE_LABEL, useLabel);
 				} else {
-					bufferedWriter.write(Constants.TYPE_MAP + tab + GSON.toJson(typeMap) + newLine);
+					writeSmssProperty(bufferedWriter, Constants.TYPE_MAP, GSON.toJson(typeMap));
 				}
 				// name map
-				bufferedWriter.write(Constants.NAME_MAP + "\t" + GSON.toJson(nameMap) + "\n");
+				writeSmssProperty(bufferedWriter, Constants.NAME_MAP, GSON.toJson(nameMap));
 			}
 		} catch (IOException ex) {
 			classLogger.error("Failed to write DataStax database smss file for database {}: {}", databaseName,
@@ -1020,17 +1017,17 @@ public final class UploadUtilities {
 			} else {
 				bufferedWriter.write(newLine);
 				// neo4j external properties
-				bufferedWriter.write(Constants.CONNECTION_URL + tab + connectionStringKey + newLine);
-				bufferedWriter.write(Constants.USERNAME + tab + username + newLine);
-				bufferedWriter.write(Constants.PASSWORD + tab + password + newLine);
+				writeSmssProperty(bufferedWriter, Constants.CONNECTION_URL, connectionStringKey);
+				writeSmssProperty(bufferedWriter, Constants.USERNAME, username);
+				writeSmssProperty(bufferedWriter, Constants.PASSWORD, password);
 				// type map
 				if (useLabel) {
-					bufferedWriter.write(Constants.TINKER_USE_LABEL + tab + useLabel + newLine);
+					writeSmssProperty(bufferedWriter, Constants.TINKER_USE_LABEL, useLabel);
 				} else {
-					bufferedWriter.write(Constants.TYPE_MAP + tab + GSON.toJson(typeMap) + newLine);
+					writeSmssProperty(bufferedWriter, Constants.TYPE_MAP, GSON.toJson(typeMap));
 				}
 				// name map
-				bufferedWriter.write(Constants.NAME_MAP + "\t" + GSON.toJson(nameMap) + "\n");
+				writeSmssProperty(bufferedWriter, Constants.NAME_MAP, GSON.toJson(nameMap));
 			}
 		} catch (IOException ex) {
 			classLogger.error("Failed to write external Neo4j database smss file for database {}: {}", databaseName,
@@ -1096,14 +1093,14 @@ public final class UploadUtilities {
 			} else {
 				bufferedWriter.write(newLine);
 				// neo4j external properties
-				bufferedWriter.write(Constants.NEO4J_FILE + tab + filePath + newLine);
+				writeSmssProperty(bufferedWriter, Constants.NEO4J_FILE, filePath);
 				if (useLabel) {
-					bufferedWriter.write(Constants.TINKER_USE_LABEL + tab + useLabel + newLine);
+					writeSmssProperty(bufferedWriter, Constants.TINKER_USE_LABEL, useLabel);
 				} else {
-					bufferedWriter.write(Constants.TYPE_MAP + tab + GSON.toJson(typeMap) + newLine);
+					writeSmssProperty(bufferedWriter, Constants.TYPE_MAP, GSON.toJson(typeMap));
 				}
 				// name map
-				bufferedWriter.write(Constants.NAME_MAP + tab + GSON.toJson(nameMap) + newLine);
+				writeSmssProperty(bufferedWriter, Constants.NAME_MAP, GSON.toJson(nameMap));
 			}
 		} catch (IOException ex) {
 			classLogger.error("Failed to write embedded Neo4j database smss file for database {}: {}", databaseName,
@@ -1155,7 +1152,7 @@ public final class UploadUtilities {
 			writeDefaultDatabaseSettings(bufferedWriter, databaseId, databaseName, owlFile, dbClassName, newLine, tab);
 			bufferedWriter.write(newLine);
 			// write the rdbms type
-			bufferedWriter.write(Constants.RDBMS_TYPE + tab + dbType.getLabel() + newLine);
+			writeSmssProperty(bufferedWriter, Constants.RDBMS_TYPE, dbType.getLabel());
 
 			// we write the url at the end
 			String host = (String) connectionDetails.get(AbstractSqlQueryUtil.HOSTNAME);
@@ -1188,7 +1185,7 @@ public final class UploadUtilities {
 
 				secretStore.writeEngineSecrets(IEngine.CATALOG_TYPE.DATABASE, databaseId, databaseName, properties);
 			} else {
-				bufferedWriter.write(Constants.DRIVER + tab + dbType.getDriver() + newLine);
+				writeSmssProperty(bufferedWriter, Constants.DRIVER, dbType.getDriver());
 				// just write everything to the smss file
 				// but ignore the connection url until the end
 				for (String key : connectionDetails.keySet()) {
@@ -1197,14 +1194,11 @@ public final class UploadUtilities {
 									&& connectionDetails.get(key).toString().isEmpty())) {
 						continue;
 					}
-					bufferedWriter.write(key.toUpperCase() + tab + connectionDetails.get(key) + newLine);
+					writeSmssProperty(bufferedWriter, key.toUpperCase(), connectionDetails.get(key));
 				}
 
 				// connection url
-				if (connectionUrl.contains("\\")) {
-					connectionUrl = connectionUrl.replace("\\", "\\\\");
-				}
-				bufferedWriter.write(Constants.CONNECTION_URL + tab + connectionUrl + newLine);
+				writeSmssProperty(bufferedWriter, Constants.CONNECTION_URL, connectionUrl);
 				bufferedWriter.write(newLine);
 
 				// write the additonal jdbc properties at the end of the properties file
@@ -1212,7 +1206,7 @@ public final class UploadUtilities {
 					if (jdbcPropertiesMap.get(key) == null || jdbcPropertiesMap.get(key).toString().isEmpty()) {
 						continue;
 					}
-					bufferedWriter.write(key + tab + jdbcPropertiesMap.get(key) + newLine);
+					writeSmssProperty(bufferedWriter, key, jdbcPropertiesMap.get(key));
 				}
 			}
 		} catch (IOException e) {
@@ -1285,17 +1279,17 @@ public final class UploadUtilities {
 				secretStore.writeEngineSecrets(IEngine.CATALOG_TYPE.DATABASE, databaseId, databaseName, properties);
 			} else {
 				bufferedWriter.write(newLine);
-				bufferedWriter.write(AbstractDatabaseEngine.DATA_FILE + tab + dataFile.replace('\\', '/') + newLine);
+				writeSmssProperty(bufferedWriter, AbstractDatabaseEngine.DATA_FILE, dataFile.replace('\\', '/'));
 				// stringify maps
 				if (newHeaders != null && !newHeaders.isEmpty()) {
-					bufferedWriter.write(Constants.NEW_HEADERS + tab + GSON.toJson(newHeaders) + newLine);
+					writeSmssProperty(bufferedWriter, Constants.NEW_HEADERS, GSON.toJson(newHeaders));
 				}
 				if (dataTypesMap != null && !dataTypesMap.isEmpty()) {
-					bufferedWriter.write(Constants.SMSS_DATA_TYPES + tab + GSON.toJson(dataTypesMap) + newLine);
+					writeSmssProperty(bufferedWriter, Constants.SMSS_DATA_TYPES, GSON.toJson(dataTypesMap));
 				}
 				if (additionalDataTypeMap != null && !additionalDataTypeMap.isEmpty()) {
-					bufferedWriter.write(
-							Constants.ADDITIONAL_DATA_TYPES + tab + GSON.toJson(additionalDataTypeMap) + newLine);
+					writeSmssProperty(bufferedWriter, Constants.ADDITIONAL_DATA_TYPES,
+							GSON.toJson(additionalDataTypeMap));
 				}
 			}
 		} catch (IOException e) {
@@ -1450,15 +1444,15 @@ public final class UploadUtilities {
 						if (key != null && key.equalsIgnoreCase(Constants.MCP_ENABLED)) {
 							mcpFromUI = true;
 						}
-						bufferedWriter.write(key.toUpperCase() + tab + properties.get(key) + newLine);
+						writeSmssProperty(bufferedWriter, key.toUpperCase(), properties.get(key));
 					}
 
 					// if UI is not sending, we set as default
 					if (!pipelineFromUI) {
-						bufferedWriter.write(IEngine.PIPELINE + tab + "pipeline.json" + newLine);
+						writeSmssProperty(bufferedWriter, IEngine.PIPELINE, "pipeline.json");
 					}
 					if (!mcpFromUI) {
-						bufferedWriter.write(Constants.MCP_ENABLED + tab + "false" + newLine);
+						writeSmssProperty(bufferedWriter, Constants.MCP_ENABLED, false);
 					}
 				}
 			}
@@ -1468,6 +1462,46 @@ public final class UploadUtilities {
 		}
 
 		return engineTempSmss;
+	}
+
+	static String escapeSmssPropertyValue(Object value) {
+		if (value == null) {
+			return "";
+		}
+
+		String stringValue = value.toString();
+		StringBuilder escapedValue = new StringBuilder(stringValue.length());
+		for (int i = 0; i < stringValue.length(); i++) {
+			char character = stringValue.charAt(i);
+			switch (character) {
+			case '\\':
+				escapedValue.append("\\\\");
+				break;
+			case '\t':
+				escapedValue.append("\\t");
+				break;
+			case '\r':
+				escapedValue.append("\\r");
+				break;
+			case '\n':
+				escapedValue.append("\\n");
+				break;
+			case '\f':
+				escapedValue.append("\\f");
+				break;
+			default:
+				if (character < 0x20 || character > 0x7e) {
+					escapedValue.append(String.format("\\u%04x", (int) character));
+				} else {
+					escapedValue.append(character);
+				}
+			}
+		}
+		return escapedValue.toString();
+	}
+
+	private static void writeSmssProperty(BufferedWriter bufferedWriter, String key, Object value) throws IOException {
+		bufferedWriter.write(key + "\t" + escapeSmssPropertyValue(value) + "\n");
 	}
 
 	/**
@@ -1496,10 +1530,10 @@ public final class UploadUtilities {
 	private static void writeDefaultEngineSettings(BufferedWriter bufferedWriter, String engineId, String engineName,
 			String className, final String newLine, final String tab) throws IOException {
 		bufferedWriter.write("#Base Properties" + newLine);
-		bufferedWriter.write(Constants.ENGINE + tab + engineId + newLine);
-		bufferedWriter.write(Constants.ENGINE_ALIAS + tab + engineName + newLine);
-		bufferedWriter.write(Constants.ENGINE_DISPLAY_NAME + tab + engineName + newLine);
-		bufferedWriter.write(Constants.ENGINE_TYPE + tab + className + newLine);
+		writeSmssProperty(bufferedWriter, Constants.ENGINE, engineId);
+		writeSmssProperty(bufferedWriter, Constants.ENGINE_ALIAS, engineName);
+		writeSmssProperty(bufferedWriter, Constants.ENGINE_DISPLAY_NAME, engineName);
+		writeSmssProperty(bufferedWriter, Constants.ENGINE_TYPE, className);
 	}
 
 	/**
@@ -1519,7 +1553,7 @@ public final class UploadUtilities {
 			throws IOException {
 		writeDefaultEngineSettings(bufferedWriter, databaseId, databaseName, className, newLine, tab);
 		// write owl
-		bufferedWriter.write(Constants.OWL + tab + owlFile.getName() + newLine);
+		writeSmssProperty(bufferedWriter, Constants.OWL, owlFile.getName());
 	}
 
 	/*

--- a/test/prerna/auth/utils/SecurityEngineUtilsUnitTests.java
+++ b/test/prerna/auth/utils/SecurityEngineUtilsUnitTests.java
@@ -339,6 +339,25 @@ public class SecurityEngineUtilsUnitTests extends AbstractSecurityUtilsUnitTests
 		assertNull(val);
 	}
 
+	@Test
+	void testSetDefaultEngineMarkdownOnlyFillsEmptyMetadata() {
+		User user = UnitTestSecurityAuthUtils.createUser("admin", true);
+		UnitTestSecurityAuthUtils.createEngine("id1", "name1", IEngine.CATALOG_TYPE.GUARDRAIL, user);
+
+		SecurityEngineUtils.setDefaultEngineMarkdown("id1", "First default");
+		assertEquals("First default", SecurityEngineUtils
+				.getAggregateEngineMetadata("id1", List.of(Constants.MARKDOWN), false).get(Constants.MARKDOWN));
+
+		SecurityEngineUtils.setDefaultEngineMarkdown("id1", "Second default");
+		assertEquals("First default", SecurityEngineUtils
+				.getAggregateEngineMetadata("id1", List.of(Constants.MARKDOWN), false).get(Constants.MARKDOWN));
+
+		SecurityEngineUtils.updateEngineMetadata("id1", Map.of(Constants.MARKDOWN, ""));
+		SecurityEngineUtils.setDefaultEngineMarkdown("id1", "Replacement default");
+		assertEquals("Replacement default", SecurityEngineUtils
+				.getAggregateEngineMetadata("id1", List.of(Constants.MARKDOWN), false).get(Constants.MARKDOWN));
+	}
+
 	///
 	/// getUserEnginePermission
 	///

--- a/test/prerna/engine/impl/guardrail/PolicyComplianceGuardrailEngineUnitTests.java
+++ b/test/prerna/engine/impl/guardrail/PolicyComplianceGuardrailEngineUnitTests.java
@@ -1,0 +1,104 @@
+package prerna.engine.impl.guardrail;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.message.InputMessage;
+
+class PolicyComplianceGuardrailEngineUnitTests {
+
+	@Test
+	void combinesSelectedTextValuesForOneReview() {
+		assertEquals("Subject\nFirst body\nSecond body",
+				PromptGuardrailEngine.extractText(List.of("Subject", "First body", "Second body")));
+	}
+
+	@Test
+	void combinesSubjectsAndBodiesFromMailboxResults() {
+		Map<String, Object> result = Map.of("messages", List.of(Map.of("subject", "First", "body", "Body one"),
+				Map.of("subject", "Second", "body", "Body two")));
+
+		assertEquals("First\nBody one\nSecond\nBody two", PromptGuardrailEngine.extractText(result));
+	}
+
+	@Test
+	void extractsAndMasksTheTextOnAnInputMessage() {
+		Room room = new Room();
+		room.setId("room-id");
+		InputMessage original = InputMessage.builder(room).withSystemPrompt("Be concise").withText("api_key=secret")
+				.withParamMap(Map.of("temperature", 0.2)).build();
+
+		assertEquals("api_key=secret", PromptGuardrailEngine.extractText(original));
+		assertEquals("api_key=secret", original.getInputText());
+
+		String messageId = original.getMessageId();
+		original.setFullInputPrompt("api_key=[masked]");
+		assertEquals("api_key=[masked]", original.getFullInputPrompt());
+		assertEquals("api_key=[masked]", original.getInputUIPrompt());
+		assertEquals(messageId, original.getMessageId());
+		assertEquals("Be concise", original.getSystemPrompt());
+		assertEquals(Map.of("temperature", 0.2), original.getParamMap());
+	}
+
+	@Test
+	void toolResultMessagesExposeAndMaskTheirModelBoundOutput() {
+		Room room = new Room();
+		room.setId("room-id");
+		InputMessage original = InputMessage.toolExecution(room, "call-1", "lookup", "secret result",
+				Map.of("query", "record"), "success", false);
+
+		assertNull(original.getInputText());
+		assertEquals("secret result", original.getFullInputPrompt());
+		original.setFullInputPrompt("[masked result]");
+		assertEquals("[masked result]", original.getFullInputPrompt());
+	}
+
+	@Test
+	void llmGuardrailsShareThePromptGuardrailBase() {
+		AggressiveSelfHarmGuardrailEngine selfHarm = new AggressiveSelfHarmGuardrailEngine();
+		PolicyComplianceGuardrailEngine policy = new PolicyComplianceGuardrailEngine();
+
+		assertTrue(selfHarm instanceof PromptGuardrailEngine);
+		assertTrue(policy instanceof PromptGuardrailEngine);
+		assertTrue(selfHarm.getDefaultSystemPrompt().contains("self"));
+		assertTrue(policy.getDefaultSystemPrompt().contains("${POLICY_DESCRIPTION}"));
+		assertFalse(selfHarm.isFailOpenByDefault());
+		assertTrue(policy.isFailOpenByDefault());
+	}
+
+	@Test
+	void defaultMarkdownContainsAReadyToCustomizePipeline() {
+		AggressiveSelfHarmGuardrailEngine selfHarm = new AggressiveSelfHarmGuardrailEngine();
+		selfHarm.setEngineId("self-harm-id");
+		String selfHarmMarkdown = selfHarm.getDefaultMarkdown();
+
+		assertTrue(selfHarmMarkdown.contains("\"guardrailEngineId\": \"self-harm-id\""));
+		assertTrue(selfHarmMarkdown.contains("\"askRoom\""));
+
+		PolicyComplianceGuardrailEngine policy = new PolicyComplianceGuardrailEngine();
+		policy.setEngineId("policy-id");
+		String policyMarkdown = policy.getDefaultMarkdown();
+
+		assertTrue(policyMarkdown.contains("\"guardrailEngineId\": \"policy-id\""));
+		assertTrue(policyMarkdown.contains("\"policy\""));
+
+		Map<String, AbstractGuardrailReactorFunctionEngine> additionalGuardrails = Map.of("detoxify-id",
+				new DetoxifyGuardrailEngine(), "gliner-id", new GLiNERGuardrailEngine(), "on-topic-id",
+				new OnTopicGuardrailEngine(), "prompt-injection-id", new PromptInjectionGuardrailEngine(),
+				"local-python-id", new LocalPythonGuardrailReactorFunctionEngine());
+		for (Map.Entry<String, AbstractGuardrailReactorFunctionEngine> entry : additionalGuardrails.entrySet()) {
+			entry.getValue().setEngineId(entry.getKey());
+			String markdown = entry.getValue().getDefaultMarkdown();
+			assertTrue(markdown.contains("\"guardrailEngineId\": \"" + entry.getKey() + "\""));
+			assertTrue(markdown.contains("\"prompt\": \"arg0\""));
+		}
+	}
+}

--- a/test/prerna/engine/impl/model/AbstractModelEngineInputModalityUnitTests.java
+++ b/test/prerna/engine/impl/model/AbstractModelEngineInputModalityUnitTests.java
@@ -29,6 +29,7 @@ package prerna.engine.impl.model;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -48,6 +49,7 @@ import prerna.engine.impl.model.message.InputMessage;
 import prerna.engine.impl.model.message.MediaMessagePart;
 import prerna.engine.impl.model.message.MessageIO;
 import prerna.engine.impl.model.message.MessageInputMedia;
+import prerna.engine.impl.model.message.ResponseMessage;
 import prerna.engine.impl.model.message.TextMessagePart;
 import prerna.engine.impl.model.responses.AskModelEngineResponse;
 import prerna.engine.impl.model.responses.EmbeddingsModelEngineResponse;
@@ -71,8 +73,7 @@ class AbstractModelEngineInputModalityUnitTests {
 
 	@Test
 	void acceptsImageWhenModelAllowsImageInput() {
-		TestModelEngine engine = new TestModelEngine(
-				EnumSet.of(ModelModalityEnum.TEXT, ModelModalityEnum.IMAGE));
+		TestModelEngine engine = new TestModelEngine(EnumSet.of(ModelModalityEnum.TEXT, ModelModalityEnum.IMAGE));
 		InputMessage message = newMessage();
 		message.addPart(new TextMessagePart("describe this"));
 		message.addPart(new MediaMessagePart(MessageInputMedia.fromUrl("https://example.com/image.png")));
@@ -82,8 +83,7 @@ class AbstractModelEngineInputModalityUnitTests {
 
 	@Test
 	void rejectsPdfWhenModelDoesNotAllowPdfInput() {
-		TestModelEngine engine = new TestModelEngine(
-				EnumSet.of(ModelModalityEnum.TEXT, ModelModalityEnum.IMAGE));
+		TestModelEngine engine = new TestModelEngine(EnumSet.of(ModelModalityEnum.TEXT, ModelModalityEnum.IMAGE));
 		InputMessage message = newMessage();
 		message.addPart(new MediaMessagePart(pdfMedia()));
 
@@ -95,8 +95,7 @@ class AbstractModelEngineInputModalityUnitTests {
 
 	@Test
 	void classifiesPdfUrlsAsPdfInput() {
-		TestModelEngine engine = new TestModelEngine(
-				EnumSet.of(ModelModalityEnum.TEXT, ModelModalityEnum.IMAGE));
+		TestModelEngine engine = new TestModelEngine(EnumSet.of(ModelModalityEnum.TEXT, ModelModalityEnum.IMAGE));
 		InputMessage message = newMessage();
 		message.addPart(new MediaMessagePart(MessageInputMedia.fromUrl("https://example.com/report.pdf")));
 
@@ -140,8 +139,7 @@ class AbstractModelEngineInputModalityUnitTests {
 		followUp.setParentMessageId(audioResponse.getMessageId());
 		followUp.addPart(new TextMessagePart("say it again"));
 
-		assertDoesNotThrow(
-				() -> engine.validateInputModalities(List.of(root, audioResponse), followUp));
+		assertDoesNotThrow(() -> engine.validateInputModalities(List.of(root, audioResponse), followUp));
 	}
 
 	@Test
@@ -165,8 +163,7 @@ class AbstractModelEngineInputModalityUnitTests {
 		textBranch.setParentMessageId(root.getMessageId());
 		textBranch.addPart(new TextMessagePart("continue here"));
 
-		assertDoesNotThrow(
-				() -> engine.validateInputModalities(List.of(root, imageBranch), textBranch));
+		assertDoesNotThrow(() -> engine.validateInputModalities(List.of(root, imageBranch), textBranch));
 	}
 
 	@Test
@@ -186,6 +183,44 @@ class AbstractModelEngineInputModalityUnitTests {
 	}
 
 	@Test
+	void usesFinalFullPromptInputAsCurrentTurn() {
+		InputMessage earlierInput = newMessage();
+		ResponseMessage response = ResponseMessage.builder().withText("response").build();
+		InputMessage finalInput = newMessage();
+
+		InputMessage result = AbstractModelEngine.requireFinalInputMessage(List.of(earlierInput, response, finalInput));
+
+		assertSame(finalInput, result);
+	}
+
+	@Test
+	void rejectsFullPromptEndingWithResponse() {
+		InputMessage input = newMessage();
+		ResponseMessage response = ResponseMessage.builder().withText("response").build();
+
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> AbstractModelEngine.requireFinalInputMessage(List.of(input, response)));
+
+		assertEquals("Full prompt must end with an input message", exception.getMessage());
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	void legacyAskCallRoutesToInputMessageAskCall() {
+		TestModelEngine engine = new TestModelEngine(EnumSet.of(ModelModalityEnum.TEXT));
+		Object fullPrompt = List.of(Map.of("role", "user", "content", "question"));
+		Map<String, Object> parameters = Map.of("temperature", 0.2);
+
+		engine.askCall("question", fullPrompt, "system prompt", null, "legacy-room", parameters);
+
+		assertEquals("question", engine.lastInputMessage.getFullInputPrompt());
+		assertEquals("system prompt", engine.lastInputMessage.getSystemPrompt());
+		assertEquals("legacy-room", engine.lastInputMessage.getRoomId());
+		assertSame(fullPrompt, engine.lastInputMessage.getParamMap().get(AbstractModelEngine.FULL_PROMPT));
+		assertSame(parameters, engine.lastHyperParameters);
+	}
+
+	@Test
 	void branchValidationWithoutNewMessageCoversOnlyTheCurrentTailBranch() {
 		TestModelEngine engine = new TestModelEngine(EnumSet.of(ModelModalityEnum.TEXT));
 		InputMessage root = newMessage();
@@ -197,8 +232,7 @@ class AbstractModelEngineInputModalityUnitTests {
 		textBranch.setParentMessageId(root.getMessageId());
 		textBranch.addPart(new TextMessagePart("continue here"));
 
-		assertDoesNotThrow(
-				() -> engine.validateInputModalities(List.of(root, imageBranch, textBranch), null));
+		assertDoesNotThrow(() -> engine.validateInputModalities(List.of(root, imageBranch, textBranch), null));
 	}
 
 	private static InputMessage newMessage() {
@@ -216,6 +250,8 @@ class AbstractModelEngineInputModalityUnitTests {
 	}
 
 	private static class TestModelEngine extends AbstractModelEngine {
+		private InputMessage lastInputMessage;
+		private Map<String, Object> lastHyperParameters;
 
 		private TestModelEngine(Set<ModelModalityEnum> inputModalities) {
 			this.inputModalities = inputModalities;
@@ -223,8 +259,10 @@ class AbstractModelEngineInputModalityUnitTests {
 		}
 
 		@Override
-		protected AskModelEngineResponse askCall(String question, Object fullPrompt, String context, Insight insight,
-				String roomId, Map<String, Object> hyperParameters) {
+		protected AskModelEngineResponse askCall(InputMessage inputMessage, Insight insight, String roomId,
+				Map<String, Object> hyperParameters) {
+			this.lastInputMessage = inputMessage;
+			this.lastHyperParameters = hyperParameters;
 			return null;
 		}
 

--- a/test/prerna/engine/impl/model/RoomMessageStoreUnitTests.java
+++ b/test/prerna/engine/impl/model/RoomMessageStoreUnitTests.java
@@ -32,19 +32,20 @@
 package prerna.engine.impl.model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import prerna.engine.impl.model.message.AbstractMessage;
+import prerna.engine.impl.model.message.InputMessage;
 
 class RoomMessageStoreUnitTests {
 
-	private static final String INVALID_PARENT_JSON = "["
-			+ "{\"io\":\"INPUT\",\"messageId\":\"child\",\"parentMessageId\":\"missing\",\"parts\":[]}"
-			+ "]";
+	private static final String INVALID_PARENT_JSON = "[{\"io\":\"INPUT\",\"messageId\":\"child\",\"parentMessageId\":\"missing\",\"parts\":[]}]";
 
 	@Test
 	void loadAllowsMessagesWithInvalidParents() {
@@ -62,8 +63,7 @@ class RoomMessageStoreUnitTests {
 		Room room = roomWithId();
 		List<AbstractMessage> messages = RoomMessageStore.loadFromPersistedJson(room, INVALID_PARENT_JSON);
 
-		assertThrows(IllegalStateException.class,
-				() -> RoomMessageStore.providerMessageHistory(room, messages));
+		assertThrows(IllegalStateException.class, () -> RoomMessageStore.providerMessageHistory(room, messages));
 	}
 
 	@Test
@@ -72,6 +72,20 @@ class RoomMessageStoreUnitTests {
 		room.setMessages(RoomMessageStore.loadFromPersistedJson(room, INVALID_PARENT_JSON));
 
 		assertThrows(IllegalStateException.class, () -> RoomMessageStore.persist(room, "user-id"));
+	}
+
+	@Test
+	void providerPayloadUsesTheGuardrailReplacementMessage() {
+		Room room = roomWithId();
+		InputMessage original = InputMessage.builder(room).withText("api_key=secret").build();
+		room.getMessages().add(original);
+		original.setFullInputPrompt("api_key=[masked]");
+
+		String payload = RoomMessageStore.messageHistoryWithNewMessage(room, original);
+
+		assertTrue(payload.contains("api_key=[masked]"));
+		assertFalse(payload.contains("api_key=secret"));
+		assertEquals("api_key=[masked]", original.getFullInputPrompt());
 	}
 
 	private static Room roomWithId() {

--- a/test/prerna/engine/impl/pipeline/PipelineInvocationHandlerUnitTests.java
+++ b/test/prerna/engine/impl/pipeline/PipelineInvocationHandlerUnitTests.java
@@ -1,0 +1,60 @@
+package prerna.engine.impl.pipeline;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Method;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import prerna.reactor.interceptor.PipelineReactorUtils;
+
+class PipelineInvocationHandlerUnitTests {
+
+	@Test
+	void inputAuditPayloadIsCapturedBeforeLaterMutation() throws Exception {
+		Method method = AuditTarget.class.getDeclaredMethod("execute", String.class, Map.class);
+		Map<String, Object> parameters = new LinkedHashMap<>();
+		parameters.put("threshold", 0.8);
+
+		String snapshot = PipelineInvocationHandler.serializeAuditPayload(method,
+				new Object[] { "masked input", parameters }, null, false);
+		parameters.put("interim_result", Map.of("pass", true));
+		parameters.put("result", "late response");
+
+		JsonObject payload = JsonParser.parseString(snapshot).getAsJsonObject();
+		assertEquals(2, payload.size());
+		assertFalse(payload.has(PipelineReactorUtils.RESULT));
+		assertFalse(snapshot.contains("late response"));
+		assertFalse(snapshot.contains(PipelineReactorUtils.INTERIM_RESULT));
+	}
+
+	@Test
+	void outputAuditPayloadContainsOnlyArgumentsAndForwardedResult() throws Exception {
+		Method method = AuditTarget.class.getDeclaredMethod("execute", String.class, Map.class);
+
+		String snapshot = PipelineInvocationHandler.serializeAuditPayload(method,
+				new Object[] { "masked input", Map.of("threshold", 0.8) }, "guarded output", true);
+
+		JsonObject payload = JsonParser.parseString(snapshot).getAsJsonObject();
+		assertEquals(3, payload.size());
+		assertEquals("guarded output", payload.get(PipelineReactorUtils.RESULT).getAsString());
+		assertFalse(payload.has(PipelineReactorUtils.CONFIG));
+		assertFalse(payload.has(PipelineReactorUtils.INTERIM_RESULT));
+		assertTrue(snapshot.contains("masked input"));
+	}
+
+	private static final class AuditTarget {
+
+		@SuppressWarnings("unused")
+		private String execute(String input, Map<String, Object> parameters) {
+			return input;
+		}
+	}
+}

--- a/test/prerna/reactor/interceptor/GenericGuardrailInputReactorUnitTests.java
+++ b/test/prerna/reactor/interceptor/GenericGuardrailInputReactorUnitTests.java
@@ -1,0 +1,147 @@
+package prerna.reactor.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.message.InputMessage;
+import prerna.sablecc2.om.GenRowStruct;
+import prerna.sablecc2.om.NounStore;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+class GenericGuardrailInputReactorUnitTests {
+
+	@Test
+	void maskingUpdatesTheGuardedInputMessageInstance() {
+		Room room = new Room();
+		room.setId("room-id");
+		InputMessage inputMessage = InputMessage.builder(room).withText("api_key=secret").build();
+
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("arg0", inputMessage);
+
+		ReactorInputHelper helper = helperFor(arguments);
+		boolean replaced = GenericGuardrailInputReactor.replaceGuardedInput(helper, Map.of("prompt", "arg0"),
+				"api_key=[masked]");
+
+		assertTrue(replaced);
+		assertSame(inputMessage, arguments.get("arg0"));
+		assertEquals("api_key=[masked]", inputMessage.getFullInputPrompt());
+		assertEquals("api_key=[masked]", inputMessage.getInputUIPrompt());
+	}
+
+	@Test
+	void maskingWritesBackUnderAnyGuardrailParameterName() {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("arg0", "/vault/notes.txt");
+		arguments.put("arg1", "api_key=secret");
+
+		// only the mapped argument is a candidate, so arg0 holding text as well
+		// does not make the target ambiguous
+		ReactorInputHelper helper = helperFor(arguments);
+		boolean replaced = GenericGuardrailInputReactor.replaceGuardedInput(helper, Map.of("content", "arg1"),
+				"api_key=[masked]");
+
+		assertTrue(replaced);
+		assertEquals("api_key=[masked]", arguments.get("arg1"));
+		assertEquals("/vault/notes.txt", arguments.get("arg0"));
+	}
+
+	@Test
+	void maskingSkipsMappedArgumentsThatHoldNoText() {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("arg0", "sensitive body");
+		arguments.put("arg1", Map.of("bucket", "reports"));
+
+		ReactorInputHelper helper = helperFor(arguments);
+		boolean replaced = GenericGuardrailInputReactor.replaceGuardedInput(helper,
+				Map.of("content", "arg0", "options", "arg1"), "[masked]");
+
+		assertTrue(replaced);
+		assertEquals("[masked]", arguments.get("arg0"));
+		assertEquals(Map.of("bucket", "reports"), arguments.get("arg1"));
+	}
+
+	@Test
+	void maskingWritesBackInsideAMapArgument() {
+		Map<String, Object> request = new HashMap<>();
+		request.put("body", "api_key=secret");
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("arg0", request);
+
+		ReactorInputHelper helper = helperFor(arguments);
+		boolean replaced = GenericGuardrailInputReactor.replaceGuardedInput(helper, Map.of("content", "arg0.body"),
+				"api_key=[masked]");
+
+		assertTrue(replaced);
+		assertEquals("api_key=[masked]", ((Map<?, ?>) arguments.get("arg0")).get("body"));
+	}
+
+	@Test
+	void maskingIsRefusedWhenTwoMappedArgumentsHoldText() {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("arg0", "the question");
+		arguments.put("arg1", "the context");
+
+		ReactorInputHelper helper = helperFor(arguments);
+		boolean replaced = GenericGuardrailInputReactor.replaceGuardedInput(helper,
+				Map.of("question", "arg0", "context", "arg1"), "[masked]");
+
+		// one returned value cannot be attributed to either argument
+		assertFalse(replaced);
+		assertEquals("the question", arguments.get("arg0"));
+		assertEquals("the context", arguments.get("arg1"));
+	}
+
+	@Test
+	void maskingIsRefusedWhenTheMappingCombinesArguments() {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("arg0", "the question");
+		arguments.put("arg1", "the context");
+
+		ReactorInputHelper helper = helperFor(arguments);
+		boolean replaced = GenericGuardrailInputReactor.replaceGuardedInput(helper,
+				Map.of("content", List.of("arg0", "arg1")), "[masked]");
+
+		assertFalse(replaced);
+		assertEquals("the question", arguments.get("arg0"));
+	}
+
+	@Test
+	void maskingIsRefusedWhenNoMappedArgumentHoldsText() {
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("arg0", List.of("chunk one", "chunk two"));
+
+		ReactorInputHelper helper = helperFor(arguments);
+		boolean replaced = GenericGuardrailInputReactor.replaceGuardedInput(helper, Map.of("content", "arg0"),
+				"[masked]");
+
+		// a list cannot take a single masked string without changing its type
+		assertFalse(replaced);
+		assertEquals(List.of("chunk one", "chunk two"), arguments.get("arg0"));
+	}
+
+	/**
+	 * Builds the helper the interceptor hands to a guardrail, over the given
+	 * intercepted arguments.
+	 *
+	 * @param arguments intercepted method arguments, keyed by argument name
+	 * @return a helper reading and writing that map
+	 */
+	private static ReactorInputHelper helperFor(Map<String, Object> arguments) {
+		NounStore nounStore = new NounStore("input-pipeline");
+		GenRowStruct argumentRow = new GenRowStruct();
+		argumentRow.add(new NounMetadata(arguments, PixelDataType.MAP));
+		nounStore.addNoun(PipelineReactorUtils.ARGUMENTS, argumentRow);
+		return new ReactorInputHelper(nounStore);
+	}
+}

--- a/test/prerna/reactor/interceptor/GuardrailValueReaderUnitTests.java
+++ b/test/prerna/reactor/interceptor/GuardrailValueReaderUnitTests.java
@@ -1,0 +1,98 @@
+package prerna.reactor.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import prerna.engine.impl.model.Room;
+import prerna.engine.impl.model.message.AbstractMessage;
+import prerna.engine.impl.model.message.InputMessage;
+import prerna.engine.impl.model.message.ResponseMessage;
+import prerna.engine.impl.model.responses.AskStringModelEngineResponse;
+
+class GuardrailValueReaderUnitTests {
+
+	@Test
+	void readsTheTextOfAnInputMessage() {
+		assertEquals("api_key=secret", GuardrailValueReader.screenableValue(inputMessage("api_key=secret")));
+	}
+
+	@Test
+	void readsTheTextOfAResponseMessage() {
+		assertEquals("the answer", GuardrailValueReader.screenableValue(ResponseMessage.text("the answer")));
+	}
+
+	@Test
+	void serializesAMapSoItsFieldsCanBeRead() {
+		Map<String, Object> parameters = new LinkedHashMap<>();
+		parameters.put("query", "api_key=secret");
+		parameters.put("limit", 10);
+
+		// the shape listBatches and the provider parameter maps hand over
+		assertEquals("{\"query\":\"api_key=secret\",\"limit\":10}", GuardrailValueReader.screenableValue(parameters));
+	}
+
+	@Test
+	void joinsTextSoNothingPastTheFirstItemIsSkipped() {
+		// a guardrail reads a text parameter as one value, so a list has to
+		// arrive joined or only its first item would be screened
+		assertEquals("one\ntwo", GuardrailValueReader.screenableValue(List.of("one", "two")));
+
+		List<Map<String, Object>> requests = new ArrayList<>();
+		requests.add(Map.of("prompt", "first"));
+		requests.add(Map.of("prompt", "second"));
+		assertEquals("{\"prompt\":\"first\"}\n{\"prompt\":\"second\"}", GuardrailValueReader.screenableValue(requests));
+	}
+
+	@Test
+	void keepsACollectionThatIsNotAllTextAsAList() {
+		List<Object> mixed = new ArrayList<>();
+		mixed.add("text");
+		mixed.add(7);
+
+		assertEquals(List.of("text", 7), GuardrailValueReader.screenableValue(mixed));
+	}
+
+	@Test
+	void readsEveryMessageOfAMessageList() {
+		// the shape validateInputModalities hands the pipeline
+		List<AbstractMessage> outboundMessages = new ArrayList<>();
+		outboundMessages.add(inputMessage("first question"));
+		outboundMessages.add(ResponseMessage.text("first answer"));
+		outboundMessages.add(inputMessage("api_key=secret"));
+
+		assertEquals("first question\nfirst answer\napi_key=secret",
+				GuardrailValueReader.screenableValue(outboundMessages));
+	}
+
+	@Test
+	void readsThePayloadOfAResponseWrapper() {
+		assertEquals("the answer",
+				GuardrailValueReader.screenableValue(new AskStringModelEngineResponse("the answer", 1, 2)));
+	}
+
+	@Test
+	void leavesValuesThatAreAlreadyContentAlone() {
+		assertEquals("plain text", GuardrailValueReader.screenableValue("plain text"));
+		assertEquals(7, GuardrailValueReader.screenableValue(7));
+		assertNull(GuardrailValueReader.screenableValue(null));
+	}
+
+	@Test
+	void reportsNoTextForAMessageThatCarriesNone() {
+		assertNull(GuardrailValueReader.messageText(null));
+		assertNull(GuardrailValueReader.messageText(ResponseMessage.text(null)));
+	}
+
+	private static InputMessage inputMessage(String text) {
+		Room room = new Room();
+		room.setId("room-id");
+		return InputMessage.builder(room).withText(text).build();
+	}
+}

--- a/test/prerna/reactor/interceptor/ReactorInputHelperUnitTests.java
+++ b/test/prerna/reactor/interceptor/ReactorInputHelperUnitTests.java
@@ -1,0 +1,65 @@
+package prerna.reactor.interceptor;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import prerna.sablecc2.om.GenRowStruct;
+import prerna.sablecc2.om.NounStore;
+import prerna.sablecc2.om.PixelDataType;
+import prerna.sablecc2.om.nounmeta.NounMetadata;
+
+class ReactorInputHelperUnitTests {
+
+	@Test
+	void resolvesValuesInsideMapArguments() {
+		ReactorInputHelper helper = helper(Map.of("arg0",
+				Map.of("subject", "Quarterly report", "message", "The report is attached.")));
+
+		assertEquals("Quarterly report", helper.getMethodArgument("arg0.subject"));
+		assertEquals("The report is attached.", helper.getMethodArgument("arg0.message"));
+	}
+
+	@Test
+	void indexesAndProjectsAcrossListResults() {
+		Map<String, Object> result = Map.of("messages",
+				List.of(Map.of("subject", "First", "body", "Body one"),
+						Map.of("subject", "Second", "body", "Body two")));
+		ReactorInputHelper helper = helper(Map.of("result", result));
+
+		assertEquals("Second", helper.getMethodArgument("result.messages.1.subject"));
+		assertEquals(List.of("Body one", "Body two"), helper.getMethodArgument("result.messages.*.body"));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void nestedReplacementCopiesTheCallersMap() {
+		Map<String, Object> originalMail = Map.of("subject", "Status", "message", "Account 123");
+		Map<String, Object> arguments = new HashMap<>();
+		arguments.put("arg0", originalMail);
+		ReactorInputHelper helper = helper(arguments);
+
+		assertTrue(helper.setMethodArgument("arg0.message", "Account [masked]"));
+
+		Map<String, Object> guardedMail = (Map<String, Object>) arguments.get("arg0");
+		assertNotSame(originalMail, guardedMail);
+		assertEquals("Account 123", originalMail.get("message"));
+		assertEquals("Account [masked]", guardedMail.get("message"));
+		assertFalse(helper.setMethodArgument("arg0.missing", "value"));
+	}
+
+	private ReactorInputHelper helper(Map<String, Object> arguments) {
+		NounStore nounStore = new NounStore("test");
+		GenRowStruct argumentNoun = new GenRowStruct();
+		argumentNoun.add(new NounMetadata(arguments, PixelDataType.MAP));
+		nounStore.addNoun(PipelineReactorUtils.ARGUMENTS, argumentNoun);
+		return new ReactorInputHelper(nounStore);
+	}
+}

--- a/test/prerna/reactor/model/UpdateModelGuardrailConfigReactorUnitTests.java
+++ b/test/prerna/reactor/model/UpdateModelGuardrailConfigReactorUnitTests.java
@@ -1,0 +1,116 @@
+package prerna.reactor.model;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import prerna.reactor.interceptor.GenericGuardrailInputReactor;
+
+class UpdateModelGuardrailConfigReactorUnitTests {
+
+	@Test
+	void acceptsOneFailureAction() {
+		Map<String, Object> blockParams = validParams();
+		blockParams.put("closeRoomOnBlock", true);
+		blockParams.put("blockErrorMessage", "The request was blocked by a guardrail.");
+		assertDoesNotThrow(() -> UpdateModelGuardrailConfigReactor.validateConfigStructure(config(blockParams)));
+
+		Map<String, Object> responseParams = validParams();
+		responseParams.put("respondWithGuardrailMessage", true);
+		assertDoesNotThrow(() -> UpdateModelGuardrailConfigReactor.validateConfigStructure(config(responseParams)));
+	}
+
+	@Test
+	void validatesRuntimeBlockResponseOptionTypes() {
+		assertInvalidParam("respondWithGuardrailMessage", "true", "must be a boolean");
+		assertInvalidParam("closeRoomOnBlock", "true", "must be a boolean");
+		assertInvalidParam("blockErrorMessage", true, "must be a non-empty string");
+		assertInvalidParam("blockErrorMessage", " ", "must be a non-empty string");
+	}
+
+	@Test
+	void rejectsConflictingFailureActions() {
+		Map<String, Object> params = validParams();
+		params.put("blockOnGuardrailFailure", true);
+		params.put("respondWithGuardrailMessage", true);
+
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> UpdateModelGuardrailConfigReactor.validateConfigStructure(config(params)));
+		assertTrue(exception.getMessage().contains("must enable exactly one failure action"));
+	}
+
+	@Test
+	void rejectsBlockOnlyOptionsForAnotherFailureAction() {
+		Map<String, Object> params = validParams();
+		params.put("respondWithGuardrailMessage", true);
+		params.put("closeRoomOnBlock", true);
+
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> UpdateModelGuardrailConfigReactor.validateConfigStructure(config(params)));
+		assertTrue(exception.getMessage().contains("can only be enabled when blocking on failure"));
+	}
+
+	@Test
+	void maskingAcceptsAnyMappedParameterName() {
+		Map<String, Object> params = validParams();
+		params.put("blockOnGuardrailFailure", false);
+		params.put("maskOnGuardrailFailure", true);
+		assertDoesNotThrow(() -> UpdateModelGuardrailConfigReactor.validateConfigStructure(config(params)));
+
+		// the masked value is written back to the argument that supplied it, so the
+		// guardrail's own parameter name carries no meaning here
+		Map<String, Object> customName = validParams();
+		customName.put("blockOnGuardrailFailure", false);
+		customName.put("maskOnGuardrailFailure", true);
+		customName.put("inputMapping", Map.of("content", "arg1"));
+		assertDoesNotThrow(() -> UpdateModelGuardrailConfigReactor.validateConfigStructure(config(customName)));
+	}
+
+	@Test
+	void maskingRejectsWhenNoMappedArgumentCanReceiveTheValue() {
+		Map<String, Object> combinedMapping = validParams();
+		combinedMapping.put("blockOnGuardrailFailure", false);
+		combinedMapping.put("maskOnGuardrailFailure", true);
+		combinedMapping.put("inputMapping", Map.of("content", List.of("arg0", "arg1")));
+		IllegalArgumentException combined = assertThrows(IllegalArgumentException.class,
+				() -> UpdateModelGuardrailConfigReactor.validateConfigStructure(config(combinedMapping)));
+		assertTrue(combined.getMessage().contains("to a single argument name"));
+
+		Map<String, Object> overriddenMapping = validParams();
+		overriddenMapping.put("blockOnGuardrailFailure", false);
+		overriddenMapping.put("maskOnGuardrailFailure", true);
+		overriddenMapping.put("directParameters", Map.of("prompt", "fixed value"));
+		IllegalArgumentException overridden = assertThrows(IllegalArgumentException.class,
+				() -> UpdateModelGuardrailConfigReactor.validateConfigStructure(config(overriddenMapping)));
+		assertTrue(overridden.getMessage().contains("does not override"));
+	}
+
+	private static void assertInvalidParam(String key, Object value, String expectedMessage) {
+		Map<String, Object> params = validParams();
+		params.put(key, value);
+
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> UpdateModelGuardrailConfigReactor.validateConfigStructure(config(params)));
+		assertTrue(exception.getMessage().contains(expectedMessage));
+	}
+
+	private static Map<String, Object> validParams() {
+		Map<String, Object> params = new HashMap<>();
+		params.put("guardrailEngineId", "guardrail-engine-id");
+		params.put("inputMapping", Map.of("prompt", "arg0"));
+		return params;
+	}
+
+	private static Map<String, Object> config(Map<String, Object> params) {
+		Map<String, Object> guardrail = Map.of("reactorClass", GenericGuardrailInputReactor.class.getName(), "params",
+				params);
+		Map<String, Object> pipeline = Map.of("input", List.of(guardrail));
+		return Map.of("pipelines", Map.of("askCall", pipeline));
+	}
+}

--- a/test/prerna/reactor/playwright/GenerateInputValuesReactorUnitTests.java
+++ b/test/prerna/reactor/playwright/GenerateInputValuesReactorUnitTests.java
@@ -143,7 +143,7 @@ class GenerateInputValuesReactorUnitTests {
 
 			ArgumentCaptor<InputMessage> promptCaptor = ArgumentCaptor.forClass(InputMessage.class);
 			verify(promptRoom).ask(promptCaptor.capture(), eq(modelEngine));
-			String prompt = promptCaptor.getValue().getInputPrompt();
+			String prompt = promptCaptor.getValue().getFullInputPrompt();
 			assertTrue(prompt.contains("CONVERSATION HISTORY"));
 			assertTrue(prompt.contains("Where should we go?"));
 			assertTrue(prompt.contains("Head to Wonderland"));

--- a/test/prerna/util/UploadUtilitiesUnitTests.java
+++ b/test/prerna/util/UploadUtilitiesUnitTests.java
@@ -1,0 +1,21 @@
+package prerna.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class UploadUtilitiesUnitTests {
+
+	@Test
+	void smssValuesPreserveControlCharactersBackslashesAndUnicode() {
+		String value = "First line\nSecond line with \\${PLACEHOLDER}\tand caf\u00e9";
+		String serialized = UploadUtilities.escapeSmssPropertyValue(value);
+
+		assertEquals(value, Utility.loadPropertiesString("PROPERTY\t" + serialized).getProperty("PROPERTY"));
+	}
+
+	@Test
+	void nullSmssValueIsWrittenAsEmpty() {
+		assertEquals("", UploadUtilities.escapeSmssPropertyValue(null));
+	}
+}


### PR DESCRIPTION
## What this does

Corrects the `askRoom` signature, then makes the guardrail pipeline able to screen any engine call rather than just chat prompts, and gives the settings UI the metadata it needs to configure one without guesswork.

## `askRoom` signature

```java
// before
AskModelEngineResponse askRoom(String question, Room room, AbstractMessage inputMessage, Map<String, Object> parameters);
// after
AskModelEngineResponse askRoom(InputMessage inputMessage, Room room, Map<String, Object> parameters);
```

The `question` String was redundant: every call site passed `msg.getInputPrompt()` alongside the message it came from, so the same text arrived twice and could disagree. The message parameter is also narrowed from `AbstractMessage` to `InputMessage`, which is what every caller actually supplied.

This is a breaking interface change. All implementations (`AbstractModelEngine`, `AbstractPythonModelEngine`, `AbstractRemoteModelEngine`, `ModelRouterEngine`, `RemoteModelEngine`, `TextEmbeddingsEngine`, the KServe engines) and all call sites (`Room`, `ConvertFrameToVegaVizReactor`, the Playwright reactors) are updated in this PR.

It also matters for guardrails: `arg0` of `askRoom` is now the `InputMessage` rather than a bare String, so an interceptor gets the whole message and can write a masked value back into it.

`InputMessage.getInputPrompt()` is replaced by two accessors that were previously conflated:

- `getInputText()` returns only the text portion
- `getFullInputPrompt()` returns the effective prompt sent to the model, falling back to combined tool output for a tool-result-only message

## Guardrails can screen any call

Previously a guardrail only reliably screened a chat prompt. Three things stood in the way, all fixed here.

**Values arrived as objects, not text.** A guardrail reads its parameters as text, so an argument holding a message, a response wrapper, or a map reached it as that object's default string form and passed every check. New `GuardrailValueReader` is the one place that reduces a value before screening: messages to their text, response wrappers to their payload, maps to JSON, and collections item by item. Collections whose items all reduce to text are joined, because a guardrail reads a text parameter as a single value and would otherwise screen only the first item.

**Output screening was wired to the wrong reactor.** `GenericGuardrailInputOutputReactor` served both slots but never unwrapped the model response, so a response guardrail scanned a Java object id and always passed. It is replaced by `GenericGuardrailOutputReactor`, output-only, which reduces the return value first. A dot path continues into the reduced payload, so `result.url` reads inside a map shaped response.

Note there is no compatibility alias for the old class name. A stored `pipeline.json` naming `GenericGuardrailInputOutputReactor` will fail to load its engine and has to be updated by hand.

**The `prompt` parameter name was hardcoded.** `GenericGuardrailInputReactor` keyed its unwrapping, its mask target, and its canned-response check on a parameter literally named `prompt`, so a custom guardrail declaring `text` or `content` was silently inert. All three are now driven by the argument's type, so masking works for any engine whose call carries text worth screening. The mask target is the single mapped argument currently holding text; two candidates, a combined mapping, or a non-text argument refuse to mask and block instead of writing a value of the wrong shape.

`UpdateModelGuardrailConfigReactor` validation follows: masking now requires at least one mapping naming a single argument that no fixed value overrides, instead of requiring `prompt` specifically.

## Settings metadata

`GetModelGuardrailConfigReactor` additively returns `interceptableMethods` and `resultArgumentName`. The method list is reflected off `IModelEngine`, excludes methods annotated `@IgnoreEngineLogging` (the invocation handler bypasses pipelines for those, so no guardrail could ever run), and carries per-argument name, type, and whether it holds text a guardrail can read.

Argument names come from `Parameter.getName()`, the same lookup the invocation handler uses, so they match whatever the running build produces. `nameIsFromSource` reports whether they are source names or positional (`arg0`, `arg1`). This is what lets the editor offer real choices instead of free-text fields where a typo silently screens nothing.

## Guardrails document themselves

`IGuardrailReactorFunctionEngine.getDefaultMarkdown()` lets a guardrail ship an explanation with a working `pipeline.json` example. Every built-in guardrail supplies one. `SecurityEngineUtils.setDefaultEngineMarkdown` initializes engine metadata from it without replacing content a user has written, and `CreateGuardrailEngineReactor` calls it on upload. `GetEngineUsageReactor` gains a guardrail section covering pipeline JSON configuration, replacing the "not written yet" placeholder.

New `PromptGuardrailEngine` is a shared base for guardrails judged by a prompt, handling the common blocked message and fail-open behaviour.

## Also here

- `UploadUtilities` smss writing goes through a single `writeSmssProperty` helper, so key/tab/newline formatting is consistent instead of hand-assembled per property.
- `ReactorInputHelper` gains a public `resolveValuePath` for walking a dot path into a value the caller already holds, and the previously empty javadoc on its path walkers is filled in.

## Testing

New unit tests for `GuardrailValueReader`, the input reactor's mask target selection, `ReactorInputHelper`, `PipelineInvocationHandler`, `PolicyComplianceGuardrailEngine`, and `UploadUtilities`; updated tests for `SecurityEngineUtils`, the guardrail config validator, input modality validation, and room message storage.

Worth exercising by hand before merge, since none of it is covered end to end:

- a request guardrail that masks, on a custom guardrail whose parameter is not named `prompt`
- a response guardrail reading `result`, confirming it sees the response text
- an engine whose stored `pipeline.json` still names the old reactor class, confirming the failure is understood
