### PR TITLE
fix: readd original text for legacy to use in displaying the sql stat…

### DIFF
--- a/src/prerna/sablecc2/PixelUtility.java
+++ b/src/prerna/sablecc2/PixelUtility.java
@@ -1335,9 +1335,9 @@ public class PixelUtility {
 	 */
 	public static Map<String, Object> generatePipeline(Insight in) {
 		long start = System.currentTimeMillis();
-		PipelineTranslation translation = new PipelineTranslation(in);
 		List<String> encodingList = new ArrayList<>();
 		Map<String, String> encodedTextToOriginal = new HashMap<>();
+		PipelineTranslation translation = new PipelineTranslation(in, encodedTextToOriginal);
 
 		PixelList pixelList = in.getPixelList();
 		int size = pixelList.size();

--- a/src/prerna/sablecc2/pipeline/PipelineTranslation.java
+++ b/src/prerna/sablecc2/pipeline/PipelineTranslation.java
@@ -106,9 +106,10 @@ public class PipelineTranslation extends LazyTranslation {
 	private List<PipelineOperation> curRoutine;
 	private List<Map<String, Object>> pixelIdToOperation = new ArrayList<>();
 
-	public PipelineTranslation(Insight insight) {
+	public PipelineTranslation(Insight insight, Map<String, String> encodedTextToOriginal) {
 		super();
 		this.insight = insight;
+		this.encodedTextToOriginal = encodedTextToOriginal;
 		if (this.insight != null) {
 			// we will copy the var store
 			VarStore copy = new VarStore();

--- a/test/prerna/sablecc2/PixelUtilityUnitTests.java
+++ b/test/prerna/sablecc2/PixelUtilityUnitTests.java
@@ -28,9 +28,18 @@
 package prerna.sablecc2;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.List;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
+
+import prerna.om.Insight;
+import prerna.om.Pixel;
+import prerna.query.querystruct.HardSelectQueryStruct;
+import prerna.sablecc2.pipeline.PipelineOperation;
 
 public class PixelUtilityUnitTests {
 
@@ -56,5 +65,33 @@ public class PixelUtilityUnitTests {
 	void decodeEscapedString_handlesNullAndPlainText() {
 		assertNull(PixelUtility.decodeEscapedString(null));
 		assertEquals("plain-text", PixelUtility.decodeEscapedString("plain-text"));
+	}
+
+	@Test
+	void generatePipeline_decodesEncodedQueryText() {
+		String query = "SELECT first_name FROM people WHERE note = 'hello world' AND code LIKE '%20%'";
+		String pixelExpression = "Database(database=[\"test-database\"]) | Query(\"<encode>" + query
+				+ "</encode>\") | Import(frame=[CreateFrame(frameType=[GRID], override=[true]).as([\"Frame_1\"])]);";
+		Insight insight = new Insight();
+		insight.getPixelList().addPixel(new Pixel("pixel-1", pixelExpression));
+
+		Map<String, Object> pipeline = PixelUtility.generatePipeline(insight);
+		@SuppressWarnings("unchecked")
+		List<List<PipelineOperation>> routines = (List<List<PipelineOperation>>) pipeline.get("pixelParsing");
+		HardSelectQueryStruct queryStruct = null;
+		for (List<PipelineOperation> routine : routines) {
+			for (PipelineOperation operation : routine) {
+				List<Map> queryStructInputs = operation.getNounInputs().get("qs");
+				if (queryStructInputs != null && !queryStructInputs.isEmpty()) {
+					Object value = queryStructInputs.get(0).get("value");
+					if (value instanceof HardSelectQueryStruct) {
+						queryStruct = (HardSelectQueryStruct) value;
+					}
+				}
+			}
+		}
+
+		assertNotNull(queryStruct);
+		assertEquals(query, queryStruct.getQuery());
 	}
 }


### PR DESCRIPTION

## Description
backend fix for legacy pipeline viewing

## Changes Made
readded a removed variable in the constructors to pass in decoded strings

## How to Test
1. Create an insight
2. add a data query to the pipeline
3. open the edit and see that there is no encoding characters

## Notes
I chose to make this change rather than updating legacy because it seemed an unintended regression but I can update legacy front end to account for this if we'd rather.