### PR TITLE
Allow file inputs if attachment column is true

### DIFF
--- a/src/prerna/engine/impl/model/AbstractModelEngine.java
+++ b/src/prerna/engine/impl/model/AbstractModelEngine.java
@@ -150,6 +150,15 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	 */
 	protected Set<ModelModalityEnum> inputModalities = null;
 
+	/**
+	 * Whether the model accepts document attachments per the MODELMETADATA row
+	 * (the static catalog's attachment flag). The catalog has no "file" input
+	 * modality - its vocabulary stops at text/image/audio/video/pdf - so this flag
+	 * is what lets generic FILE media (pptx, docx, xlsx, ...) through the input
+	 * modality gate. Null when the table does not say.
+	 */
+	protected Boolean attachmentSupported = null;
+
 	@Override
 	public void open(Properties smssProp) throws Exception {
 		super.open(smssProp);
@@ -223,6 +232,9 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 		}
 		if (metadata.get("temperature") instanceof Boolean) {
 			this.temperatureSupported = (Boolean) metadata.get("temperature");
+		}
+		if (metadata.get("attachment") instanceof Boolean) {
+			this.attachmentSupported = (Boolean) metadata.get("attachment");
 		}
 		if (metadata.get("reasoningConfig") instanceof Map) {
 			@SuppressWarnings("unchecked")
@@ -781,14 +793,34 @@ public abstract class AbstractModelEngine extends AbstractEngine implements IMod
 	/**
 	 * Throw when the given modality is not in the configured input modalities.
 	 * No-op when the engine does not restrict input.
+	 * <p>
+	 * FILE is special-cased: the static catalog never declares a "file" modality,
+	 * so a generic document (pptx, docx, xlsx, json, ...) is also allowed when the
+	 * model accepts attachments or already accepts PDF documents. The provider
+	 * remains the authority on which specific file types it can parse.
 	 */
 	protected void requireInputModalityAllowed(ModelModalityEnum modality) {
 		if (this.inputModalities == null || this.inputModalities.contains(modality)) {
 			return;
 		}
+		if (modality == ModelModalityEnum.FILE && allowsGenericFileInput()) {
+			return;
+		}
 		String model = this.engineName == null || this.engineName.isBlank() ? this.engineId : this.engineName;
 		throw new IllegalArgumentException("Model " + model + " does not allow " + modality.name()
 				+ " input. Configured input modalities: " + this.inputModalities);
+	}
+
+	/**
+	 * Whether generic FILE media may be sent even though FILE is not listed in the
+	 * configured input modalities: true when the metadata row flags attachment
+	 * support or when PDF documents are already accepted.
+	 */
+	private boolean allowsGenericFileInput() {
+		if (Boolean.TRUE.equals(this.attachmentSupported)) {
+			return true;
+		}
+		return this.inputModalities != null && this.inputModalities.contains(ModelModalityEnum.PDF);
 	}
 
 	private static ModelModalityEnum modalityFor(MessagePart part) {

--- a/test/prerna/engine/impl/model/AbstractModelEngineInputModalityUnitTests.java
+++ b/test/prerna/engine/impl/model/AbstractModelEngineInputModalityUnitTests.java
@@ -94,6 +94,50 @@ class AbstractModelEngineInputModalityUnitTests {
 	}
 
 	@Test
+	void rejectsGenericFileWhenModelHasNoDocumentSupport() {
+		// text+image only, attachment not flagged: a pptx has nowhere to go
+		TestModelEngine engine = new TestModelEngine(EnumSet.of(ModelModalityEnum.TEXT, ModelModalityEnum.IMAGE));
+		InputMessage message = newMessage();
+		message.addPart(new MediaMessagePart(pptxMedia()));
+
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+				() -> engine.validateInputModalities(List.of(), message));
+
+		assertTrue(exception.getMessage().contains("does not allow FILE input"));
+	}
+
+	@Test
+	void allowsGenericFileWhenModelAcceptsPdfInput() {
+		// the static catalog never declares "file"; pdf is its document modality
+		TestModelEngine engine = new TestModelEngine(
+				EnumSet.of(ModelModalityEnum.TEXT, ModelModalityEnum.IMAGE, ModelModalityEnum.PDF));
+		InputMessage message = newMessage();
+		message.addPart(new MediaMessagePart(pptxMedia()));
+
+		assertDoesNotThrow(() -> engine.validateInputModalities(List.of(), message));
+	}
+
+	@Test
+	void allowsGenericFileWhenMetadataFlagsAttachmentSupport() {
+		TestModelEngine engine = new TestModelEngine(EnumSet.of(ModelModalityEnum.TEXT, ModelModalityEnum.IMAGE),
+				Boolean.TRUE);
+		InputMessage message = newMessage();
+		message.addPart(new MediaMessagePart(pptxMedia()));
+
+		assertDoesNotThrow(() -> engine.validateInputModalities(List.of(), message));
+	}
+
+	@Test
+	void attachmentFlagDoesNotUnlockOtherModalities() {
+		// attachment support only widens FILE; an image is still gated by the list
+		TestModelEngine engine = new TestModelEngine(EnumSet.of(ModelModalityEnum.TEXT), Boolean.TRUE);
+		InputMessage message = newMessage();
+		message.addPart(new MediaMessagePart(MessageInputMedia.fromUrl("https://example.com/image.png")));
+
+		assertThrows(IllegalArgumentException.class, () -> engine.validateInputModalities(List.of(), message));
+	}
+
+	@Test
 	void classifiesPdfUrlsAsPdfInput() {
 		TestModelEngine engine = new TestModelEngine(EnumSet.of(ModelModalityEnum.TEXT, ModelModalityEnum.IMAGE));
 		InputMessage message = newMessage();
@@ -249,12 +293,23 @@ class AbstractModelEngineInputModalityUnitTests {
 		return new Gson().fromJson("{\"mimeType\":\"audio/mp3\"}", MessageInputMedia.class);
 	}
 
+	private static MessageInputMedia pptxMedia() {
+		return new Gson().fromJson(
+				"{\"mimeType\":\"application/vnd.openxmlformats-officedocument.presentationml.presentation\"}",
+				MessageInputMedia.class);
+	}
+
 	private static class TestModelEngine extends AbstractModelEngine {
 		private InputMessage lastInputMessage;
 		private Map<String, Object> lastHyperParameters;
 
 		private TestModelEngine(Set<ModelModalityEnum> inputModalities) {
+			this(inputModalities, null);
+		}
+
+		private TestModelEngine(Set<ModelModalityEnum> inputModalities, Boolean attachmentSupported) {
 			this.inputModalities = inputModalities;
+			this.attachmentSupported = attachmentSupported;
 			setEngineName("test-model");
 		}
 


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

Allowing models to accept file inputs if the `attachment` column in the `modelmetadata` table is true. Previously I required 'FILE' and an explicit value in the `inputmodalities` column. 

## Changes Made
<!-- List the key changes made in this PR -->

## How to Test
<!-- Explain how reviewers can test your changes -->
1. Steps to reproduce/test the behavior
2. Expected outcomes

## Notes
<!-- Any further notes regarding changes -->