### PR TITLE
Add in-platform `ServerClient` stand-in to the `ai_server` shim

### DIFF
--- a/py/ai_server.py
+++ b/py/ai_server.py
@@ -1,4 +1,16 @@
-"""Unified interface for SEMOSS Python TCP server components."""
+"""Unified interface for SEMOSS Python TCP server components.
+
+This module shadows the external `ai-server-sdk` PyPI package so that scripts
+written against the SDK can run inside the SEMOSS platform without changes.
+The engine classes (ModelEngine, DatabaseEngine, etc.) are aliased to the
+internal TCP-bridge implementations, and ServerClient is an in-platform
+stand-in that reuses the already-active insight context instead of opening an
+HTTP connection back to the server.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from gaas_gpt_model import ModelEngine
 from gaas_gpt_database import DatabaseEngine
@@ -8,6 +20,8 @@ from gaas_gpt_vector import VectorEngine
 from semoss import Insight
 from gaas_rest_server import RESTServer
 
+logger: logging.Logger = logging.getLogger(__name__)
+
 __all__ = [
     "ModelEngine",
     "DatabaseEngine",
@@ -16,4 +30,326 @@ __all__ = [
     "VectorEngine",
     "Insight",
     "RESTServer",
+    "ServerClient",
 ]
+
+
+class ServerClient:
+    """In-platform stand-in for the ai-server-sdk ServerClient.
+
+    Scripts written against the external SDK create this object to
+    authenticate and open an insight before using the engine classes. When
+    the same script runs inside SEMOSS it is already executing on the server
+    within an authenticated insight, so this class:
+        - accepts and ignores all connection/credential arguments
+        - exposes `cur_insight` resolved from the executing thread's payload
+        - delegates `run_pixel` and friends to the internal TCP bridge
+        - raises NotImplementedError for REST-only capabilities that have no
+          in-platform equivalent (file transfer, async job polling, etc.)
+
+    Example (identical to the SDK usage):
+
+    ```python
+    >>> from ai_server import ServerClient, ModelEngine
+    >>> client = ServerClient(base="<url>", access_key="a", secret_key="b")
+    >>> model = ModelEngine(engine_id="<id>", insight_id=client.cur_insight)
+    ```
+    """
+
+    # class attribute the SDK uses to hold the singleton instance
+    da_server = None
+
+    def __init__(
+        self,
+        base: Optional[str] = None,
+        access_key: Optional[str] = None,
+        secret_key: Optional[str] = None,
+        bearer_token: Optional[str] = None,
+        bearer_token_provider: Optional[str] = None,
+        **kwargs: Any,
+    ) -> None:
+        """
+        Accepts the same arguments as the SDK ServerClient but performs no
+        authentication - the script is already running inside an
+        authenticated SEMOSS session.
+
+        Args:
+            base (`Optional[str]`): Ignored. Kept so SDK scripts run unchanged.
+            access_key (`Optional[str]`): Ignored.
+            secret_key (`Optional[str]`): Ignored.
+            bearer_token (`Optional[str]`): Ignored.
+            bearer_token_provider (`Optional[str]`): Ignored.
+            **kwargs: Ignored.
+        """
+        logger.info(
+            "ServerClient is running inside SEMOSS - connection and credential "
+            "arguments are ignored and the active insight context is used"
+        )
+
+        self.main_url: Optional[str] = base
+        if self.main_url is not None and self.main_url.endswith("/"):
+            self.main_url = self.main_url[:-1]
+
+        # stored only so scripts that read these attributes back do not break
+        self.access_key: Optional[str] = access_key
+        self.secret_key: Optional[str] = secret_key
+        self.bearer_token: Optional[str] = bearer_token
+        self.bearer_token_provider: Optional[str] = bearer_token_provider
+
+        # never populated in-platform; kept for SDK attribute parity
+        self.required_headers: Dict = {}
+        self.auth_headers: Dict = {}
+        self.cookies = None
+
+        # bridge into the insight this python process is executing within
+        self._insight: Insight = Insight()
+        self.cur_insight: Optional[str] = self._insight.insight_id
+
+        self.open_insights = set()
+        if self.cur_insight is not None:
+            self.open_insights.add(self.cur_insight)
+
+        # map to keep track of requests and responses outside of this class
+        self.monitors: Dict = {}
+
+        ServerClient.da_server = self
+
+    # ----------------------------------------------------------------------
+    # authentication / connection lifecycle - all no-ops in-platform
+    # ----------------------------------------------------------------------
+
+    def loginUserAccessKey(self) -> None:
+        """No-op in-platform. The user is already authenticated."""
+        logger.info("loginUserAccessKey skipped - already authenticated in SEMOSS")
+
+    def loginBearerToken(self) -> None:
+        """No-op in-platform. The user is already authenticated."""
+        logger.info("loginBearerToken skipped - already authenticated in SEMOSS")
+
+    def reconnect(self) -> None:
+        """No-op in-platform. The TCP bridge manages its own connection."""
+        logger.info("reconnect skipped - connection is managed by SEMOSS")
+
+    def is_session_login(
+        self, headers: Optional[Dict[str, str]] = None
+    ) -> Tuple[None, bool]:
+        """
+        In-platform the session is always logged in.
+
+        Returns:
+            `Tuple[None, bool]`: (None, True). The SDK returns the raw
+            `/config` response as the first element; there is no HTTP
+            response in-platform so None is returned in its place.
+        """
+        return None, True
+
+    def set_csrf_if_enabled(self) -> None:
+        """No-op in-platform. CSRF only applies to REST calls."""
+        pass
+
+    def logout(self) -> None:
+        """No-op in-platform. The session is managed by SEMOSS."""
+        logger.info("logout skipped - session is managed by SEMOSS")
+
+    # ----------------------------------------------------------------------
+    # insight management
+    # ----------------------------------------------------------------------
+
+    def make_new_insight(self) -> Optional[str]:
+        """
+        In-platform the script already executes inside an insight, so instead
+        of creating a new temporal workspace this returns the active insight.
+        """
+        if self.cur_insight is None:
+            self.cur_insight = self._insight.get_thread_insight_id()
+        if self.cur_insight is not None:
+            self.open_insights.add(self.cur_insight)
+        return self.cur_insight
+
+    def get_open_insights(self) -> List[str]:
+        """
+        Retrieves a list of insight IDs open in the user's session.
+
+        Returns:
+            `List[str]`: List of insight IDs
+        """
+        open_insights = self.run_pixel(payload="MyOpenInsights();")
+
+        # keep track of the open insights within the python object itself
+        self.open_insights = set(open_insights)
+
+        return open_insights
+
+    def drop_insights(self, insight_ids: Union[str, List[str]]) -> None:
+        """
+        No-op in-platform. The active insight hosts this python process -
+        dropping it (or sibling session insights) from within a script would
+        tear down live state, so insight cleanup is left to the platform.
+        """
+        logger.warning(
+            "drop_insights skipped - insights are managed by SEMOSS when "
+            "running in-platform"
+        )
+
+    # ----------------------------------------------------------------------
+    # pixel execution - delegated to the internal TCP bridge
+    # ----------------------------------------------------------------------
+
+    def run_pixel(
+        self,
+        payload: str,
+        insight_id: Optional[str] = None,
+        full_response: Optional[bool] = False,
+    ) -> Union[Any, Dict]:
+        """
+        Execute a pixel expression against the server.
+
+        Matches the SDK contract (raises on ERROR operations, returns either
+        the full runPixel response or just the first output) but routes the
+        call over the in-platform TCP bridge instead of the REST endpoint.
+
+        Args:
+            payload (`str`): DSL (Pixel) instruction on what specific action should be performed
+            insight_id (`Optional[str]`): Unique identifier for the temporal workspace where actions are being isolated
+            full_response (`Optional[bool]`): Indicate whether to return the full json response or only the actions output
+
+        Returns:
+            `Union[Any, Dict]`: The output object from the runPixel response or the entire runPixel response.
+        """
+        if insight_id is None:
+            insight_id = self.cur_insight
+            if insight_id is None:
+                insight_id = self.make_new_insight()
+
+        raw = self._insight.run_pixel(
+            pixel=payload, insight_id=insight_id, raw=True
+        )
+
+        # the bridge returns a list whose first element is the runPixel
+        # response dict that the REST endpoint would have returned
+        response_dict = raw[0] if isinstance(raw, list) else raw
+
+        if "ERROR" in response_dict["pixelReturn"][0]["operationType"]:
+            raise Exception(response_dict["pixelReturn"][0]["output"])
+
+        if full_response:
+            return response_dict
+        else:
+            return self.get_pixel_output(response_dict)
+
+    def get_pixel_output(self, response: Dict) -> Union[Any, List]:
+        """
+        Utility method to grab the output of a runPixel call.
+
+        Args:
+            response (`Dict`): The runPixel response from the Tomcat Server
+
+        Returns:
+            `Union[Any, List]`: The output object or a list of objects
+        """
+        main_output = response["pixelReturn"][0]["output"]
+
+        if isinstance(main_output, list):
+            output = main_output[0]
+        else:
+            output = main_output
+
+        return output
+
+    def send_request(self, payload_struct: Dict) -> None:
+        """
+        Constructs the pixel payload from a PayloadStruct for various server
+        resources such as ModelEngine, StorageEngine and DatabaseEngine.
+
+        Args:
+            payload_struct (`Dict`): the actual payload being sent to the AI Server
+
+        Returns:
+            `None`
+        """
+        epoc = payload_struct["epoc"]
+
+        input_payload_message = json.dumps(payload_struct, ensure_ascii=False)
+
+        logger.info("Sending a PayloadStruct " + input_payload_message)
+
+        output_payload_message = self.run_pixel(
+            payload='RemoteEngineRun(payload="<e>' + input_payload_message + '</e>");',
+            insight_id=payload_struct["insightId"],
+        )
+
+        if epoc in self.monitors:
+            self.monitors[epoc] = output_payload_message
+
+    # ----------------------------------------------------------------------
+    # REST-only capabilities with no in-platform equivalent
+    # ----------------------------------------------------------------------
+
+    def get_auth_headers(self) -> Dict:
+        """Not available in-platform - there are no REST auth headers."""
+        raise NotImplementedError(
+            "get_auth_headers is not available when running inside SEMOSS - "
+            "the script is already executing in an authenticated session"
+        )
+
+    def get_openai_endpoint(self) -> str:
+        """Get the corresponding openai endpoint for the AI server."""
+        if self.main_url:
+            return self.main_url + "/model/openai"
+        raise NotImplementedError(
+            "get_openai_endpoint requires the 'base' url to be passed to "
+            "ServerClient - no REST connection exists when running inside "
+            "SEMOSS"
+        )
+
+    def run_pixel_async(
+        self, payload: str, insight_id: Optional[str] = None
+    ) -> Union[Any, Dict]:
+        """Not available in-platform - use run_pixel instead."""
+        raise NotImplementedError(
+            "run_pixel_async is not available when running inside SEMOSS - "
+            "use run_pixel instead"
+        )
+
+    def get_partial_responses(self, job_id: str) -> None:
+        """Not available in-platform - use run_pixel instead."""
+        raise NotImplementedError(
+            "get_partial_responses is not available when running inside "
+            "SEMOSS - use run_pixel instead"
+        )
+
+    def import_data_product(
+        self, project_id: str, insight_id: str, sql: str
+    ) -> None:
+        """Not available in-platform."""
+        raise NotImplementedError(
+            "import_data_product is not available when running inside SEMOSS"
+        )
+
+    def upload_files(
+        self,
+        files: List[str],
+        project_id: Optional[str] = None,
+        insight_id: Optional[str] = None,
+        path: Optional[str] = None,
+    ) -> None:
+        """Not available in-platform - the script already runs on the server."""
+        raise NotImplementedError(
+            "upload_files is not available when running inside SEMOSS - files "
+            "created by this script already live in the server's insight "
+            "workspace, use standard file I/O instead"
+        )
+
+    def download_file(
+        self,
+        file: str,
+        project_id: Optional[str] = None,
+        insight_id: Optional[str] = None,
+        custom_filename: Optional[str] = None,
+    ) -> None:
+        """Not available in-platform - the script already runs on the server."""
+        raise NotImplementedError(
+            "download_file is not available when running inside SEMOSS - files "
+            "in the insight workspace are directly accessible, use standard "
+            "file I/O instead"
+        )


### PR DESCRIPTION
### Summary

Scripts written against our external [`ai-server-sdk`](https://pypi.org/project/ai-server-sdk/) PyPI package start with `from ai_server import ServerClient` and instantiate a connection with access/secret keys or a bearer token. When one of those scripts is run **inside** SEMOSS, that import fails — the in-platform `ai_server.py` shim only aliased the engine classes (`ModelEngine`, `DatabaseEngine`, `StorageEngine`, `VectorEngine`, `FunctionEngine`) to their internal TCP-bridge implementations and had no `ServerClient`.

This PR adds an in-platform `ServerClient` stand-in to `py/ai_server.py` so SDK scripts run unchanged on the platform. Since the script is already executing on the server inside an authenticated insight, the class ignores all connection/credential arguments and binds to the active insight context instead of opening a REST connection back to the server. Parity target is SDK v0.0.30.

### Behavior

**Construction**
- Accepts (and ignores) all SDK constructor args: `base`, `access_key`, `secret_key`, `bearer_token`, `bearer_token_provider`, plus arbitrary kwargs. Bare `ServerClient()` also works — no credentials are required in-platform.
- `cur_insight` is resolved from the executing thread's payload via `semoss.Insight` / `get_thread_insight_id()`, so the common SDK pattern `ModelEngine(engine_id=..., insight_id=client.cur_insight)` works as-is. (`None` is also safe — the internal `ServerProxy` self-resolves the insight at call time.)
- Sets the `ServerClient.da_server` singleton for attribute parity with the SDK.

**Delegated to the internal TCP bridge**
- `run_pixel(payload, insight_id=None, full_response=False)` — routes through `Insight.run_pixel`, with exact SDK output mapping: raises on `ERROR` operation types, returns the full runPixel response dict when `full_response=True`, otherwise applies the SDK's `get_pixel_output` unwrapping.
- `get_pixel_output`, `get_open_insights` (`MyOpenInsights();`), and `send_request` (replays the SDK's `RemoteEngineRun(payload="<e>...</e>");` pixel — `RemoteEngineRunReactor` already exists server-side).

**No-ops (logged where useful)**
- `loginUserAccessKey`, `loginBearerToken`, `reconnect`, `logout`, `set_csrf_if_enabled` — the session is already authenticated and managed by the platform.
- `is_session_login()` always returns `(None, True)`.
- `make_new_insight()` returns the active insight — the script already runs inside one.
- `drop_insights()` is a **deliberate warn-no-op** (not delegated): in-platform, the current insight hosts the running Python process, so actually executing `DropInsight();` would tear down live session state mid-script.
